### PR TITLE
chore: Change tokens in workflow

### DIFF
--- a/.github/workflows/label_will_do.yml
+++ b/.github/workflows/label_will_do.yml
@@ -48,7 +48,7 @@ jobs:
               }
             }
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
 
       - name: Add label 'will_do' where missing
         run: |
@@ -74,4 +74,4 @@ jobs:
             fi
           done
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}


### PR DESCRIPTION
Updated GitHub Actions workflow (will do labeling) to use a personal access token with org permissions instead of GITHUB_TOKEN for authentication.