### PR TITLE
  feat(editor): add interactive sidebar with breadcrumb navigation and inline editing

### DIFF
--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
             use: {
                 ...devices["Desktop Chrome"],
                 // Use prepared auth state.
-                storageState: "tmp/.auth/chromium-user.json",
+                storageState: path.join(__dirname, "tmp/.auth/chromium-user.json"),
             },
             dependencies: ["setup chromium"],
         },
@@ -65,7 +65,7 @@ export default defineConfig({
             use: {
                 ...devices["Desktop Firefox"],
                 // Use prepared auth state.
-                storageState: "tmp/.auth/firefox-user.json",
+                storageState: path.join(__dirname, "tmp/.auth/firefox-user.json"),
             },
             dependencies: ["setup firefox"],
         },
@@ -81,7 +81,7 @@ export default defineConfig({
             use: {
                 ...devices["Desktop Safari"],
                 // Use prepared auth state.
-                storageState: "tmp/.auth/webkit-user.json",
+                storageState: path.join(__dirname, "tmp/.auth/webkit-user.json"),
             },
             dependencies: ["setup webkit"],
         },

--- a/apps/frontend/src/application/selectors/assets.selectors.test.ts
+++ b/apps/frontend/src/application/selectors/assets.selectors.test.ts
@@ -1,0 +1,27 @@
+import { assetsSelectors } from "./assets.selectors";
+import { createAsset } from "#test-utils/builders.ts";
+import { assetsAdapter } from "../adapters/asset.adapter";
+import type { RootState } from "../store.types";
+import type { Asset } from "../../api/types/asset.types";
+
+const withAssets = (assets: Asset[]) =>
+    ({
+        assets: assetsAdapter.upsertMany(assetsAdapter.getInitialState({ isPending: false }), assets),
+    }) as RootState;
+
+describe("assetsSelectors", () => {
+    describe("selectById", () => {
+        it("returns the asset when it exists", () => {
+            const asset = createAsset({ id: 42 });
+            const state = withAssets([asset]);
+
+            expect(assetsSelectors.selectById(state, 42)).toEqual(asset);
+        });
+
+        it("returns undefined when the id does not exist", () => {
+            const state = withAssets([createAsset({ id: 1 })]);
+
+            expect(assetsSelectors.selectById(state, 999)).toBeUndefined();
+        });
+    });
+});

--- a/apps/frontend/src/application/selectors/assets.selectors.ts
+++ b/apps/frontend/src/application/selectors/assets.selectors.ts
@@ -6,12 +6,11 @@ import { assetsAdapter } from "../adapters/asset.adapter";
 const selectAssetsEntities = (state: RootState) => state.assets.entities;
 const selectProjectId = (_state: RootState, projectId: number) => projectId;
 
-const { selectAll, selectById } = assetsAdapter.getSelectors((state: RootState) => state.assets);
+const { selectById } = assetsAdapter.getSelectors((state: RootState) => state.assets);
 
 export const assetsSelectors = {
     selectByProjectId: createSelector([selectAssetsEntities, selectProjectId], (entities, projectId): Asset[] => {
         return Object.values(entities).filter((item) => item.projectId === projectId);
     }),
-    selectAll,
     selectById,
 };

--- a/apps/frontend/src/application/selectors/assets.selectors.ts
+++ b/apps/frontend/src/application/selectors/assets.selectors.ts
@@ -6,10 +6,12 @@ import { assetsAdapter } from "../adapters/asset.adapter";
 const selectAssetsEntities = (state: RootState) => state.assets.entities;
 const selectProjectId = (_state: RootState, projectId: number) => projectId;
 
+const { selectAll, selectById } = assetsAdapter.getSelectors((state: RootState) => state.assets);
+
 export const assetsSelectors = {
     selectByProjectId: createSelector([selectAssetsEntities, selectProjectId], (entities, projectId): Asset[] => {
         return Object.values(entities).filter((item) => item.projectId === projectId);
     }),
-
-    selectAll: assetsAdapter.getSelectors((state: RootState) => state.assets).selectAll,
+    selectAll,
+    selectById,
 };

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -1,0 +1,101 @@
+import type { Asset } from "#api/types/asset.types.ts";
+import type { ExtendedProject } from "#api/types/project.types.ts";
+import {
+    AnchorOrientation,
+    type AugmentedSystemComponent,
+    type SystemConnection,
+    type SystemPointOfAttack,
+} from "#api/types/system.types.ts";
+import type { SystemConnectionPoint } from "#application/adapters/system-connection-point.adapter.ts";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { CONFIDENTIALITY_LEVELS } from "#utils/confidentiality.ts";
+
+export const createAsset = (overrides: Partial<Asset> = {}): Asset => ({
+    id: 1,
+    name: "Test Asset",
+    description: "",
+    confidentiality: 3,
+    integrity: 3,
+    availability: 2,
+    confidentialityJustification: "",
+    integrityJustification: "",
+    availabilityJustification: "",
+    projectId: 1,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    ...overrides,
+});
+
+export const createSystemComponent = (overrides: Partial<AugmentedSystemComponent> = {}): AugmentedSystemComponent => ({
+    id: "comp-1",
+    name: "Test Component",
+    description: "",
+    type: STANDARD_COMPONENT_TYPES.CLIENT,
+    x: 0,
+    y: 0,
+    gridX: 0,
+    gridY: 0,
+    width: 100,
+    height: 100,
+    selected: true,
+    projectId: 1,
+    symbol: null,
+    pointsOfAttack: [],
+    ...overrides,
+});
+
+export const createPointOfAttack = (overrides: Partial<SystemPointOfAttack> = {}): SystemPointOfAttack => ({
+    id: "poa-1",
+    name: null,
+    type: POINTS_OF_ATTACK.USER_INTERFACE,
+    componentId: "comp-1",
+    connectionId: null,
+    projectId: 1,
+    connectionPointId: null,
+    assets: [],
+    componentName: "Test Component",
+    ...overrides,
+});
+
+export const createConnectionPoint = (overrides: Partial<SystemConnectionPoint> = {}): SystemConnectionPoint => ({
+    id: "cp-1",
+    name: "eth0",
+    connectionId: "conn-1",
+    projectId: 1,
+    componentId: "comp-1",
+    componentName: "Test Component",
+    description: "",
+    ...overrides,
+});
+
+export const createProject = (overrides: Partial<ExtendedProject> = {}): ExtendedProject => ({
+    id: 1,
+    catalogId: 1,
+    name: "Test Project",
+    confidentialityLevel: CONFIDENTIALITY_LEVELS.INTERNAL,
+    lineOfToleranceGreen: 3,
+    lineOfToleranceRed: 6,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    role: USER_ROLES.EDITOR,
+    image: null,
+    ...overrides,
+});
+
+export const createConnection = (overrides: Partial<SystemConnection> = {}): SystemConnection => ({
+    id: "conn-1",
+    name: "Test Connection",
+    from: { id: "comp-1", anchor: AnchorOrientation.right, type: STANDARD_COMPONENT_TYPES.CLIENT },
+    to: { id: "comp-2", anchor: AnchorOrientation.left, type: STANDARD_COMPONENT_TYPES.SERVER },
+    connectionPoints: [],
+    connectionPointsMeta: [],
+    waypoints: [],
+    recalculate: false,
+    projectId: 1,
+    visible: true,
+    communicationInterfaceId: null,
+    communicationInterface: null,
+    ...overrides,
+});

--- a/apps/frontend/src/test-utils/mock-hooks.ts
+++ b/apps/frontend/src/test-utils/mock-hooks.ts
@@ -1,0 +1,153 @@
+import { type MockInstance, vi } from "vitest";
+import * as dialogHook from "#application/hooks/use-dialog.hook.ts";
+import * as confirmHook from "#application/hooks/use-confirm.hook.ts";
+import * as alertHook from "#application/hooks/use-alert.hook.ts";
+import * as editorHook from "#application/hooks/use-editor.hook.ts";
+import * as assetsHook from "#application/hooks/use-assets.hook.ts";
+
+/**
+ * @module mock-hooks - Reusable hook spies.
+ *
+ * Each function spies on the real hook module and returns the MockInstance.
+ * Import and call — no vi.mock() needed in the test file.
+ *
+ * Usage:
+ *   import { mockUseDialog } from "#test-utils/mock-hooks.ts";
+ *
+ *   const spy = mockUseDialog();
+ *   const spy = mockUseDialog({ cancelDialog: myTrackedFn });
+ */
+
+type UseDialogResult = ReturnType<typeof dialogHook.useDialog>;
+type UseConfirmResult = ReturnType<typeof confirmHook.useConfirm>;
+type UseAlertResult = ReturnType<typeof alertHook.useAlert>;
+type UseEditorResult = ReturnType<typeof editorHook.useEditor>;
+type UseAssetsResult = ReturnType<typeof assetsHook.useAssets>;
+
+export const mockUseDialog = (config?: Partial<UseDialogResult>): MockInstance => {
+    return vi.spyOn(dialogHook, "useDialog").mockImplementation(() => ({
+        values: null,
+        setValue: vi.fn(),
+        cancelDialog: vi.fn(),
+        confirmDialog: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseConfirm = (config?: Partial<UseConfirmResult>): MockInstance => {
+    return vi.spyOn(confirmHook, "useConfirm").mockImplementation(() => ({
+        openConfirm: vi.fn(),
+        cancelConfirm: vi.fn(),
+        acceptConfirm: vi.fn(),
+        acceptColor: undefined,
+        open: false,
+        message: "",
+        cancelText: "",
+        acceptText: "",
+        ...config,
+    }));
+};
+
+export const mockUseAlert = (config?: Partial<UseAlertResult>): MockInstance => {
+    return vi.spyOn(alertHook, "useAlert").mockImplementation(() => ({
+        type: "",
+        text: "",
+        visible: false,
+        close: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showSuccessMessage: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseEditor = (config?: Partial<UseEditorResult>): MockInstance => {
+    return vi.spyOn(editorHook, "useEditor").mockImplementation(() => ({
+        deleteCustomComponent: vi.fn(),
+        autoSaveBlocked: vi.fn(),
+        addComponent: vi.fn(),
+        moveComponent: vi.fn(),
+        selectComponent: vi.fn(),
+        deselectComponent: vi.fn(),
+        removeComponent: vi.fn(),
+        selectConnector: vi.fn(),
+        deselectConnector: vi.fn(),
+        selectConnection: vi.fn(),
+        deselectConnection: vi.fn(),
+        loadSystem: vi.fn(),
+        systemPending: false,
+        saveCurrentSystem: vi.fn(),
+        setLayerPosition: vi.fn(),
+        setShowHelpLines: vi.fn(),
+        setComponentsGridPosition: vi.fn(),
+        setSelectedComponentName: vi.fn(),
+        setSelectedComponentDescription: vi.fn(),
+        setSelectedConnectionPointDescription: vi.fn(),
+        addPointOfAttack: vi.fn(),
+        removePointOfAttack: vi.fn(),
+        removeConnection: vi.fn(),
+        removeConnectionById: vi.fn(),
+        selectPointOfAttack: vi.fn(),
+        deselectPointOfAttack: vi.fn(),
+        addAssetToSelectedPointOfAttack: vi.fn(),
+        removeAssetToSelectedPointOfAttack: vi.fn(),
+        updateConnectionsOfComponent: vi.fn(),
+        connectionRecalculated: vi.fn(),
+        selectConnectionPoint: vi.fn(),
+        deselectConnectionPoint: vi.fn(),
+        setMousePointers: vi.fn(),
+        addAssetToPointOfAttack: vi.fn(),
+        removeAssetFromPointOfAttack: vi.fn(),
+        setAssetSearchValue: vi.fn(),
+        setStageScale: vi.fn(),
+        loadComponentTypes: vi.fn(),
+        setConnectionVisibility: vi.fn(),
+        setAlwaysShowAnchorsOfComponent: vi.fn(),
+        addComponentConnectionLine: vi.fn(),
+        removeComponentConnectionLine: vi.fn(),
+        clearComponentConnectionLines: vi.fn(),
+        addInUseComponent: vi.fn(),
+        removeInUseComponent: vi.fn(),
+        setSelectedConnectionName: vi.fn(),
+        setSelectedConnectionPointName: vi.fn(),
+        setAutoSaveStatus: vi.fn(),
+        handleChangeCommunicationInterfaceName: vi.fn(),
+        handleDeleteCommunicationInterface: vi.fn(),
+        addCommunicationInterface: vi.fn(),
+        initialized: true,
+        components: [],
+        connections: [],
+        hasSystemChanged: false,
+        layerPosition: { x: 0, y: 0 },
+        showHelpLines: false,
+        selectedComponent: undefined,
+        selectedComponentId: null,
+        selectedConnection: undefined,
+        selectedConnectionId: null,
+        selectedPointOfAttack: undefined,
+        selectedConnectionPointId: null,
+        mousePointers: [] as never,
+        newConnection: null,
+        pointsOfAttackOfSelectedComponent: [],
+        assetSearchValue: "",
+        blockAutoSave: false,
+        connectionsOfComponent: [],
+        componentConnectionLines: [],
+        isAnyComponentInUse: false,
+        selectedConnectionPoint: undefined,
+        autoSaveStatus: "uninitialized" as const,
+        makeScreenshot: false,
+        stageScale: 1,
+        stagePosition: { x: 0, y: 0 },
+        ...config,
+    }));
+};
+
+export const mockUseAssets = (config?: Partial<UseAssetsResult>): MockInstance => {
+    return vi.spyOn(assetsHook, "useAssets").mockImplementation(() => ({
+        items: [],
+        isPending: false,
+        loadAssets: vi.fn(),
+        deleteAsset: vi.fn(),
+        ...config,
+    }));
+};

--- a/apps/frontend/src/test-utils/render-with-providers.tsx
+++ b/apps/frontend/src/test-utils/render-with-providers.tsx
@@ -16,7 +16,7 @@ import type { ReactNode } from "react";
 import { render } from "@testing-library/react";
 import type { RenderOptions, RenderResult } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, type InitialEntry } from "react-router-dom";
 import { I18nextProvider } from "react-i18next";
 import { createStore } from "../application/store";
 import type { RootState } from "../application/store";
@@ -26,7 +26,7 @@ interface RenderWithProvidersOptions extends Omit<RenderOptions, "wrapper"> {
     /** Partial Redux state to pre-load into the store. */
     preloadedState?: Partial<RootState>;
     /** Initial URL entries for MemoryRouter. Defaults to ["/"]. */
-    initialEntries?: string[];
+    initialEntries?: InitialEntry[];
 }
 
 /**

--- a/apps/frontend/src/view/components/button.component.test.tsx
+++ b/apps/frontend/src/view/components/button.component.test.tsx
@@ -9,7 +9,6 @@
 /// <reference types="@testing-library/jest-dom" />
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
 import { Button } from "./button.component";
 
 describe("Button", () => {

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EditorSidebarAssetList, type EditorSidebarAssetListProps } from "./editor-sidebar-asset-list.component";
+import { createAsset } from "#test-utils/builders.ts";
+
+const setup = (propsOverride: Partial<EditorSidebarAssetListProps> = {}) => {
+    const props = {
+        items: [createAsset({ id: 1, name: "DB Server" }), createAsset({ id: 2, name: "Web App" })],
+        checkedAssets: [1],
+        onChangeHandler: vi.fn(),
+        onAssetNameClick: vi.fn(),
+        onAssetHover: vi.fn(),
+        onAssetLeave: vi.fn(),
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    render(<EditorSidebarAssetList {...props} />);
+    return { props, user };
+};
+
+describe("EditorSidebarAssetList", () => {
+    it("renders each asset name as visible text", () => {
+        setup();
+
+        expect(screen.getByText("DB Server")).toBeInTheDocument();
+        expect(screen.getByText("Web App")).toBeInTheDocument();
+    });
+
+    it("checked assets have their switch turned on", () => {
+        setup({ checkedAssets: [1] });
+
+        const switches = screen.getAllByRole("checkbox");
+        expect(switches[0]).toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "DB Server" })).toBeChecked();
+    });
+
+    it("assets not in checkedAssets have their switch turned off", () => {
+        setup({ checkedAssets: [1] });
+
+        const switches = screen.getAllByRole("checkbox");
+        expect(switches[1]).not.toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "Web App" })).not.toBeChecked();
+    });
+
+    it("toggling a switch calls onChangeHandler with the correct asset", async () => {
+        const { props, user } = setup();
+
+        await user.click(screen.getByRole("checkbox", { name: "Web App" }));
+
+        expect(props.onChangeHandler).toHaveBeenCalledOnce();
+        expect(props.onChangeHandler).toHaveBeenCalledWith(expect.any(Object), props.items[1]);
+    });
+
+    it("clicking an asset name calls onAssetNameClick with that asset", async () => {
+        const { props, user } = setup();
+
+        await user.click(screen.getByText("DB Server"));
+
+        expect(props.onAssetNameClick).toHaveBeenCalledOnce();
+        expect(props.onAssetNameClick).toHaveBeenCalledWith(props.items[0]);
+    });
+
+    it("clicking an asset name does not toggle the switch", async () => {
+        const { props, user } = setup();
+
+        await user.click(screen.getByText("Web App"));
+
+        expect(props.onChangeHandler).not.toHaveBeenCalled();
+    });
+
+    it("hovering an asset name calls onAssetHover", async () => {
+        const { props, user } = setup();
+
+        await user.hover(screen.getByText("DB Server"));
+
+        expect(props.onAssetHover).toHaveBeenCalledOnce();
+        expect(props.onAssetHover).toHaveBeenCalledWith(expect.any(Object), props.items[0]);
+    });
+
+    it("leaving an asset name calls onAssetLeave", async () => {
+        const { props, user } = setup();
+
+        await user.hover(screen.getByText("DB Server"));
+        await user.unhover(screen.getByText("DB Server"));
+
+        expect(props.onAssetLeave).toHaveBeenCalled();
+    });
+
+    it("renders nothing when items is empty", () => {
+        setup({ items: [] });
+
+        expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+        expect(screen.queryByText("DB Server")).not.toBeInTheDocument();
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
@@ -2,7 +2,7 @@ import { FormControlLabel, FormGroup, Switch, Typography } from "@mui/material";
 import type { ChangeEvent, MouseEvent } from "react";
 import type { Asset } from "#api/types/asset.types.ts";
 
-interface EditorSidebarAssetListProps {
+export interface EditorSidebarAssetListProps {
     items: Asset[];
     checkedAssets: number[];
     onChangeHandler: (event: ChangeEvent<HTMLInputElement>, asset: Asset) => void;

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
@@ -1,14 +1,24 @@
 import { FormControlLabel, FormGroup, Switch, Typography } from "@mui/material";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import type { Asset } from "#api/types/asset.types.ts";
 
 interface EditorSidebarAssetListProps {
     items: Asset[];
     checkedAssets: number[];
     onChangeHandler: (event: ChangeEvent<HTMLInputElement>, asset: Asset) => void;
+    onAssetNameClick: (asset: Asset) => void;
+    onAssetHover: (event: MouseEvent<HTMLElement>, asset: Asset) => void;
+    onAssetLeave: () => void;
 }
 
-export const EditorSidebarAssetList = ({ items, checkedAssets, onChangeHandler }: EditorSidebarAssetListProps) => {
+export const EditorSidebarAssetList = ({
+    items,
+    checkedAssets,
+    onChangeHandler,
+    onAssetNameClick,
+    onAssetHover,
+    onAssetLeave,
+}: EditorSidebarAssetListProps) => {
     return (
         <FormGroup sx={{ color: "text.primary", paddingLeft: 0.5 }}>
             {items.map((asset, index) => {
@@ -34,10 +44,19 @@ export const EditorSidebarAssetList = ({ items, checkedAssets, onChangeHandler }
                         }
                         label={
                             <Typography
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    onAssetNameClick(asset);
+                                }}
+                                onMouseEnter={(e) => onAssetHover(e, asset)}
+                                onMouseLeave={onAssetLeave}
                                 sx={{
                                     fontSize: "0.75rem",
                                     fontWeight: "bold",
                                     marginLeft: 1,
+                                    cursor: "pointer",
+                                    "&:hover": { textDecoration: "underline" },
                                 }}
                                 data-testid="asset-search-results"
                             >

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.test.tsx
@@ -10,7 +10,7 @@ import { USER_ROLES } from "#api/types/user-roles.types.ts";
 
 const setup = (propsOverride: Partial<EditorSidebarSelectedCommunicationInterfaceProps> = {}) => {
     const props = {
-        selectedConnectionPoint: createConnectionPoint(),
+        selectedConnectionPoint: createConnectionPoint({ componentName: "Test Component" }),
         selectedPointOfAttack: createPointOfAttack({ assets: [1] }),
         assetSearchValue: "",
         handleAssetSearchChanged: vi.fn(),
@@ -23,6 +23,7 @@ const setup = (propsOverride: Partial<EditorSidebarSelectedCommunicationInterfac
         handleChangeCommunicationInterfaceName: vi.fn(),
         handleDeleteCommunicationInterface: vi.fn(),
         handleAssetNameClick: vi.fn(),
+        handleInterfaceBreadcrumbClick: vi.fn(),
         userRole: USER_ROLES.EDITOR,
         ...propsOverride,
     };
@@ -32,6 +33,24 @@ const setup = (propsOverride: Partial<EditorSidebarSelectedCommunicationInterfac
 };
 
 describe("EditorSidebarSelectedCommunicationInterface", () => {
+    describe("breadcrumb", () => {
+        it("renders the component name, separator, and Interface label", () => {
+            setup();
+
+            expect(screen.getByText("Test Component")).toBeInTheDocument();
+            expect(screen.getByText(">")).toBeInTheDocument();
+            expect(screen.getByText("Interface:")).toBeInTheDocument();
+        });
+
+        it("clicking the component name calls handleInterfaceBreadcrumbClick", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("Test Component"));
+
+            expect(props.handleInterfaceBreadcrumbClick).toHaveBeenCalledOnce();
+        });
+    });
+
     describe("asset name click", () => {
         it("calls handleAssetNameClick with the correct asset when an asset name is clicked", async () => {
             const { props, user } = setup();

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.test.tsx
@@ -1,0 +1,72 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+    EditorSidebarSelectedCommunicationInterface,
+    type EditorSidebarSelectedCommunicationInterfaceProps,
+} from "./editor-sidebar-selected-communication-interface.component";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createConnectionPoint, createPointOfAttack } from "#test-utils/builders.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+const setup = (propsOverride: Partial<EditorSidebarSelectedCommunicationInterfaceProps> = {}) => {
+    const props = {
+        selectedConnectionPoint: createConnectionPoint(),
+        selectedPointOfAttack: createPointOfAttack({ assets: [1] }),
+        assetSearchValue: "",
+        handleAssetSearchChanged: vi.fn(),
+        items: [
+            createAsset({ id: 1, name: "DB Server", confidentiality: 3, integrity: 2, availability: 1 }),
+            createAsset({ id: 2, name: "Web App", confidentiality: 1, integrity: 3, availability: 2 }),
+        ],
+        handleOnAssetChanged: vi.fn(),
+        handleOnConnectionPointDescriptionChange: vi.fn(),
+        handleChangeCommunicationInterfaceName: vi.fn(),
+        handleDeleteCommunicationInterface: vi.fn(),
+        handleAssetNameClick: vi.fn(),
+        userRole: USER_ROLES.EDITOR,
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    renderWithProviders(<EditorSidebarSelectedCommunicationInterface {...props} />);
+    return { props, user };
+};
+
+describe("EditorSidebarSelectedCommunicationInterface", () => {
+    describe("asset name click", () => {
+        it("calls handleAssetNameClick with the correct asset when an asset name is clicked", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("DB Server"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledOnce();
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[0]);
+        });
+    });
+
+    describe("Popper hover tooltip", () => {
+        it("shows CIA values when hovering over an asset name", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("DB Server"));
+
+            expect(screen.getByText("(C 3 / I 2 / A 1)")).toBeInTheDocument();
+        });
+
+        it("hides CIA tooltip when mouse leaves the asset name", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("DB Server"));
+            await user.unhover(screen.getByText("DB Server"));
+
+            expect(screen.queryByText("(C 3 / I 2 / A 1)")).not.toBeInTheDocument();
+        });
+
+        it("shows correct CIA values for a different asset", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("Web App"));
+
+            expect(screen.getByText("(C 1 / I 3 / A 2)")).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.tsx
@@ -1,12 +1,13 @@
-import { IconButton, Typography } from "@mui/material";
+import { IconButton, Popper, Typography } from "@mui/material";
 import { Box } from "@mui/system";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EditorSidebarAssetList } from "./editor-sidebar-asset-list.component";
 import { SearchField } from "../search-field.component";
 import { TextField } from "../textfield.component";
 import { checkUserRole, USER_ROLES } from "../../../api/types/user-roles.types";
 import { Delete } from "@mui/icons-material";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import type { SystemConnectionPoint } from "#application/adapters/system-connection-point.adapter.ts";
 import type { Asset } from "#api/types/asset.types.ts";
 import type { SystemPointOfAttack } from "#api/types/system.types.ts";
@@ -27,6 +28,7 @@ interface EditorSidebarSelectedCommunicationInterfaceProps {
         isFromCommunicationInterfaceSidebar?: boolean
     ) => void;
     userRole: USER_ROLES | undefined;
+    handleAssetNameClick: (asset: Asset) => void;
 }
 
 export const EditorSidebarSelectedCommunicationInterface = ({
@@ -40,232 +42,266 @@ export const EditorSidebarSelectedCommunicationInterface = ({
     handleChangeCommunicationInterfaceName,
     handleDeleteCommunicationInterface,
     userRole,
+    handleAssetNameClick,
 }: EditorSidebarSelectedCommunicationInterfaceProps) => {
     const { t } = useTranslation("editorPage");
+    const [assetAnchorEl, setAssetAnchorEl] = useState<HTMLElement | null>(null);
+    const [hoveredAsset, setHoveredAsset] = useState<Asset | null>(null);
+
+    const handleAssetHover = (event: MouseEvent<HTMLElement>, asset: Asset) => {
+        setHoveredAsset(asset);
+        setAssetAnchorEl(event.currentTarget);
+    };
+
+    const handleAssetLeave = () => {
+        setHoveredAsset(null);
+        setAssetAnchorEl(null);
+    };
     return (
-        <>
-            <Box>
+        <Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#f2f4f500",
+                    borderRadius: 15,
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                    alignItems: "flex-start",
+                    justifyContent: "space-between",
+                    marginBottom: "-10px",
+                }}
+            >
                 <Box
                     sx={{
                         display: "flex",
+                        flexDirection: "column",
                         backgroundColor: "#f2f4f500",
                         borderRadius: 15,
                         paddingLeft: 0,
                         paddingRight: 0,
                         alignItems: "flex-start",
-                        justifyContent: "space-between",
-                        marginBottom: "-10px",
-                    }}
-                >
-                    <Box
-                        sx={{
-                            display: "flex",
-                            flexDirection: "column",
-                            backgroundColor: "#f2f4f500",
-                            borderRadius: 15,
-                            paddingLeft: 0,
-                            paddingRight: 0,
-                            alignItems: "flex-start",
-                            marginBottom: "8px",
-                        }}
-                    >
-                        <Typography
-                            sx={{
-                                fontWeight: "bold",
-                                fontSize: "0.875rem",
-                                color: "text.primary",
-                                marginBottom: "4px",
-                            }}
-                        >
-                            {selectedConnectionPoint?.componentName} Interface:
-                        </Typography>
-                        <TextField
-                            value={selectedConnectionPoint?.name ? selectedConnectionPoint.name : ""}
-                            onChange={(e) => {
-                                if (!selectedConnectionPoint.componentId) {
-                                    return;
-                                }
-                                handleChangeCommunicationInterfaceName(
-                                    selectedConnectionPoint.componentId,
-                                    selectedConnectionPoint.id,
-                                    e.target.value
-                                );
-                            }}
-                            onKeyUp={(event) => {
-                                if (event.key === "Delete") {
-                                    event.stopPropagation();
-                                }
-                            }}
-                            sx={{
-                                border: "none !important",
-                                width: "100%",
-                                "& .MuiInputBase-root": {
-                                    borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
-                                },
-                                "*": {
-                                    border: "none !important",
-                                    padding: "0 !important",
-                                    borderRadius: "0 !important",
-                                },
-                                "& .Mui-focused": {
-                                    borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                                },
-                                input: {
-                                    fontSize: "0.875rem !important",
-                                    width: "100% !important",
-                                },
-                                color: "text.primary !important",
-                                padding: "0 !important",
-                            }}
-                        />
-                    </Box>
-                    {checkUserRole(userRole, USER_ROLES.EDITOR) && (
-                        <IconButton
-                            onClick={() => {
-                                if (!selectedConnectionPoint.componentId) {
-                                    return;
-                                }
-                                handleDeleteCommunicationInterface(
-                                    selectedConnectionPoint.componentId,
-                                    selectedConnectionPoint.id,
-                                    selectedConnectionPoint.name,
-                                    true
-                                );
-                            }}
-                            sx={{
-                                "&:hover": {
-                                    color: "#ef5350",
-                                    backgroundColor: "background.paperIntransparent",
-                                },
-                                marginTop: -1,
-                            }}
-                        >
-                            <Delete sx={{ fontSize: 18 }} />
-                        </IconButton>
-                    )}
-                </Box>
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
+                        marginBottom: "8px",
                     }}
                 >
                     <Typography
                         sx={{
                             fontWeight: "bold",
-                            fontSize: "0.75rem",
+                            fontSize: "0.875rem",
                             color: "text.primary",
+                            marginBottom: "4px",
                         }}
                     >
-                        {t("sidebar.description.title")}
+                        {selectedConnectionPoint?.componentName} Interface:
                     </Typography>
-                </Box>
-                <TextField
-                    value={selectedConnectionPoint?.description ? selectedConnectionPoint.description : ""}
-                    onChange={handleOnConnectionPointDescriptionChange}
-                    onKeyUp={(event) => {
-                        if (event.key === "Delete") {
-                            event.stopPropagation();
-                        }
-                    }}
-                    multiline
-                    minRows={1}
-                    maxRows={Infinity}
-                    sx={{
-                        border: "none !important",
-                        width: "100%",
-                        "& .MuiInputBase-root": {
-                            borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
-                        },
-                        "*": {
-                            border: "none !important",
-                            padding: "0 !important",
-                            borderRadius: "0 !important",
-                        },
-                        "& .Mui-focused": {
-                            borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                        },
-                        textarea: {
-                            fontSize: "0.875rem !important",
-                            width: "100% !important",
-                            lineHeight: "1.5 !important",
-                        },
-                        color: "text.primary !important",
-                        padding: "0 !important",
-                    }}
-                />
-
-                {selectedPointOfAttack !== undefined && selectedPointOfAttack != null && (
-                    <Box>
-                        <Box
-                            sx={{
-                                display: "flex",
-                                backgroundColor: "#fff",
-                                borderRadius: 15,
-                                height: "31px",
-                                paddingLeft: 8,
-                                paddingRight: 0,
-                                alignItems: "center",
-                                justifyContent: "space-between",
-                                marginTop: 4,
-                                marginBottom: 2,
-                                marginLeft: -8,
-                                marginRight: -8,
-                            }}
-                        >
-                            <Typography
-                                sx={{
-                                    fontWeight: "bold",
-                                    fontSize: "0.75rem",
-                                    color: "text.primary",
-                                }}
-                            >
-                                {t("sidebar.assets.title")}
-                            </Typography>
-                        </Box>
-
-                        <SearchField
-                            sx={{
-                                marginBottom: 2,
-                                marginLeft: -0.5,
-                                width: "40%",
-                                height: "31px",
-                                borderRadius: 5,
-                            }}
-                            inputSx={{ fontSize: "0.75rem" }}
-                            value={assetSearchValue}
-                            onChange={handleAssetSearchChanged}
-                            data-testid="selected-communication-asset-search-field"
-                        />
-
-                        <EditorSidebarAssetList
-                            items={
-                                assetSearchValue != ""
-                                    ? items.filter((item) => {
-                                          const lcSearchValue = assetSearchValue.toLowerCase();
-                                          return (
-                                              assetSearchValue === "" ||
-                                              item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
-                                          );
-                                      })
-                                    : items
+                    <TextField
+                        value={selectedConnectionPoint?.name ? selectedConnectionPoint.name : ""}
+                        onChange={(e) => {
+                            if (!selectedConnectionPoint.componentId) {
+                                return;
                             }
-                            checkedAssets={selectedPointOfAttack.assets}
-                            onChangeHandler={handleOnAssetChanged}
-                        />
-                    </Box>
+                            handleChangeCommunicationInterfaceName(
+                                selectedConnectionPoint.componentId,
+                                selectedConnectionPoint.id,
+                                e.target.value
+                            );
+                        }}
+                        onKeyUp={(event) => {
+                            if (event.key === "Delete") {
+                                event.stopPropagation();
+                            }
+                        }}
+                        sx={{
+                            border: "none !important",
+                            width: "100%",
+                            "& .MuiInputBase-root": {
+                                borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
+                            },
+                            "*": {
+                                border: "none !important",
+                                padding: "0 !important",
+                                borderRadius: "0 !important",
+                            },
+                            "& .Mui-focused": {
+                                borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
+                            },
+                            input: {
+                                fontSize: "0.875rem !important",
+                                width: "100% !important",
+                            },
+                            color: "text.primary !important",
+                            padding: "0 !important",
+                        }}
+                    />
+                </Box>
+                {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                    <IconButton
+                        onClick={() => {
+                            if (!selectedConnectionPoint.componentId) {
+                                return;
+                            }
+                            handleDeleteCommunicationInterface(
+                                selectedConnectionPoint.componentId,
+                                selectedConnectionPoint.id,
+                                selectedConnectionPoint.name,
+                                true
+                            );
+                        }}
+                        sx={{
+                            "&:hover": {
+                                color: "#ef5350",
+                                backgroundColor: "background.paperIntransparent",
+                            },
+                            marginTop: -1,
+                        }}
+                    >
+                        <Delete sx={{ fontSize: 18 }} />
+                    </IconButton>
                 )}
             </Box>
-        </>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.description.title")}
+                </Typography>
+            </Box>
+            <TextField
+                value={selectedConnectionPoint?.description ? selectedConnectionPoint.description : ""}
+                onChange={handleOnConnectionPointDescriptionChange}
+                onKeyUp={(event) => {
+                    if (event.key === "Delete") {
+                        event.stopPropagation();
+                    }
+                }}
+                multiline
+                minRows={1}
+                maxRows={Infinity}
+                sx={{
+                    border: "none !important",
+                    width: "100%",
+                    "& .MuiInputBase-root": {
+                        borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
+                    },
+                    "*": {
+                        border: "none !important",
+                        padding: "0 !important",
+                        borderRadius: "0 !important",
+                    },
+                    "& .Mui-focused": {
+                        borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
+                    },
+                    textarea: {
+                        fontSize: "0.875rem !important",
+                        width: "100% !important",
+                        lineHeight: "1.5 !important",
+                    },
+                    color: "text.primary !important",
+                    padding: "0 !important",
+                }}
+            />
+
+            {selectedPointOfAttack !== undefined && selectedPointOfAttack != null && (
+                <Box>
+                    <Box
+                        sx={{
+                            display: "flex",
+                            backgroundColor: "#fff",
+                            borderRadius: 15,
+                            height: "31px",
+                            paddingLeft: 8,
+                            paddingRight: 0,
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            marginTop: 4,
+                            marginBottom: 2,
+                            marginLeft: -8,
+                            marginRight: -8,
+                        }}
+                    >
+                        <Typography
+                            sx={{
+                                fontWeight: "bold",
+                                fontSize: "0.75rem",
+                                color: "text.primary",
+                            }}
+                        >
+                            {t("sidebar.assets.title")}
+                        </Typography>
+                    </Box>
+
+                    <SearchField
+                        sx={{
+                            marginBottom: 2,
+                            marginLeft: -0.5,
+                            width: "40%",
+                            height: "31px",
+                            borderRadius: 5,
+                        }}
+                        inputSx={{ fontSize: "0.75rem" }}
+                        value={assetSearchValue}
+                        onChange={handleAssetSearchChanged}
+                        data-testid="selected-communication-asset-search-field"
+                    />
+
+                    <EditorSidebarAssetList
+                        items={
+                            assetSearchValue != ""
+                                ? items.filter((item) => {
+                                      const lcSearchValue = assetSearchValue.toLowerCase();
+                                      return (
+                                          assetSearchValue === "" ||
+                                          item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
+                                      );
+                                  })
+                                : items
+                        }
+                        checkedAssets={selectedPointOfAttack.assets}
+                        onChangeHandler={handleOnAssetChanged}
+                        onAssetNameClick={handleAssetNameClick}
+                        onAssetHover={handleAssetHover}
+                        onAssetLeave={handleAssetLeave}
+                    />
+
+                    <Popper
+                        open={assetAnchorEl != null}
+                        anchorEl={assetAnchorEl}
+                        placement="bottom-start"
+                        sx={{
+                            backgroundColor: "background.defaultIntransparent",
+                            borderRadius: 5,
+                            boxShadow: 1,
+                            zIndex: 1000,
+                        }}
+                    >
+                        {hoveredAsset && (
+                            <Box sx={{ padding: 1, margin: 0.5 }}>
+                                <Typography sx={{ fontSize: "0.75rem" }}>
+                                    {`(C ${hoveredAsset.confidentiality} / I ${hoveredAsset.integrity} / A ${hoveredAsset.availability})`}
+                                </Typography>
+                            </Box>
+                        )}
+                    </Popper>
+                </Box>
+            )}
+        </Box>
     );
 };

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.tsx
@@ -12,7 +12,7 @@ import type { SystemConnectionPoint } from "#application/adapters/system-connect
 import type { Asset } from "#api/types/asset.types.ts";
 import type { SystemPointOfAttack } from "#api/types/system.types.ts";
 
-interface EditorSidebarSelectedCommunicationInterfaceProps {
+export interface EditorSidebarSelectedCommunicationInterfaceProps {
     selectedConnectionPoint: SystemConnectionPoint;
     selectedPointOfAttack: SystemPointOfAttack | null | undefined;
     assetSearchValue: string;

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.tsx
@@ -29,6 +29,7 @@ export interface EditorSidebarSelectedCommunicationInterfaceProps {
     ) => void;
     userRole: USER_ROLES | undefined;
     handleAssetNameClick: (asset: Asset) => void;
+    handleInterfaceBreadcrumbClick: () => void;
 }
 
 export const EditorSidebarSelectedCommunicationInterface = ({
@@ -43,6 +44,7 @@ export const EditorSidebarSelectedCommunicationInterface = ({
     handleDeleteCommunicationInterface,
     userRole,
     handleAssetNameClick,
+    handleInterfaceBreadcrumbClick,
 }: EditorSidebarSelectedCommunicationInterfaceProps) => {
     const { t } = useTranslation("editorPage");
     const [assetAnchorEl, setAssetAnchorEl] = useState<HTMLElement | null>(null);
@@ -85,13 +87,29 @@ export const EditorSidebarSelectedCommunicationInterface = ({
                 >
                     <Typography
                         sx={{
+                            display: "inline",
                             fontWeight: "bold",
                             fontSize: "0.875rem",
                             color: "text.primary",
                             marginBottom: "4px",
                         }}
                     >
-                        {selectedConnectionPoint?.componentName} Interface:
+                        <Typography
+                            component="span"
+                            onClick={handleInterfaceBreadcrumbClick}
+                            sx={{
+                                fontWeight: "bold",
+                                fontSize: "0.875rem",
+                                cursor: "pointer",
+                                "&:hover": { textDecoration: "underline" },
+                            }}
+                        >
+                            {selectedConnectionPoint?.componentName}
+                        </Typography>
+                        <Typography component="span" sx={{ display: "inline", marginLeft: 1, marginRight: 1 }}>
+                            &gt;
+                        </Typography>
+                        Interface:
                     </Typography>
                     <TextField
                         value={selectedConnectionPoint?.name ? selectedConnectionPoint.name : ""}

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.test.tsx
@@ -9,7 +9,11 @@ import { createAsset, createSystemComponent, createPointOfAttack } from "#test-u
 import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 import { USER_ROLES } from "#api/types/user-roles.types.ts";
 import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
-import { AnchorOrientation, type ConnectionEndpointWithComponent } from "#api/types/system.types.ts";
+import {
+    AnchorOrientation,
+    type ConnectionEndpointWithComponent,
+    type SystemCommunicationInterface,
+} from "#api/types/system.types.ts";
 
 const setup = (propsOverride: Partial<EditorSidebarSelectedComponentProps> = {}) => {
     const props = {
@@ -148,6 +152,76 @@ describe("EditorSidebarSelectedComponent — new click handlers", () => {
             await user.click(screen.getByText("Main DB"));
 
             expect(props.handleSelectConnectedComponent).toHaveBeenCalledWith("comp-3", null);
+        });
+    });
+
+    describe("communication interface items", () => {
+        const communicationInterfaces: SystemCommunicationInterface[] = [
+            {
+                id: "ci-1",
+                name: "API Gateway",
+                icon: null,
+                type: "REST",
+                projectId: 1,
+                componentId: "comp-1",
+                componentName: "Test Component",
+            },
+        ];
+
+        const componentWithInterfaces = createSystemComponent({ communicationInterfaces });
+
+        it("clicking an interface name calls handleSelectConnectedComponent with component and interface ids", async () => {
+            const { props, user } = setup({ selectedComponent: componentWithInterfaces });
+
+            await user.click(screen.getByText("API Gateway"));
+
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledOnce();
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledWith("comp-1", "ci-1");
+        });
+
+        it("clicking the edit icon shows a text input for renaming", async () => {
+            const { user } = setup({ selectedComponent: componentWithInterfaces });
+
+            expect(screen.getByText("API Gateway")).toBeInTheDocument();
+
+            const editIcon = screen.getByTestId("EditIcon");
+            await user.click(editIcon);
+
+            // The interface name should now be in a textbox, not as plain text
+            const textboxes = screen.getAllByRole("textbox");
+            const interfaceInput = textboxes.find((input) => (input as HTMLInputElement).value === "API Gateway");
+            expect(interfaceInput).toBeDefined();
+            expect(screen.queryByText("API Gateway")).not.toBeInTheDocument();
+        });
+
+        it("blurring the text input exits edit mode and shows clickable text again", async () => {
+            const { user } = setup({ selectedComponent: componentWithInterfaces });
+
+            await user.click(screen.getByTestId("EditIcon"));
+
+            await user.tab(); // moves focus away
+
+            expect(screen.getByText("API Gateway")).toBeInTheDocument();
+        });
+
+        it("pressing Enter in the text input exits edit mode", async () => {
+            const { user } = setup({ selectedComponent: componentWithInterfaces });
+
+            await user.click(screen.getByTestId("EditIcon"));
+
+            await user.keyboard("{Enter}");
+
+            expect(screen.getByText("API Gateway")).toBeInTheDocument();
+        });
+
+        it("edit and delete icons are not rendered for non-editor roles", () => {
+            setup({
+                selectedComponent: componentWithInterfaces,
+                userRole: USER_ROLES.VIEWER,
+            });
+
+            expect(screen.queryByTestId("EditIcon")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("DeleteIcon")).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.test.tsx
@@ -1,0 +1,153 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+    EditorSidebarSelectedComponent,
+    type EditorSidebarSelectedComponentProps,
+} from "./editor-sidebar-selected-component.component";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createSystemComponent, createPointOfAttack } from "#test-utils/builders.ts";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { AnchorOrientation, type ConnectionEndpointWithComponent } from "#api/types/system.types.ts";
+
+const setup = (propsOverride: Partial<EditorSidebarSelectedComponentProps> = {}) => {
+    const props = {
+        selectedComponent: createSystemComponent(),
+        handleDeleteComponent: vi.fn(),
+        handleOnNameChange: vi.fn(),
+        handleChangePointOfAttack: vi.fn(),
+        handleAddAssetToAllPointsOfAttack: vi.fn(),
+        handleRemoveAssetFromAllPointsOfAttack: vi.fn(),
+        assetSearchValue: "",
+        handleAssetSearchChanged: vi.fn(),
+        items: [createAsset({ id: 1, name: "DB Server" }), createAsset({ id: 2, name: "Web App" })],
+        pointsOfAttackOfSelectedComponent: [],
+        userRole: USER_ROLES.EDITOR,
+        handleOnDescriptionChange: vi.fn(),
+        connectedComponents: [] as ConnectionEndpointWithComponent[],
+        handleDeleteConnectionBetweenComponents: vi.fn(),
+        handleChangeCommunicationInterfaceName: vi.fn(),
+        handleDeleteCommunicationInterface: vi.fn(),
+        handlePointOfAttackLabelClick: vi.fn(),
+        handleAssetNameClick: vi.fn(),
+        handleSelectConnectedComponent: vi.fn(),
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    renderWithProviders(<EditorSidebarSelectedComponent {...props} />);
+    return { props, user };
+};
+
+describe("EditorSidebarSelectedComponent — new click handlers", () => {
+    describe("handleAssetNameClick", () => {
+        it("clicking an asset name calls handleAssetNameClick with the asset", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("DB Server"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledOnce();
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[0]);
+        });
+
+        it("clicking a different asset passes the correct asset", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("Web App"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[1]);
+        });
+    });
+
+    describe("handlePointOfAttackLabelClick", () => {
+        it("clicking a checked POA label calls handlePointOfAttackLabelClick with the POA id and component id", async () => {
+            const poa = createPointOfAttack({ id: "poa-ui", type: POINTS_OF_ATTACK.USER_INTERFACE });
+            const component = createSystemComponent({ id: "comp-1", pointsOfAttack: [poa] });
+
+            const { props, user } = setup({ selectedComponent: component });
+
+            // The label text comes from common translations: "User Interface"
+            await user.click(screen.getByText("User Interface"));
+
+            expect(props.handlePointOfAttackLabelClick).toHaveBeenCalledOnce();
+            expect(props.handlePointOfAttackLabelClick).toHaveBeenCalledWith("poa-ui", "comp-1");
+        });
+
+        it("clicking a POA label when the POA is NOT checked does not call handlePointOfAttackLabelClick", async () => {
+            // Component with no pointsOfAttack means no currPointOfAttack for any type
+            const component = createSystemComponent({ pointsOfAttack: [] });
+
+            const { props, user } = setup({ selectedComponent: component });
+
+            // The label still renders (as an unchecked switch label)
+            await user.click(screen.getByText("User Interface"));
+
+            expect(props.handlePointOfAttackLabelClick).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("handleSelectConnectedComponent", () => {
+        it("clicking a connected component name calls handleSelectConnectedComponent with the correct ids", async () => {
+            const connectedComponents: ConnectionEndpointWithComponent[] = [
+                {
+                    id: "comp-2",
+                    anchor: AnchorOrientation.left,
+                    type: STANDARD_COMPONENT_TYPES.SERVER,
+                    communicationInterfaceId: "ci-1",
+                    component: {
+                        id: "comp-2",
+                        name: "Backend Server",
+                        type: STANDARD_COMPONENT_TYPES.SERVER,
+                        x: 0,
+                        y: 0,
+                        gridX: 0,
+                        gridY: 0,
+                        width: 100,
+                        height: 100,
+                        selected: false,
+                        projectId: 1,
+                        symbol: null,
+                    },
+                },
+            ];
+
+            const { props, user } = setup({ connectedComponents });
+
+            await user.click(screen.getByTestId("connected-component-name"));
+
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledOnce();
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledWith("comp-2", "ci-1");
+        });
+
+        it("passes null communicationInterfaceId when connection has none", async () => {
+            const connectedComponents: ConnectionEndpointWithComponent[] = [
+                {
+                    id: "comp-3",
+                    anchor: AnchorOrientation.right,
+                    type: STANDARD_COMPONENT_TYPES.DATABASE,
+                    communicationInterfaceId: null,
+                    component: {
+                        id: "comp-3",
+                        name: "Main DB",
+                        type: STANDARD_COMPONENT_TYPES.DATABASE,
+                        x: 0,
+                        y: 0,
+                        gridX: 0,
+                        gridY: 0,
+                        width: 100,
+                        height: 100,
+                        selected: false,
+                        projectId: 1,
+                        symbol: null,
+                    },
+                },
+            ];
+
+            const { props, user } = setup({ connectedComponents });
+
+            await user.click(screen.getByText("Main DB"));
+
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledWith("comp-3", null);
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
@@ -337,6 +337,7 @@ export const EditorSidebarSelectedComponent = ({
                                 key={i}
                                 label={
                                     <Typography
+                                        component="span"
                                         sx={{
                                             fontSize: "0.75rem",
                                             fontWeight: "bold",

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { PointOfAttackSwitch } from "./point-of-attack-switch.component";
 import { POINTS_OF_ATTACK } from "../../../api/types/points-of-attack.types";
 import { POA_COLORS } from "../../colors/pointsOfAttack.colors";
-import { Delete } from "@mui/icons-material";
+import { Delete, Edit } from "@mui/icons-material";
 import { TextField } from "../textfield.component";
 import { SearchField } from "../search-field.component";
 import { ToggleButtons } from "../toggle-buttons.component";
@@ -93,6 +93,7 @@ export const EditorSidebarSelectedComponent = ({
     const [localName, setLocalName] = useState<string>("");
     const [localDescription, setLocalDescription] = useState<string>("");
     const [interfaceNames, setInterfaceNames] = useState<Record<string, string>>({});
+    const [editingInterfaceId, setEditingInterfaceId] = useState<string | null>(null);
 
     const debouncedHandleNameChange = useDebounce(handleOnNameChange);
     const debouncedHandleDescriptionChange = useDebounce(handleOnDescriptionChange);
@@ -442,61 +443,98 @@ export const EditorSidebarSelectedComponent = ({
                                             {IconComponent ? <IconComponent /> : null}
                                         </Avatar>
                                     </ListItemAvatar>
-                                    <TextField
-                                        value={interfaceNames[communicationInterface.id] || ""}
-                                        onChange={(event) =>
-                                            handleLocalInterfaceNameChange(
-                                                selectedComponent.id,
-                                                communicationInterface.id,
-                                                event.target.value
-                                            )
-                                        }
-                                        onKeyUp={(event) => {
-                                            if (event.key === "Delete") {
-                                                event.stopPropagation();
+                                    {editingInterfaceId === communicationInterface.id ? (
+                                        <TextField
+                                            value={interfaceNames[communicationInterface.id] || ""}
+                                            onChange={(event) =>
+                                                handleLocalInterfaceNameChange(
+                                                    selectedComponent.id,
+                                                    communicationInterface.id,
+                                                    event.target.value
+                                                )
                                             }
-                                        }}
-                                        autoFocus={false}
-                                        sx={{
-                                            border: "none !important",
-                                            width: "82.5%",
-                                            "& .MuiInputBase-root": {
-                                                borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
-                                            },
-                                            "*": {
+                                            onBlur={() => setEditingInterfaceId(null)}
+                                            onKeyUp={(event) => {
+                                                if (event.key === "Enter") {
+                                                    setEditingInterfaceId(null);
+                                                }
+                                                if (event.key === "Delete") {
+                                                    event.stopPropagation();
+                                                }
+                                            }}
+                                            autoFocus
+                                            sx={{
                                                 border: "none !important",
+                                                width: "82.5%",
+                                                "& .MuiInputBase-root": {
+                                                    borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
+                                                },
+                                                "*": {
+                                                    border: "none !important",
+                                                    padding: "0 !important",
+                                                    borderRadius: "0 !important",
+                                                    fontWeight: "bold",
+                                                },
+                                                input: {
+                                                    fontSize: "0.75rem !important",
+                                                    width: "100% !important",
+                                                },
+                                                color: "text.primary !important",
                                                 padding: "0 !important",
-                                                borderRadius: "0 !important",
+                                            }}
+                                        />
+                                    ) : (
+                                        <Typography
+                                            onClick={() =>
+                                                handleSelectConnectedComponent(
+                                                    selectedComponent.id,
+                                                    communicationInterface.id
+                                                )
+                                            }
+                                            sx={{
+                                                fontSize: "0.75rem",
                                                 fontWeight: "bold",
-                                            },
-                                            "& .Mui-focused": {
-                                                borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                                            },
-                                            input: {
-                                                fontSize: "0.875rem !important",
-                                                width: "100% !important",
-                                            },
-                                            color: "text.primary !important",
-                                            padding: "0 !important",
-                                        }}
-                                    />
-                                    <IconButton
-                                        onClick={() =>
-                                            handleDeleteCommunicationInterface(
-                                                selectedComponent.id,
-                                                communicationInterface.id,
-                                                communicationInterface.name
-                                            )
-                                        }
-                                        sx={{
-                                            "&:hover": {
-                                                color: "#ef5350",
-                                                backgroundColor: "background.paperIntransparent",
-                                            },
-                                        }}
-                                    >
-                                        <Delete sx={{ fontSize: 18 }} />
-                                    </IconButton>
+                                                cursor: "pointer",
+                                                width: "82.5%",
+                                                "&:hover": { textDecoration: "underline" },
+                                            }}
+                                        >
+                                            {interfaceNames[communicationInterface.id] || ""}
+                                        </Typography>
+                                    )}
+                                    <Box sx={{ display: "flex", alignItems: "center" }}>
+                                        {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                                            <IconButton
+                                                onClick={() => setEditingInterfaceId(communicationInterface.id)}
+                                                sx={{
+                                                    "&:hover": {
+                                                        backgroundColor: "background.paperIntransparent",
+                                                    },
+                                                }}
+                                            >
+                                                <Edit sx={{ fontSize: 18 }} />
+                                            </IconButton>
+                                        )}
+                                        {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                                            <IconButton
+                                                onClick={() =>
+                                                    handleDeleteCommunicationInterface(
+                                                        selectedComponent.id,
+                                                        communicationInterface.id,
+                                                        communicationInterface.name
+                                                    )
+                                                }
+                                                sx={{
+                                                    "&:hover": {
+                                                        color: "#ef5350",
+                                                        backgroundColor: "background.paperIntransparent",
+                                                    },
+                                                }}
+                                            >
+                                                <Delete sx={{ fontSize: 18 }} />
+                                            </IconButton>
+                                        )}
+                                    </Box>
                                 </Box>
                             );
                         })}

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
@@ -339,6 +339,7 @@ export const EditorSidebarSelectedComponent = ({
                                 label={
                                     <Typography
                                         component="span"
+                                        data-testid={`poa-switch-${type}`}
                                         sx={{
                                             fontSize: "0.75rem",
                                             fontWeight: "bold",

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
@@ -22,7 +22,7 @@ import type {
 
 const muiIconMap = MuiIcons as Record<string, ElementType>;
 
-interface EditorSidebarSelectedComponentProps {
+export interface EditorSidebarSelectedComponentProps {
     selectedComponent: AugmentedSystemComponent | undefined;
     handleDeleteComponent: () => void;
     handleOnNameChange: (event: ChangeEvent<HTMLInputElement>) => void;

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
@@ -48,6 +48,9 @@ interface EditorSidebarSelectedComponentProps {
         interfaceName: string | null,
         doCloseSidebar?: boolean
     ) => void;
+    handlePointOfAttackLabelClick: (pointOfAttackId: string, componentId?: string) => void;
+    handleAssetNameClick: (asset: Asset) => void;
+    handleSelectConnectedComponent: (componentId: string, communicationInterfaceId?: string | null) => void;
 }
 
 const getSortValueForPointOfAttack = (pointOfAttack: POINTS_OF_ATTACK) => {
@@ -81,6 +84,9 @@ export const EditorSidebarSelectedComponent = ({
     handleDeleteConnectionBetweenComponents,
     handleChangeCommunicationInterfaceName,
     handleDeleteCommunicationInterface,
+    handlePointOfAttackLabelClick,
+    handleAssetNameClick,
+    handleSelectConnectedComponent,
 }: EditorSidebarSelectedComponentProps) => {
     const { t } = useTranslation("editorPage");
     const [communicationInterfaces, setCommunicationInterfaces] = useState<SystemCommunicationInterface[]>([]);
@@ -132,110 +138,32 @@ export const EditorSidebarSelectedComponent = ({
     }
 
     return (
-        <>
-            <Box>
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#f2f4f500",
-                        borderRadius: 15,
-                        paddingLeft: 0,
-                        paddingRight: 0,
-                        alignItems: "flex-start",
-                        justifyContent: "space-between",
-                        marginBottom: "-10px",
-                    }}
-                >
-                    <TextField
-                        value={localName}
-                        onChange={handleLocalNameChange}
-                        autoFocus={false}
-                        // Don't delete the whole Component if Delete is pressed
-                        onKeyUp={(event) => {
-                            if (event.key === "Delete") {
-                                event.stopPropagation();
-                            }
-                        }}
-                        sx={{
-                            border: "none !important",
-                            width: "82.5%",
-                            "& .MuiInputBase-root": {
-                                borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
-                            },
-                            "*": {
-                                border: "none !important",
-                                padding: "0 !important",
-                                borderRadius: "0 !important",
-                                fontWeight: "bold",
-                            },
-                            "& .Mui-focused": {
-                                borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                            },
-                            input: {
-                                fontSize: "0.875rem !important",
-                                width: "100% !important",
-                            },
-                            color: "text.primary !important",
-                            padding: "0 !important",
-                        }}
-                    />
-                    {checkUserRole(userRole, USER_ROLES.EDITOR) && (
-                        <IconButton
-                            onClick={handleDeleteComponent}
-                            sx={{
-                                "&:hover": {
-                                    color: "#ef5350",
-                                    backgroundColor: "background.paperIntransparent",
-                                },
-                                marginTop: -1,
-                            }}
-                        >
-                            <Delete sx={{ fontSize: 18 }} />
-                        </IconButton>
-                    )}
-                </Box>
-
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
-                    }}
-                >
-                    <Typography
-                        sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
-                        }}
-                    >
-                        {t("sidebar.description.title")}
-                    </Typography>
-                </Box>
+        <Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#f2f4f500",
+                    borderRadius: 15,
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                    alignItems: "flex-start",
+                    justifyContent: "space-between",
+                    marginBottom: "-10px",
+                }}
+            >
                 <TextField
-                    value={localDescription}
-                    onChange={handleLocalDescriptionChange}
+                    value={localName}
+                    onChange={handleLocalNameChange}
+                    autoFocus={false}
+                    // Don't delete the whole Component if Delete is pressed
                     onKeyUp={(event) => {
                         if (event.key === "Delete") {
                             event.stopPropagation();
                         }
                     }}
-                    autoFocus={false}
-                    multiline
-                    minRows={1} // Start with the height of just 1 line
-                    maxRows={Infinity} // Allow it to grow as needed
                     sx={{
                         border: "none !important",
-                        width: "100%",
+                        width: "82.5%",
                         "& .MuiInputBase-root": {
                             borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
                         },
@@ -243,384 +171,442 @@ export const EditorSidebarSelectedComponent = ({
                             border: "none !important",
                             padding: "0 !important",
                             borderRadius: "0 !important",
+                            fontWeight: "bold",
                         },
                         "& .Mui-focused": {
                             borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
                         },
-                        textarea: {
+                        input: {
                             fontSize: "0.875rem !important",
                             width: "100% !important",
-                            lineHeight: "1.5 !important",
                         },
                         color: "text.primary !important",
                         padding: "0 !important",
                     }}
                 />
-
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
-                    }}
-                >
-                    <Typography
+                {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                    <IconButton
+                        onClick={handleDeleteComponent}
                         sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
+                            "&:hover": {
+                                color: "#ef5350",
+                                backgroundColor: "background.paperIntransparent",
+                            },
+                            marginTop: -1,
                         }}
                     >
-                        {t("sidebar.pointsofattack.title")}
-                    </Typography>
-                </Box>
-                <FormGroup sx={{ marginLeft: 0.5 }}>
-                    {Object.values(POINTS_OF_ATTACK)
-                        .filter((type) => type !== POINTS_OF_ATTACK.COMMUNICATION_INTERFACES)
-                        .filter((type) => {
-                            switch (selectedComponent?.type) {
-                                case "USERS":
-                                    return (
-                                        type === POINTS_OF_ATTACK.USER_BEHAVIOUR &&
-                                        // @ts-expect-error TODO: Bug? Should it be type !== POINTS_OF_ATTACK.USER_BEHAVIOUR or || instead of &&?
-                                        type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
-                                    );
-                                case "CLIENT":
+                        <Delete sx={{ fontSize: 18 }} />
+                    </IconButton>
+                )}
+            </Box>
+
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.description.title")}
+                </Typography>
+            </Box>
+            <TextField
+                value={localDescription}
+                onChange={handleLocalDescriptionChange}
+                onKeyUp={(event) => {
+                    if (event.key === "Delete") {
+                        event.stopPropagation();
+                    }
+                }}
+                autoFocus={false}
+                multiline
+                minRows={1} // Start with the height of just 1 line
+                maxRows={Infinity} // Allow it to grow as needed
+                sx={{
+                    border: "none !important",
+                    width: "100%",
+                    "& .MuiInputBase-root": {
+                        borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
+                    },
+                    "*": {
+                        border: "none !important",
+                        padding: "0 !important",
+                        borderRadius: "0 !important",
+                    },
+                    "& .Mui-focused": {
+                        borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
+                    },
+                    textarea: {
+                        fontSize: "0.875rem !important",
+                        width: "100% !important",
+                        lineHeight: "1.5 !important",
+                    },
+                    color: "text.primary !important",
+                    padding: "0 !important",
+                }}
+            />
+
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.pointsofattack.title")}
+                </Typography>
+            </Box>
+            <FormGroup sx={{ marginLeft: 0.5 }}>
+                {Object.values(POINTS_OF_ATTACK)
+                    .filter((type) => type !== POINTS_OF_ATTACK.COMMUNICATION_INTERFACES)
+                    .filter((type) => {
+                        switch (selectedComponent?.type) {
+                            case "USERS":
+                                return (
+                                    type === POINTS_OF_ATTACK.USER_BEHAVIOUR &&
+                                    // @ts-expect-error TODO: Bug? Should it be type !== POINTS_OF_ATTACK.USER_BEHAVIOUR or || instead of &&?
+                                    type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
+                                );
+                            case "CLIENT":
+                                return (
+                                    type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
+                                    type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
+                                );
+                            case "SERVER":
+                                return (
+                                    type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
+                                    type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
+                                );
+                            case "DATABASE":
+                                return (
+                                    type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
+                                    type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
+                                );
+                            case "COMMUNICATION_INFRASTRUCTURE":
+                                return type === POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE;
+                            default:
+                                // For custom components (where type is an integer)
+                                if (Number.isInteger(selectedComponent?.type)) {
                                     return (
                                         type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
                                         type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
                                     );
-                                case "SERVER":
-                                    return (
-                                        type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
-                                        type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
-                                    );
-                                case "DATABASE":
-                                    return (
-                                        type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
-                                        type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
-                                    );
-                                case "COMMUNICATION_INFRASTRUCTURE":
-                                    return type === POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE;
-                                default:
-                                    // For custom components (where type is an integer)
-                                    if (Number.isInteger(selectedComponent?.type)) {
-                                        return (
-                                            type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
-                                            type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
-                                        );
+                                }
+                                return true;
+                        }
+                    })
+                    .sort((a, b) => {
+                        return getSortValueForPointOfAttack(a) < getSortValueForPointOfAttack(b) ? -1 : 1;
+                    })
+                    .map((type, i) => {
+                        const currPointOfAttack = selectedComponent?.pointsOfAttack?.find((item) => item.type === type);
+                        return (
+                            <PointOfAttackSwitch
+                                key={i}
+                                label={
+                                    <Typography
+                                        sx={{
+                                            fontSize: "0.75rem",
+                                            fontWeight: "bold",
+                                        }}
+                                    >
+                                        {t(`pointsOfAttackList.${type}`)}
+                                    </Typography>
+                                }
+                                color={POA_COLORS[type].normal}
+                                onChange={(e) => handleChangePointOfAttack(e, type, currPointOfAttack)}
+                                checked={currPointOfAttack !== undefined}
+                                onLabelClick={() => {
+                                    if (currPointOfAttack) {
+                                        handlePointOfAttackLabelClick(currPointOfAttack.id, selectedComponent?.id);
                                     }
-                                    return true;
-                            }
-                        })
-                        .sort((a, b) => {
-                            return getSortValueForPointOfAttack(a) < getSortValueForPointOfAttack(b) ? -1 : 1;
-                        })
-                        .map((type, i) => {
-                            const currPointOfAttack = selectedComponent?.pointsOfAttack?.find(
-                                (item) => item.type === type
-                            );
-                            return (
-                                <PointOfAttackSwitch
-                                    key={i}
-                                    label={
-                                        <Typography
-                                            sx={{
-                                                fontSize: "0.75rem",
-                                                fontWeight: "bold",
-                                            }}
-                                        >
-                                            {t(`pointsOfAttackList.${type}`)}
-                                        </Typography>
-                                    }
-                                    color={POA_COLORS[type].normal}
-                                    onChange={(e) => handleChangePointOfAttack(e, type, currPointOfAttack)}
-                                    checked={currPointOfAttack !== undefined}
-                                />
-                            );
-                        })}
-                </FormGroup>
-                {/* Display the communication interfaces section */}
-                {communicationInterfaces.length > 0 && (
-                    <>
+                                }}
+                            />
+                        );
+                    })}
+            </FormGroup>
+            {/* Display the communication interfaces section */}
+            {communicationInterfaces.length > 0 && (
+                <>
+                    <Box
+                        sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            borderRadius: 15,
+                            height: "31px",
+                            paddingLeft: 8,
+                            paddingRight: 0,
+                            justifyContent: "space-between",
+                            marginTop: 4,
+                            marginLeft: -8,
+                            marginRight: -8,
+                            padding: 0,
+                            margin: 0,
+                            marginBottom: 1,
+                        }}
+                    >
                         <Box
                             sx={{
                                 display: "flex",
                                 alignItems: "center",
-                                borderRadius: 15,
-                                height: "31px",
-                                paddingLeft: 8,
-                                paddingRight: 0,
-                                justifyContent: "space-between",
-                                marginTop: 4,
-                                marginLeft: -8,
-                                marginRight: -8,
-                                padding: 0,
-                                margin: 0,
-                                marginBottom: 1,
                             }}
                         >
                             <Box
                                 sx={{
-                                    display: "flex",
-                                    alignItems: "center",
+                                    backgroundColor: POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INTERFACES].normal,
+                                    width: "16px",
+                                    height: "16px",
+                                    marginLeft: 1,
+                                    borderRadius: 50,
+                                }}
+                            ></Box>
+                            <Typography
+                                sx={{
+                                    fontWeight: "bold",
+                                    fontSize: "0.75rem",
+                                    color: "text.primary",
+                                    marginLeft: 2,
                                 }}
                             >
-                                <Box
-                                    sx={{
-                                        backgroundColor: POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INTERFACES].normal,
-                                        width: "16px",
-                                        height: "16px",
-                                        marginLeft: 1,
-                                        borderRadius: 50,
-                                    }}
-                                ></Box>
-                                <Typography
-                                    sx={{
-                                        fontWeight: "bold",
-                                        fontSize: "0.75rem",
-                                        color: "text.primary",
-                                        marginLeft: 2,
-                                    }}
-                                >
-                                    Communication Interfaces
-                                </Typography>
-                            </Box>
+                                Communication Interfaces
+                            </Typography>
                         </Box>
-                        <Box sx={{ paddingLeft: 4 }}>
-                            {communicationInterfaces.map((communicationInterface, index) => {
-                                const IconComponent =
-                                    communicationInterface.icon != null
-                                        ? muiIconMap[communicationInterface.icon]
-                                        : undefined;
+                    </Box>
+                    <Box sx={{ paddingLeft: 4 }}>
+                        {communicationInterfaces.map((communicationInterface, index) => {
+                            const IconComponent =
+                                communicationInterface.icon != null
+                                    ? muiIconMap[communicationInterface.icon]
+                                    : undefined;
 
-                                return (
-                                    <Box
-                                        key={index}
-                                        sx={{
-                                            display: "flex",
-                                            alignItems: "center",
-                                            justifyContent: "space-between",
-                                            marginBottom: 0,
-                                        }}
-                                    >
-                                        <ListItemAvatar
-                                            sx={{
-                                                marginTop: "-8px",
-                                                minWidth: "0px",
-                                                marginRight: "13px",
-                                            }}
-                                        >
-                                            <Avatar
-                                                sx={{
-                                                    width: 20,
-                                                    height: 20,
-                                                    fontSize: 15,
-                                                    padding: 0.25,
-                                                    bgcolor: "transparent",
-                                                    color: "primary.main",
-                                                }}
-                                            >
-                                                {IconComponent ? <IconComponent /> : null}
-                                            </Avatar>
-                                        </ListItemAvatar>
-                                        <TextField
-                                            value={interfaceNames[communicationInterface.id] || ""}
-                                            onChange={(event) =>
-                                                handleLocalInterfaceNameChange(
-                                                    selectedComponent.id,
-                                                    communicationInterface.id,
-                                                    event.target.value
-                                                )
-                                            }
-                                            onKeyUp={(event) => {
-                                                if (event.key === "Delete") {
-                                                    event.stopPropagation();
-                                                }
-                                            }}
-                                            autoFocus={false}
-                                            sx={{
-                                                border: "none !important",
-                                                width: "82.5%",
-                                                "& .MuiInputBase-root": {
-                                                    borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
-                                                },
-                                                "*": {
-                                                    border: "none !important",
-                                                    padding: "0 !important",
-                                                    borderRadius: "0 !important",
-                                                    fontWeight: "bold",
-                                                },
-                                                "& .Mui-focused": {
-                                                    borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                                                },
-                                                input: {
-                                                    fontSize: "0.875rem !important",
-                                                    width: "100% !important",
-                                                },
-                                                color: "text.primary !important",
-                                                padding: "0 !important",
-                                            }}
-                                        />
-                                        <IconButton
-                                            onClick={() =>
-                                                handleDeleteCommunicationInterface(
-                                                    selectedComponent.id,
-                                                    communicationInterface.id,
-                                                    communicationInterface.name
-                                                )
-                                            }
-                                            sx={{
-                                                "&:hover": {
-                                                    color: "#ef5350",
-                                                    backgroundColor: "background.paperIntransparent",
-                                                },
-                                            }}
-                                        >
-                                            <Delete sx={{ fontSize: 18 }} />
-                                        </IconButton>
-                                    </Box>
-                                );
-                            })}
-                        </Box>
-                    </>
-                )}
-
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
-                    }}
-                >
-                    <Typography
-                        sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
-                        }}
-                    >
-                        {t("sidebar.assets.title")}
-                    </Typography>
-                </Box>
-                <Box>
-                    <SearchField
-                        sx={{
-                            marginBottom: 1,
-                            marginLeft: -0.5,
-                            width: "40%",
-                            height: "31px",
-                            borderRadius: 5,
-                        }}
-                        inputSx={{ fontSize: "0.75rem" }}
-                        //don't delete the whole Component if Delete is pressed
-                        onKeyUp={(event) => {
-                            if (event.key === "Delete") {
-                                event.stopPropagation();
-                            }
-                        }}
-                        value={assetSearchValue}
-                        onChange={handleAssetSearchChanged}
-                        data-testid="selected-component-asset-search-field"
-                    />
-                    {items
-                        .filter((item) => {
-                            const lcSearchValue = assetSearchValue.toLowerCase();
-                            return (
-                                assetSearchValue === "" ||
-                                item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
-                            );
-                        })
-                        .map((asset, index) => {
-                            let assetIsSetOnCommunicationInterfaces = false;
                             return (
                                 <Box
                                     key={index}
                                     sx={{
                                         display: "flex",
-                                        flexDirection: "row",
                                         alignItems: "center",
-                                        marginBottom: 1,
+                                        justifyContent: "space-between",
+                                        marginBottom: 0,
                                     }}
                                 >
-                                    <Typography
+                                    <ListItemAvatar
                                         sx={{
-                                            minWidth: "130px",
-                                            maxWidth: "130px",
-                                            color: "text.primary",
-                                            fontSize: "0.75rem",
-                                            fontWeight: "bold",
-                                        }}
-                                        data-testid="selected-component-asset-search-results"
-                                    >
-                                        {asset.name}
-                                    </Typography>
-                                    <Box
-                                        sx={{
-                                            display: "flex",
-                                            flexDirection: "row",
-                                            minWidth: "104px",
+                                            marginTop: "-8px",
+                                            minWidth: "0px",
+                                            marginRight: "13px",
                                         }}
                                     >
-                                        {pointsOfAttackOfSelectedComponent
-                                            .sort((a, b) => b.type.localeCompare(a.type))
-                                            .map((pointOfAttack, pointOfAttackIndex) => {
-                                                if (
-                                                    !assetIsSetOnCommunicationInterfaces &&
-                                                    pointOfAttack.type === POINTS_OF_ATTACK.COMMUNICATION_INTERFACES
-                                                ) {
-                                                    assetIsSetOnCommunicationInterfaces = true;
-                                                    const communicationInterfaces =
-                                                        pointsOfAttackOfSelectedComponent.filter(
-                                                            (poa) =>
-                                                                poa.type === POINTS_OF_ATTACK.COMMUNICATION_INTERFACES
-                                                        );
-                                                    const setInterfaces = communicationInterfaces.filter((poa) =>
-                                                        poa.assets.includes(asset.id)
+                                        <Avatar
+                                            sx={{
+                                                width: 20,
+                                                height: 20,
+                                                fontSize: 15,
+                                                padding: 0.25,
+                                                bgcolor: "transparent",
+                                                color: "primary.main",
+                                            }}
+                                        >
+                                            {IconComponent ? <IconComponent /> : null}
+                                        </Avatar>
+                                    </ListItemAvatar>
+                                    <TextField
+                                        value={interfaceNames[communicationInterface.id] || ""}
+                                        onChange={(event) =>
+                                            handleLocalInterfaceNameChange(
+                                                selectedComponent.id,
+                                                communicationInterface.id,
+                                                event.target.value
+                                            )
+                                        }
+                                        onKeyUp={(event) => {
+                                            if (event.key === "Delete") {
+                                                event.stopPropagation();
+                                            }
+                                        }}
+                                        autoFocus={false}
+                                        sx={{
+                                            border: "none !important",
+                                            width: "82.5%",
+                                            "& .MuiInputBase-root": {
+                                                borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
+                                            },
+                                            "*": {
+                                                border: "none !important",
+                                                padding: "0 !important",
+                                                borderRadius: "0 !important",
+                                                fontWeight: "bold",
+                                            },
+                                            "& .Mui-focused": {
+                                                borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
+                                            },
+                                            input: {
+                                                fontSize: "0.875rem !important",
+                                                width: "100% !important",
+                                            },
+                                            color: "text.primary !important",
+                                            padding: "0 !important",
+                                        }}
+                                    />
+                                    <IconButton
+                                        onClick={() =>
+                                            handleDeleteCommunicationInterface(
+                                                selectedComponent.id,
+                                                communicationInterface.id,
+                                                communicationInterface.name
+                                            )
+                                        }
+                                        sx={{
+                                            "&:hover": {
+                                                color: "#ef5350",
+                                                backgroundColor: "background.paperIntransparent",
+                                            },
+                                        }}
+                                    >
+                                        <Delete sx={{ fontSize: 18 }} />
+                                    </IconButton>
+                                </Box>
+                            );
+                        })}
+                    </Box>
+                </>
+            )}
+
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.assets.title")}
+                </Typography>
+            </Box>
+            <Box>
+                <SearchField
+                    sx={{
+                        marginBottom: 1,
+                        marginLeft: -0.5,
+                        width: "40%",
+                        height: "31px",
+                        borderRadius: 5,
+                    }}
+                    inputSx={{ fontSize: "0.75rem" }}
+                    //don't delete the whole Component if Delete is pressed
+                    onKeyUp={(event) => {
+                        if (event.key === "Delete") {
+                            event.stopPropagation();
+                        }
+                    }}
+                    value={assetSearchValue}
+                    onChange={handleAssetSearchChanged}
+                    data-testid="selected-component-asset-search-field"
+                />
+                {items
+                    .filter((item) => {
+                        const lcSearchValue = assetSearchValue.toLowerCase();
+                        return (
+                            assetSearchValue === "" ||
+                            item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
+                        );
+                    })
+                    .map((asset, index) => {
+                        let assetIsSetOnCommunicationInterfaces = false;
+                        return (
+                            <Box
+                                key={index}
+                                sx={{
+                                    display: "flex",
+                                    flexDirection: "row",
+                                    alignItems: "center",
+                                    marginBottom: 1,
+                                }}
+                            >
+                                <Typography
+                                    onClick={() => handleAssetNameClick(asset)}
+                                    sx={{
+                                        minWidth: "130px",
+                                        maxWidth: "130px",
+                                        color: "text.primary",
+                                        fontSize: "0.75rem",
+                                        fontWeight: "bold",
+                                        cursor: "pointer",
+                                        "&:hover": { textDecoration: "underline" },
+                                    }}
+                                    data-testid="selected-component-asset-search-results"
+                                >
+                                    {asset.name}
+                                </Typography>
+                                <Box
+                                    sx={{
+                                        display: "flex",
+                                        flexDirection: "row",
+                                        minWidth: "104px",
+                                    }}
+                                >
+                                    {pointsOfAttackOfSelectedComponent
+                                        .sort((a, b) => b.type.localeCompare(a.type))
+                                        .map((pointOfAttack, pointOfAttackIndex) => {
+                                            if (
+                                                !assetIsSetOnCommunicationInterfaces &&
+                                                pointOfAttack.type === POINTS_OF_ATTACK.COMMUNICATION_INTERFACES
+                                            ) {
+                                                assetIsSetOnCommunicationInterfaces = true;
+                                                const communicationInterfaces =
+                                                    pointsOfAttackOfSelectedComponent.filter(
+                                                        (poa) => poa.type === POINTS_OF_ATTACK.COMMUNICATION_INTERFACES
                                                     );
-                                                    if (setInterfaces.length > 0) {
-                                                        return (
-                                                            <Box key={pointOfAttackIndex}>
-                                                                <Box
-                                                                    sx={{
-                                                                        backgroundColor:
-                                                                            POA_COLORS[pointOfAttack.type].normal,
-                                                                        width: "16px",
-                                                                        height: "16px",
-                                                                        marginLeft: 1,
-                                                                        borderRadius: 50,
-                                                                        clipPath:
-                                                                            setInterfaces.length ===
-                                                                            communicationInterfaces.length
-                                                                                ? "circle(50%)"
-                                                                                : "polygon(0% 0%, 50% 0%, 50% 100%, 0% 100%)",
-                                                                    }}
-                                                                ></Box>
-                                                            </Box>
-                                                        );
-                                                    }
-                                                } else if (
-                                                    pointOfAttack.type !== POINTS_OF_ATTACK.COMMUNICATION_INTERFACES &&
-                                                    pointOfAttack.assets.includes(asset.id)
-                                                ) {
+                                                const setInterfaces = communicationInterfaces.filter((poa) =>
+                                                    poa.assets.includes(asset.id)
+                                                );
+                                                if (setInterfaces.length > 0) {
                                                     return (
                                                         <Box key={pointOfAttackIndex}>
                                                             <Box
@@ -631,147 +617,173 @@ export const EditorSidebarSelectedComponent = ({
                                                                     height: "16px",
                                                                     marginLeft: 1,
                                                                     borderRadius: 50,
+                                                                    clipPath:
+                                                                        setInterfaces.length ===
+                                                                        communicationInterfaces.length
+                                                                            ? "circle(50%)"
+                                                                            : "polygon(0% 0%, 50% 0%, 50% 100%, 0% 100%)",
                                                                 }}
                                                             ></Box>
                                                         </Box>
                                                     );
                                                 }
-                                                return null;
-                                            })}
-                                    </Box>
-                                    <Box
-                                        sx={{
-                                            display: "flex",
-                                            flexDirection: "row",
-                                            marginLeft: "auto",
-                                        }}
-                                    >
-                                        <ToggleButtons
-                                            value={(() => {
-                                                // Count how many POAs (including com interfaces) have this asset
-                                                const totalAssetOccurrences = pointsOfAttackOfSelectedComponent.reduce(
-                                                    (count, poa) => count + (poa.assets.includes(asset.id) ? 1 : 0),
-                                                    0
+                                            } else if (
+                                                pointOfAttack.type !== POINTS_OF_ATTACK.COMMUNICATION_INTERFACES &&
+                                                pointOfAttack.assets.includes(asset.id)
+                                            ) {
+                                                return (
+                                                    <Box key={pointOfAttackIndex}>
+                                                        <Box
+                                                            sx={{
+                                                                backgroundColor: POA_COLORS[pointOfAttack.type].normal,
+                                                                width: "16px",
+                                                                height: "16px",
+                                                                marginLeft: 1,
+                                                                borderRadius: 50,
+                                                            }}
+                                                        ></Box>
+                                                    </Box>
                                                 );
-
-                                                if (totalAssetOccurrences === 0) {
-                                                    return "unsetAll";
-                                                }
-
-                                                if (
-                                                    totalAssetOccurrences === pointsOfAttackOfSelectedComponent.length
-                                                ) {
-                                                    return "setAll";
-                                                }
-
-                                                return "";
-                                            })()}
-                                            buttonProps={{
-                                                width: "87px",
-                                            }}
-                                            buttons={[
-                                                {
-                                                    value: "setAll",
-                                                    text: t("setAllBtn"),
-                                                    onClick: (e) => handleAddAssetToAllPointsOfAttack(e, asset),
-                                                },
-                                                {
-                                                    value: "unsetAll",
-                                                    text: t("unsetAllBtn"),
-                                                    onClick: (e) => handleRemoveAssetFromAllPointsOfAttack(e, asset),
-                                                },
-                                            ]}
-                                        />
-                                    </Box>
+                                            }
+                                            return null;
+                                        })}
                                 </Box>
-                            );
-                        })}
-                </Box>
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
-                    }}
-                >
-                    <Typography
-                        sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
-                        }}
-                    >
-                        {t("sidebar.connected_components.title")}
-                    </Typography>
-                </Box>
-                <Box>
-                    {connectedComponents.map((connection, index) => {
-                        const connectedComponent = connection.component;
-                        if (!connectedComponent) {
-                            return null;
-                        }
-
-                        const communicationInterfaceName =
-                            selectedComponent.type === "COMMUNICATION_INFRASTRUCTURE"
-                                ? connectedComponent.communicationInterfaces?.find(
-                                      (communicationInterface) =>
-                                          communicationInterface.id === connection.communicationInterfaceId
-                                  )?.name
-                                : undefined;
-
-                        const label =
-                            connectedComponent.name +
-                            (communicationInterfaceName ? ` > ${communicationInterfaceName}` : "");
-
-                        return (
-                            <Box
-                                key={index}
-                                sx={{
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "space-between",
-                                    marginBottom: 1,
-                                }}
-                            >
-                                <Typography
+                                <Box
                                     sx={{
-                                        fontSize: "0.75rem",
-                                        fontWeight: "bold",
-                                        color: "text.primary",
+                                        display: "flex",
+                                        flexDirection: "row",
+                                        marginLeft: "auto",
                                     }}
                                 >
-                                    {label}
-                                </Typography>
-                                <IconButton
-                                    onClick={() =>
-                                        handleDeleteConnectionBetweenComponents(
-                                            selectedComponent.id,
-                                            connectedComponent.id
-                                        )
-                                    }
-                                    sx={{
-                                        "&:hover": {
-                                            color: "#ef5350",
-                                            backgroundColor: "background.paperIntransparent",
-                                        },
-                                    }}
-                                >
-                                    <Delete sx={{ fontSize: 18 }} />
-                                </IconButton>
+                                    <ToggleButtons
+                                        value={(() => {
+                                            // Count how many POAs (including com interfaces) have this asset
+                                            const totalAssetOccurrences = pointsOfAttackOfSelectedComponent.reduce(
+                                                (count, poa) => count + (poa.assets.includes(asset.id) ? 1 : 0),
+                                                0
+                                            );
+
+                                            if (totalAssetOccurrences === 0) {
+                                                return "unsetAll";
+                                            }
+
+                                            if (totalAssetOccurrences === pointsOfAttackOfSelectedComponent.length) {
+                                                return "setAll";
+                                            }
+
+                                            return "";
+                                        })()}
+                                        buttonProps={{
+                                            width: "87px",
+                                        }}
+                                        buttons={[
+                                            {
+                                                value: "setAll",
+                                                text: t("setAllBtn"),
+                                                onClick: (e) => handleAddAssetToAllPointsOfAttack(e, asset),
+                                            },
+                                            {
+                                                value: "unsetAll",
+                                                text: t("unsetAllBtn"),
+                                                onClick: (e) => handleRemoveAssetFromAllPointsOfAttack(e, asset),
+                                            },
+                                        ]}
+                                    />
+                                </Box>
                             </Box>
                         );
                     })}
-                </Box>
             </Box>
-        </>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.connected_components.title")}
+                </Typography>
+            </Box>
+            <Box>
+                {connectedComponents.map((connection, index) => {
+                    const connectedComponent = connection.component;
+                    if (!connectedComponent) {
+                        return null;
+                    }
+
+                    const communicationInterfaceName =
+                        selectedComponent.type === "COMMUNICATION_INFRASTRUCTURE"
+                            ? connectedComponent.communicationInterfaces?.find(
+                                  (communicationInterface) =>
+                                      communicationInterface.id === connection.communicationInterfaceId
+                              )?.name
+                            : undefined;
+
+                    const label =
+                        connectedComponent.name +
+                        (communicationInterfaceName ? ` > ${communicationInterfaceName}` : "");
+
+                    return (
+                        <Box
+                            key={index}
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "space-between",
+                                marginBottom: 1,
+                            }}
+                        >
+                            <Typography
+                                onClick={() =>
+                                    handleSelectConnectedComponent(
+                                        connectedComponent.id,
+                                        connection.communicationInterfaceId
+                                    )
+                                }
+                                sx={{
+                                    fontSize: "0.75rem",
+                                    fontWeight: "bold",
+                                    color: "text.primary",
+                                    cursor: "pointer",
+                                    "&:hover": { textDecoration: "underline" },
+                                }}
+                                data-testid="connected-component-name"
+                            >
+                                {label}
+                            </Typography>
+                            <IconButton
+                                onClick={() =>
+                                    handleDeleteConnectionBetweenComponents(selectedComponent.id, connectedComponent.id)
+                                }
+                                sx={{
+                                    "&:hover": {
+                                        color: "#ef5350",
+                                        backgroundColor: "background.paperIntransparent",
+                                    },
+                                }}
+                            >
+                                <Delete sx={{ fontSize: 18 }} />
+                            </IconButton>
+                        </Box>
+                    );
+                })}
+            </Box>
+        </Box>
     );
 };

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.test.tsx
@@ -1,0 +1,86 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+    EditorSidebarSelectedPointOfAttack,
+    type EditorSidebarSelectedPointOfAttackProps,
+} from "./editor-sidebar-selected-point-of-attack.component";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createSystemComponent, createPointOfAttack } from "#test-utils/builders.ts";
+
+const setup = (propsOverride: Partial<EditorSidebarSelectedPointOfAttackProps> = {}) => {
+    const props = {
+        selectedComponent: createSystemComponent({ name: "My Component" }),
+        selectedPointOfAttack: createPointOfAttack(),
+        assetSearchValue: "",
+        handleAssetSearchChanged: vi.fn(),
+        items: [
+            createAsset({ id: 1, name: "DB Server", confidentiality: 3, integrity: 3, availability: 2 }),
+            createAsset({ id: 2, name: "Web App", confidentiality: 1, integrity: 2, availability: 3 }),
+        ],
+        handleOnAssetChanged: vi.fn(),
+        handleAssetNameClick: vi.fn(),
+        handleComponentBreadcrumbClick: vi.fn(),
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    renderWithProviders(<EditorSidebarSelectedPointOfAttack {...props} />);
+    return { props, user };
+};
+
+describe("EditorSidebarSelectedPointOfAttack", () => {
+    describe("breadcrumb click", () => {
+        it("calls handleComponentBreadcrumbClick when the component name is clicked", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("My Component"));
+
+            expect(props.handleComponentBreadcrumbClick).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("asset name click", () => {
+        it("calls handleAssetNameClick with the correct asset", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("DB Server"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledOnce();
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[0]);
+        });
+
+        it("calls handleAssetNameClick with a different asset", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("Web App"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[1]);
+        });
+    });
+
+    describe("Popper hover tooltip", () => {
+        it("shows CIA values when hovering over an asset name", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("DB Server"));
+
+            expect(screen.getByText("(C 3 / I 3 / A 2)")).toBeInTheDocument();
+        });
+
+        it("hides CIA tooltip when mouse leaves the asset name", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("DB Server"));
+            await user.unhover(screen.getByText("DB Server"));
+
+            expect(screen.queryByText("(C 3 / I 3 / A 2)")).not.toBeInTheDocument();
+        });
+
+        it("shows correct CIA values for a different asset", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("Web App"));
+
+            expect(screen.getByText("(C 1 / I 2 / A 3)")).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
@@ -79,7 +79,9 @@ export const EditorSidebarSelectedPointOfAttack = ({
                     >
                         {selectedComponent.name}
                     </Typography>
-                    <Typography sx={{ display: "inline", marginLeft: 1, marginRight: 1 }}>&gt;</Typography>
+                    <Typography component="span" sx={{ display: "inline", marginLeft: 1, marginRight: 1 }}>
+                        &gt;
+                    </Typography>
                     {t(`pointsOfAttackList.${selectedPointOfAttack.type}`)}
                 </Typography>
             </Box>

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
@@ -8,7 +8,7 @@ import type { ChangeEvent, MouseEvent } from "react";
 import type { Asset } from "#api/types/asset.types.ts";
 import type { SystemComponent, SystemPointOfAttack } from "#api/types/system.types.ts";
 
-interface EditorSidebarSelectedPointOfAttackProps {
+export interface EditorSidebarSelectedPointOfAttackProps {
     selectedComponent: SystemComponent & { pointsOfAttack?: SystemPointOfAttack[] };
     selectedPointOfAttack: SystemPointOfAttack;
     assetSearchValue: string;

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
@@ -70,6 +70,7 @@ export const EditorSidebarSelectedPointOfAttack = ({
                     <Typography
                         component="span"
                         onClick={handleComponentBreadcrumbClick}
+                        data-testid="poa-breadcrumb-component"
                         sx={{
                             fontWeight: "bold",
                             fontSize: "0.875rem",

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
@@ -1,9 +1,10 @@
-import { Typography } from "@mui/material";
+import { Popper, Typography } from "@mui/material";
 import { Box } from "@mui/system";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EditorSidebarAssetList } from "./editor-sidebar-asset-list.component";
 import { SearchField } from "../search-field.component";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import type { Asset } from "#api/types/asset.types.ts";
 import type { SystemComponent, SystemPointOfAttack } from "#api/types/system.types.ts";
 
@@ -14,6 +15,8 @@ interface EditorSidebarSelectedPointOfAttackProps {
     handleAssetSearchChanged: (event: ChangeEvent<HTMLInputElement>) => void;
     items: Asset[];
     handleOnAssetChanged: (event: ChangeEvent<HTMLInputElement>, asset: Asset) => void;
+    handleAssetNameClick: (asset: Asset) => void;
+    handleComponentBreadcrumbClick: () => void;
 }
 
 export const EditorSidebarSelectedPointOfAttack = ({
@@ -23,96 +26,143 @@ export const EditorSidebarSelectedPointOfAttack = ({
     handleAssetSearchChanged,
     items,
     handleOnAssetChanged,
+    handleAssetNameClick,
+    handleComponentBreadcrumbClick,
 }: EditorSidebarSelectedPointOfAttackProps) => {
     const { t } = useTranslation("editorPage");
+    const [assetAnchorEl, setAssetAnchorEl] = useState<HTMLElement | null>(null);
+    const [hoveredAsset, setHoveredAsset] = useState<Asset | null>(null);
+
+    const handleAssetHover = (event: MouseEvent<HTMLElement>, asset: Asset) => {
+        setHoveredAsset(asset);
+        setAssetAnchorEl(event.currentTarget);
+    };
+
+    const handleAssetLeave = () => {
+        setHoveredAsset(null);
+        setAssetAnchorEl(null);
+    };
+
     return (
-        <>
-            <Box>
-                <Box
+        <Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#f2f4f500",
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                    alignItems: "flex-start",
+                    marginBottom: "-10px",
+                    height: "26px",
+                    border: "none",
+                }}
+            >
+                <Typography
                     sx={{
-                        display: "flex",
-                        backgroundColor: "#f2f4f500",
-                        paddingLeft: 0,
-                        paddingRight: 0,
-                        alignItems: "flex-start",
-                        marginBottom: "-10px",
-                        height: "26px",
+                        display: "inline",
+                        marginTop: "-0.5px",
+                        fontWeight: "bold",
+                        fontSize: "0.875rem",
+                        color: "text.primary",
                         border: "none",
                     }}
                 >
                     <Typography
+                        component="span"
+                        onClick={handleComponentBreadcrumbClick}
                         sx={{
-                            display: "inline",
-                            marginTop: "-0.5px",
                             fontWeight: "bold",
                             fontSize: "0.875rem",
-                            color: "text.primary",
-                            border: "none",
+                            cursor: "pointer",
+                            "&:hover": { textDecoration: "underline" },
                         }}
                     >
                         {selectedComponent.name}
-                        <Typography sx={{ display: "inline", marginLeft: 1, marginRight: 1 }}>&gt;</Typography>
-                        {t(`pointsOfAttackList.${selectedPointOfAttack.type}`)}
                     </Typography>
-                </Box>
+                    <Typography sx={{ display: "inline", marginLeft: 1, marginRight: 1 }}>&gt;</Typography>
+                    {t(`pointsOfAttackList.${selectedPointOfAttack.type}`)}
+                </Typography>
+            </Box>
 
-                <Box
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
                     sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
                     }}
                 >
-                    <Typography
-                        sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
-                        }}
-                    >
-                        {t("sidebar.assets.title")}
-                    </Typography>
-                </Box>
-
-                <SearchField
-                    sx={{
-                        marginBottom: 2,
-                        marginLeft: -0.5,
-                        height: "31px",
-                        width: "40%",
-                        borderRadius: 5,
-                    }}
-                    inputSx={{ fontSize: "0.75rem" }}
-                    value={assetSearchValue}
-                    onChange={handleAssetSearchChanged}
-                    data-testid="selected-point-of-attack-asset-search-field"
-                />
-
-                <EditorSidebarAssetList
-                    items={
-                        assetSearchValue != ""
-                            ? items.filter((item) => {
-                                  const lcSearchValue = assetSearchValue.toLowerCase();
-                                  return (
-                                      assetSearchValue === "" ||
-                                      item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
-                                  );
-                              })
-                            : items
-                    }
-                    checkedAssets={selectedPointOfAttack.assets}
-                    onChangeHandler={handleOnAssetChanged}
-                />
+                    {t("sidebar.assets.title")}
+                </Typography>
             </Box>
-        </>
+
+            <SearchField
+                sx={{
+                    marginBottom: 2,
+                    marginLeft: -0.5,
+                    height: "31px",
+                    width: "40%",
+                    borderRadius: 5,
+                }}
+                inputSx={{ fontSize: "0.75rem" }}
+                value={assetSearchValue}
+                onChange={handleAssetSearchChanged}
+                data-testid="selected-point-of-attack-asset-search-field"
+            />
+
+            <EditorSidebarAssetList
+                items={
+                    assetSearchValue != ""
+                        ? items.filter((item) => {
+                              const lcSearchValue = assetSearchValue.toLowerCase();
+                              return (
+                                  assetSearchValue === "" ||
+                                  item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
+                              );
+                          })
+                        : items
+                }
+                checkedAssets={selectedPointOfAttack.assets}
+                onChangeHandler={handleOnAssetChanged}
+                onAssetNameClick={handleAssetNameClick}
+                onAssetHover={handleAssetHover}
+                onAssetLeave={handleAssetLeave}
+            />
+
+            <Popper
+                open={assetAnchorEl != null}
+                anchorEl={assetAnchorEl}
+                placement="bottom-start"
+                sx={{
+                    backgroundColor: "background.defaultIntransparent",
+                    borderRadius: 5,
+                    boxShadow: 1,
+                    zIndex: 1000,
+                }}
+            >
+                {hoveredAsset && (
+                    <Box sx={{ padding: 1, margin: 0.5 }}>
+                        <Typography sx={{ fontSize: "0.75rem" }}>
+                            {`(C ${hoveredAsset.confidentiality} / I ${hoveredAsset.integrity} / A ${hoveredAsset.availability})`}
+                        </Typography>
+                    </Box>
+                )}
+            </Popper>
+        </Box>
     );
 };

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar.component.test.tsx
@@ -56,6 +56,7 @@ const setup = (propsOverride: Partial<EditorSidebarProps> = {}) => {
         handleAssetNameClick: vi.fn(),
         handleSelectConnectedComponent: vi.fn(),
         handleComponentBreadcrumbClick: vi.fn(),
+        handleInterfaceBreadcrumbClick: vi.fn(),
         ...propsOverride,
     };
     renderWithProviders(<EditorSidebar {...props} />);

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar.component.test.tsx
@@ -1,0 +1,140 @@
+import { screen } from "@testing-library/react";
+import { createRef } from "react";
+import { EditorSidebar, type EditorSidebarProps } from "./editor-sidebar.component";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import {
+    createAsset,
+    createSystemComponent,
+    createPointOfAttack,
+    createConnectionPoint,
+    createConnection,
+} from "#test-utils/builders.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+vi.mock("./editor-sidebar-selected-component.component", () => ({
+    EditorSidebarSelectedComponent: () => <div data-testid="selected-component" />,
+}));
+vi.mock("./editor-sidebar-selected-connection.component", () => ({
+    EditorSidebarSelectedConnection: () => <div data-testid="selected-connection" />,
+}));
+vi.mock("./editor-sidebar-selected-communication-interface.component", () => ({
+    EditorSidebarSelectedCommunicationInterface: () => <div data-testid="selected-communication-interface" />,
+}));
+vi.mock("./editor-sidebar-selected-point-of-attack.component", () => ({
+    EditorSidebarSelectedPointOfAttack: () => <div data-testid="selected-point-of-attack" />,
+}));
+
+const setup = (propsOverride: Partial<EditorSidebarProps> = {}) => {
+    const props = {
+        sidebarRef: createRef<HTMLDivElement>(),
+        selectedComponent: undefined,
+        selectedComponentId: undefined,
+        selectedPointOfAttack: undefined,
+        handleDeleteComponent: vi.fn(),
+        handleOnNameChange: vi.fn(),
+        handleChangePointOfAttack: vi.fn(),
+        handleAddAssetToAllPointsOfAttack: vi.fn(),
+        handleRemoveAssetFromAllPointsOfAttack: vi.fn(),
+        assetSearchValue: "",
+        handleAssetSearchChanged: vi.fn(),
+        items: [createAsset()],
+        pointsOfAttackOfSelectedComponent: [],
+        selectedConnectionId: undefined,
+        selectedConnection: undefined,
+        handleDeleteConnection: vi.fn(),
+        handleOnConnectionNameChange: vi.fn(),
+        handleOnAssetChanged: vi.fn(),
+        selectedConnectionPoint: undefined,
+        userRole: USER_ROLES.EDITOR,
+        handleOnDescriptionChange: vi.fn(),
+        connectedComponents: [],
+        handleDeleteConnectionBetweenComponents: vi.fn(),
+        handleOnConnectionPointDescriptionChange: vi.fn(),
+        handleChangeCommunicationInterfaceName: vi.fn(),
+        handleDeleteCommunicationInterface: vi.fn(),
+        handlePointOfAttackLabelClick: vi.fn(),
+        handleAssetNameClick: vi.fn(),
+        handleSelectConnectedComponent: vi.fn(),
+        handleComponentBreadcrumbClick: vi.fn(),
+        ...propsOverride,
+    };
+    renderWithProviders(<EditorSidebar {...props} />);
+    return { props };
+};
+
+describe("EditorSidebar", () => {
+    describe("conditional rendering", () => {
+        it("renders nothing when no selection is active", () => {
+            setup();
+
+            expect(screen.queryByTestId("selected-component")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("selected-connection")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("selected-communication-interface")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("selected-point-of-attack")).not.toBeInTheDocument();
+        });
+
+        it("renders EditorSidebarSelectedComponent when a component is selected without a POA", () => {
+            setup({
+                selectedComponentId: "comp-1",
+                selectedComponent: createSystemComponent(),
+                selectedPointOfAttack: null,
+            });
+
+            expect(screen.getByTestId("selected-component")).toBeInTheDocument();
+            expect(screen.queryByTestId("selected-point-of-attack")).not.toBeInTheDocument();
+        });
+
+        it("renders EditorSidebarSelectedConnection when a connection is selected", () => {
+            setup({
+                selectedConnectionId: "conn-1",
+                selectedConnection: createConnection(),
+            });
+
+            expect(screen.getByTestId("selected-connection")).toBeInTheDocument();
+        });
+
+        it("renders EditorSidebarSelectedCommunicationInterface when a connection point is selected", () => {
+            setup({
+                selectedConnectionPoint: createConnectionPoint(),
+            });
+
+            expect(screen.getByTestId("selected-communication-interface")).toBeInTheDocument();
+        });
+
+        it("renders EditorSidebarSelectedPointOfAttack when a component and POA are both selected", () => {
+            setup({
+                selectedComponent: createSystemComponent(),
+                selectedComponentId: "comp-1",
+                selectedPointOfAttack: createPointOfAttack(),
+            });
+
+            expect(screen.getByTestId("selected-point-of-attack")).toBeInTheDocument();
+            expect(screen.queryByTestId("selected-component")).not.toBeInTheDocument();
+        });
+
+        it("does not render POA panel when selectedConnectionPoint is set", () => {
+            setup({
+                selectedComponent: createSystemComponent(),
+                selectedComponentId: "comp-1",
+                selectedPointOfAttack: createPointOfAttack(),
+                selectedConnectionPoint: createConnectionPoint(),
+            });
+
+            expect(screen.queryByTestId("selected-point-of-attack")).not.toBeInTheDocument();
+            expect(screen.getByTestId("selected-communication-interface")).toBeInTheDocument();
+        });
+
+        it("does not render POA panel when selectedConnection is set", () => {
+            setup({
+                selectedComponent: createSystemComponent(),
+                selectedComponentId: "comp-1",
+                selectedPointOfAttack: createPointOfAttack(),
+                selectedConnectionId: "conn-1",
+                selectedConnection: createConnection(),
+            });
+
+            expect(screen.queryByTestId("selected-point-of-attack")).not.toBeInTheDocument();
+            expect(screen.getByTestId("selected-connection")).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar.component.tsx
@@ -51,6 +51,10 @@ interface EditorSidebarProps {
         interfaceName: string | null,
         doCloseSidebar?: boolean
     ) => void;
+    handlePointOfAttackLabelClick: (pointOfAttackId: string, componentId?: string) => void;
+    handleAssetNameClick: (asset: Asset) => void;
+    handleSelectConnectedComponent: (componentId: string, communicationInterfaceId?: string | null) => void;
+    handleComponentBreadcrumbClick: () => void;
 }
 
 export const EditorSidebar = ({
@@ -80,106 +84,114 @@ export const EditorSidebar = ({
     handleOnConnectionPointDescriptionChange,
     handleChangeCommunicationInterfaceName,
     handleDeleteCommunicationInterface,
+    handlePointOfAttackLabelClick,
+    handleAssetNameClick,
+    handleSelectConnectedComponent,
+    handleComponentBreadcrumbClick,
 }: EditorSidebarProps) => {
     return (
-        <>
+        <Box
+            sx={{
+                position: "fixed",
+                top: "125px",
+                right: "-600px",
+                bottom: "40px",
+                width: "480px",
+                zIndex: 999,
+                bgcolor: "#e5e8ebEE",
+                boxShadow: 6,
+                borderRadius: 5,
+                transition: "right 0.3s",
+                overflow: "hidden",
+            }}
+            ref={sidebarRef}
+        >
             <Box
                 sx={{
-                    position: "fixed",
-                    top: "125px",
-                    right: "-600px",
-                    bottom: "40px",
-                    width: "480px",
-                    zIndex: 999,
-                    bgcolor: "#e5e8ebEE",
-                    boxShadow: 6,
-                    borderRadius: 5,
-                    transition: "right 0.3s",
-                    overflow: "hidden",
+                    display: "flex",
+                    flexDirection: "column",
+                    height: "100%",
+                    width: "100%",
+                    overflowX: "hidden",
+                    overflowY: "auto",
+                    padding: "30px",
+                    boxSizing: "border-box",
+                    "::-webkit-scrollbar-track": {
+                        borderTopLeftRadius: 0,
+                        borderBottomLeftRadius: 0,
+                        borderBottomRightRadius: 500,
+                        borderTopRightRadius: 500,
+                    },
                 }}
-                ref={sidebarRef}
             >
-                <Box
-                    sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        height: "100%",
-                        width: "100%",
-                        overflowX: "hidden",
-                        overflowY: "auto",
-                        padding: "30px",
-                        boxSizing: "border-box",
-                        "::-webkit-scrollbar-track": {
-                            borderTopLeftRadius: 0,
-                            borderBottomLeftRadius: 0,
-                            borderBottomRightRadius: 500,
-                            borderTopRightRadius: 500,
-                        },
-                    }}
-                >
-                    {selectedComponentId !== undefined &&
-                        selectedComponentId != null &&
-                        (selectedPointOfAttack === null || selectedPointOfAttack === undefined) && (
-                            <EditorSidebarSelectedComponent
-                                handleDeleteComponent={handleDeleteComponent}
-                                handleChangePointOfAttack={handleChangePointOfAttack}
-                                handleAddAssetToAllPointsOfAttack={handleAddAssetToAllPointsOfAttack}
-                                handleRemoveAssetFromAllPointsOfAttack={handleRemoveAssetFromAllPointsOfAttack}
-                                selectedComponent={selectedComponent}
-                                handleOnNameChange={handleOnNameChange}
-                                assetSearchValue={assetSearchValue}
-                                handleAssetSearchChanged={handleAssetSearchChanged}
-                                items={items}
-                                pointsOfAttackOfSelectedComponent={pointsOfAttackOfSelectedComponent}
-                                userRole={userRole}
-                                handleOnDescriptionChange={handleOnDescriptionChange}
-                                connectedComponents={connectedComponents}
-                                handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
-                                handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
-                                handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
-                            />
-                        )}
-
-                    {selectedConnectionId !== undefined && selectedConnectionId != null && (
-                        <EditorSidebarSelectedConnection
-                            selectedConnection={selectedConnection}
-                            handleDeleteConnection={handleDeleteConnection}
-                            handleOnConnectionNameChange={handleOnConnectionNameChange}
-                            userRole={userRole}
-                        />
-                    )}
-
-                    {selectedConnectionPoint !== undefined && selectedConnectionPoint != null && (
-                        <EditorSidebarSelectedCommunicationInterface
-                            selectedConnectionPoint={selectedConnectionPoint}
-                            handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
+                {selectedComponentId !== undefined &&
+                    selectedComponentId != null &&
+                    (selectedPointOfAttack === null || selectedPointOfAttack === undefined) && (
+                        <EditorSidebarSelectedComponent
+                            handleDeleteComponent={handleDeleteComponent}
+                            handleChangePointOfAttack={handleChangePointOfAttack}
+                            handleAddAssetToAllPointsOfAttack={handleAddAssetToAllPointsOfAttack}
+                            handleRemoveAssetFromAllPointsOfAttack={handleRemoveAssetFromAllPointsOfAttack}
+                            selectedComponent={selectedComponent}
+                            handleOnNameChange={handleOnNameChange}
                             assetSearchValue={assetSearchValue}
                             handleAssetSearchChanged={handleAssetSearchChanged}
-                            handleOnAssetChanged={handleOnAssetChanged}
                             items={items}
-                            selectedPointOfAttack={selectedPointOfAttack}
-                            handleOnConnectionPointDescriptionChange={handleOnConnectionPointDescriptionChange}
-                            handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
+                            pointsOfAttackOfSelectedComponent={pointsOfAttackOfSelectedComponent}
                             userRole={userRole}
+                            handleOnDescriptionChange={handleOnDescriptionChange}
+                            connectedComponents={connectedComponents}
+                            handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
+                            handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
+                            handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
+                            handlePointOfAttackLabelClick={handlePointOfAttackLabelClick}
+                            handleAssetNameClick={handleAssetNameClick}
+                            handleSelectConnectedComponent={handleSelectConnectedComponent}
                         />
                     )}
 
-                    {selectedComponent &&
-                        !selectedConnectionPoint &&
-                        !selectedConnection &&
-                        selectedPointOfAttack !== undefined &&
-                        selectedPointOfAttack != null && (
-                            <EditorSidebarSelectedPointOfAttack
-                                selectedComponent={selectedComponent}
-                                selectedPointOfAttack={selectedPointOfAttack}
-                                assetSearchValue={assetSearchValue}
-                                handleAssetSearchChanged={handleAssetSearchChanged}
-                                items={items}
-                                handleOnAssetChanged={handleOnAssetChanged}
-                            />
-                        )}
-                </Box>
+                {selectedConnectionId !== undefined && selectedConnectionId != null && (
+                    <EditorSidebarSelectedConnection
+                        selectedConnection={selectedConnection}
+                        handleDeleteConnection={handleDeleteConnection}
+                        handleOnConnectionNameChange={handleOnConnectionNameChange}
+                        userRole={userRole}
+                    />
+                )}
+
+                {selectedConnectionPoint !== undefined && selectedConnectionPoint != null && (
+                    <EditorSidebarSelectedCommunicationInterface
+                        selectedConnectionPoint={selectedConnectionPoint}
+                        handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
+                        assetSearchValue={assetSearchValue}
+                        handleAssetSearchChanged={handleAssetSearchChanged}
+                        handleOnAssetChanged={handleOnAssetChanged}
+                        items={items}
+                        selectedPointOfAttack={selectedPointOfAttack}
+                        handleOnConnectionPointDescriptionChange={handleOnConnectionPointDescriptionChange}
+                        handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
+                        userRole={userRole}
+                        handleAssetNameClick={handleAssetNameClick}
+                    />
+                )}
+
+                {selectedComponent &&
+                    !selectedConnectionPoint &&
+                    !selectedConnection &&
+                    selectedPointOfAttack !== undefined &&
+                    selectedPointOfAttack != null && (
+                        <EditorSidebarSelectedPointOfAttack
+                            selectedComponent={selectedComponent}
+                            selectedPointOfAttack={selectedPointOfAttack}
+                            assetSearchValue={assetSearchValue}
+                            handleAssetSearchChanged={handleAssetSearchChanged}
+                            items={items}
+                            handleOnAssetChanged={handleOnAssetChanged}
+                            handleAssetNameClick={handleAssetNameClick}
+                            handleComponentBreadcrumbClick={handleComponentBreadcrumbClick}
+                        />
+                    )}
             </Box>
-        </>
+        </Box>
     );
 };

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar.component.tsx
@@ -55,6 +55,7 @@ export interface EditorSidebarProps {
     handleAssetNameClick: (asset: Asset) => void;
     handleSelectConnectedComponent: (componentId: string, communicationInterfaceId?: string | null) => void;
     handleComponentBreadcrumbClick: () => void;
+    handleInterfaceBreadcrumbClick: () => void;
 }
 
 export const EditorSidebar = ({
@@ -88,6 +89,7 @@ export const EditorSidebar = ({
     handleAssetNameClick,
     handleSelectConnectedComponent,
     handleComponentBreadcrumbClick,
+    handleInterfaceBreadcrumbClick,
 }: EditorSidebarProps) => {
     return (
         <Box
@@ -172,6 +174,7 @@ export const EditorSidebar = ({
                         handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
                         userRole={userRole}
                         handleAssetNameClick={handleAssetNameClick}
+                        handleInterfaceBreadcrumbClick={handleInterfaceBreadcrumbClick}
                     />
                 )}
 

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar.component.tsx
@@ -15,7 +15,7 @@ import type {
     SystemPointOfAttack,
 } from "#api/types/system.types.ts";
 
-interface EditorSidebarProps {
+export interface EditorSidebarProps {
     sidebarRef: RefObject<HTMLDivElement | null>;
     selectedComponent: AugmentedSystemComponent | undefined;
     selectedComponentId: string | null | undefined;

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PointOfAttackSwitch, type PointOfAttackSwitchProps } from "./point-of-attack-switch.component";
+
+const setup = (propsOverride: Partial<PointOfAttackSwitchProps> = {}) => {
+    const props = {
+        color: "#ff0000",
+        label: "Test Label",
+        onLabelClick: vi.fn(),
+        checked: false,
+        onChange: vi.fn(),
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    render(<PointOfAttackSwitch {...props} />);
+    return { props, user };
+};
+
+describe("PointOfAttackSwitch", () => {
+    it("renders the label text", () => {
+        setup();
+
+        expect(screen.getByText("Test Label")).toBeInTheDocument();
+    });
+
+    it("renders a switch", () => {
+        setup();
+
+        expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    });
+
+    it("switch is unchecked by default", () => {
+        setup({ checked: false });
+
+        expect(screen.getByRole("checkbox")).not.toBeChecked();
+    });
+
+    it("switch reflects checked state", () => {
+        setup({ checked: true });
+
+        expect(screen.getByRole("checkbox")).toBeChecked();
+    });
+
+    it("toggling the switch calls onChange", async () => {
+        const { props, user } = setup();
+
+        expect(props.onChange).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole("checkbox"));
+
+        expect(props.onChange).toHaveBeenCalledOnce();
+    });
+
+    it("clicking the label calls onLabelClick", async () => {
+        const { props, user } = setup();
+
+        expect(props.onLabelClick).not.toHaveBeenCalled();
+
+        await user.click(screen.getByText("Test Label"));
+
+        expect(props.onLabelClick).toHaveBeenCalledOnce();
+    });
+
+    it("clicking the label does not toggle the switch", async () => {
+        const { props, user } = setup();
+
+        await user.click(screen.getByText("Test Label"));
+
+        expect(props.onChange).not.toHaveBeenCalled();
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
@@ -1,19 +1,20 @@
 import { Box, FormControlLabel, Switch, Typography, type SwitchProps } from "@mui/material";
-import type { ReactNode } from "react";
+import type { ReactNode, MouseEvent } from "react";
 
 interface PointOfAttackSwitchProps extends Omit<SwitchProps, "color"> {
     color: string;
     label: ReactNode;
+    onLabelClick: (event: MouseEvent<HTMLElement>) => void;
 }
 
-export const PointOfAttackSwitch = ({ color, label, ...props }: PointOfAttackSwitchProps) => {
+export const PointOfAttackSwitch = ({ color, label, onLabelClick, ...props }: PointOfAttackSwitchProps) => {
     return (
         <Box
             sx={{
                 display: "flex",
                 flexDirection: "row",
                 alignItems: "center",
-                justifyContent: "space-between",
+                justifyContent: "flex-start",
                 marginBottom: 1,
                 color: "text.primary",
                 fontSize: "0.75rem",
@@ -40,9 +41,19 @@ export const PointOfAttackSwitch = ({ color, label, ...props }: PointOfAttackSwi
                 }
                 label={
                     <Typography
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onLabelClick(e);
+                        }}
                         sx={{
                             fontSize: "0.75rem",
                             marginLeft: 1,
+                            cursor: "default",
+                            ...(props.checked && {
+                                cursor: "pointer",
+                                "&:hover": { textDecoration: "underline" },
+                            }),
                         }}
                     >
                         {label}
@@ -52,16 +63,3 @@ export const PointOfAttackSwitch = ({ color, label, ...props }: PointOfAttackSwi
         </Box>
     );
 };
-
-/**
- *
- *
-<Box
-    sx={{
-        backgroundColor: color,
-        width: "16px",
-        height: "16px",
-        marginLeft: 1,
-        borderRadius: 50,
-    }}
-></Box> */

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
@@ -1,7 +1,7 @@
 import { Box, FormControlLabel, Switch, Typography, type SwitchProps } from "@mui/material";
 import type { ReactNode, MouseEvent } from "react";
 
-interface PointOfAttackSwitchProps extends Omit<SwitchProps, "color"> {
+export interface PointOfAttackSwitchProps extends Omit<SwitchProps, "color"> {
     color: string;
     label: ReactNode;
     onLabelClick: (event: MouseEvent<HTMLElement>) => void;

--- a/apps/frontend/src/view/components/name-textfield.component.tsx
+++ b/apps/frontend/src/view/components/name-textfield.component.tsx
@@ -41,6 +41,7 @@ const BaseNameTextField = <TFieldValues extends FieldValues>({
     ownId,
     type,
     projectId,
+    catalogId: _catalogId,
     ...props
 }: BaseNameTextFieldProps<TFieldValues>) => {
     const { t } = useTranslation();

--- a/apps/frontend/src/view/dialogs/add-asset.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/add-asset.dialog.test.tsx
@@ -1,0 +1,82 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddAssetDialog, { type AddAssetDialogProps } from "./add-asset.dialog";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset } from "#test-utils/builders.ts";
+import { mockUseDialog } from "#test-utils/mock-hooks.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+mockUseDialog();
+
+const navigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react-router")>();
+    return { ...actual, useNavigate: () => navigate };
+});
+
+const validAsset = createAsset({ id: 1, name: "Existing Asset" });
+
+const setup = (propsOverride: Partial<AddAssetDialogProps> = {}) => {
+    const props = {
+        projectId: 1,
+        userRole: USER_ROLES.EDITOR,
+        asset: validAsset,
+        open: true,
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    renderWithProviders(<AddAssetDialog {...props} />);
+    return { props, user };
+};
+
+describe("AddAssetDialog — onDialogClose prop", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("calls onDialogClose instead of navigate(-1) when cancel is clicked", async () => {
+        const onDialogClose = vi.fn();
+        const { user } = setup({ onDialogClose });
+
+        expect(onDialogClose).not.toHaveBeenCalled();
+
+        await user.click(screen.getByTestId("cancel-button"));
+
+        expect(onDialogClose).toHaveBeenCalledOnce();
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("falls back to navigate(-1) when onDialogClose is not provided", async () => {
+        const { user } = setup();
+
+        expect(navigate).not.toHaveBeenCalled();
+
+        await user.click(screen.getByTestId("cancel-button"));
+
+        expect(navigate).toHaveBeenCalledOnce();
+        expect(navigate).toHaveBeenCalledWith(-1);
+    });
+
+    it("calls onDialogClose after form submission", async () => {
+        const onDialogClose = vi.fn();
+        const { user } = setup({ onDialogClose });
+
+        await user.click(screen.getByTestId("save-button"));
+
+        await waitFor(() => {
+            expect(onDialogClose).toHaveBeenCalledOnce();
+        });
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("calls navigate(-1) after form submission when onDialogClose is not provided", async () => {
+        const { user } = setup();
+
+        await user.click(screen.getByTestId("save-button"));
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledOnce();
+        });
+        expect(navigate).toHaveBeenCalledWith(-1);
+    });
+});

--- a/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
@@ -49,7 +49,7 @@ interface FormValues {
 
 interface AssetDialogFormValues extends FormValues, Omit<Partial<Asset>, keyof FormValues>, DialogValue {}
 
-interface AddAssetDialogProps extends DialogProps {
+export interface AddAssetDialogProps extends DialogProps {
     projectId: number | undefined;
     asset?: Partial<Asset>;
     userRole: USER_ROLES | undefined;

--- a/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
@@ -53,6 +53,7 @@ interface AddAssetDialogProps extends DialogProps {
     projectId: number | undefined;
     asset?: Partial<Asset>;
     userRole: USER_ROLES | undefined;
+    onDialogClose?: () => void;
 }
 
 /**
@@ -64,7 +65,7 @@ interface AddAssetDialogProps extends DialogProps {
  * @param {object} props - Dialog properties.
  * @returns React component for adding an asset.
  */
-const AddAssetDialog = ({ projectId, asset, userRole, ...props }: AddAssetDialogProps) => {
+const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }: AddAssetDialogProps) => {
     const { cancelDialog, confirmDialog } = useDialog<AssetDialogFormValues | null>("assets");
     const navigate = useNavigate();
     const { t } = useTranslation("assetDialogPage");
@@ -97,7 +98,11 @@ const AddAssetDialog = ({ projectId, asset, userRole, ...props }: AddAssetDialog
      * Closes the dialog.
      */
     const closeDialog = () => {
-        navigate(-1);
+        if (onDialogClose) {
+            onDialogClose();
+        } else {
+            navigate(-1);
+        }
     };
 
     /**

--- a/apps/frontend/src/view/pages/asset-dialog.page.test.tsx
+++ b/apps/frontend/src/view/pages/asset-dialog.page.test.tsx
@@ -1,0 +1,96 @@
+import { screen } from "@testing-library/react";
+import { Route, Routes, type InitialEntry } from "react-router-dom";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createProject } from "#test-utils/builders.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import type { RootState } from "#application/store.ts";
+import AssetDialogPage from "./asset-dialog.page";
+import type { AddAssetDialogProps } from "../dialogs/add-asset.dialog";
+
+vi.mock("../dialogs/add-asset.dialog", () => ({
+    default: (props: AddAssetDialogProps) => (
+        <div
+            data-testid="add-asset-dialog"
+            data-project-id={props.projectId}
+            data-user-role={props.userRole}
+            data-has-asset={props.asset !== undefined ? "true" : "false"}
+            data-has-on-dialog-close={props.onDialogClose !== undefined ? "true" : "false"}
+        />
+    ),
+}));
+
+const REDIRECT_MARKER = "redirected-to-assets";
+
+function renderPage({ url, preloadedState }: { url: InitialEntry; preloadedState: Partial<RootState> }) {
+    return renderWithProviders(
+        <Routes>
+            <Route path="/projects/:projectId/assets/:assetId/edit" element={<AssetDialogPage />} />
+            <Route path="/projects/:projectId/assets/edit" element={<AssetDialogPage />} />
+            <Route path="/projects/:projectId/assets" element={<div>{REDIRECT_MARKER}</div>} />
+        </Routes>,
+        { preloadedState, initialEntries: [url] }
+    );
+}
+
+describe("AssetDialogPage", () => {
+    it("renders nothing while assets are still loading", () => {
+        renderPage({
+            url: "/projects/1/assets/5/edit",
+            preloadedState: {
+                assets: { ids: [], entities: {}, isPending: true },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+            },
+        });
+
+        expect(screen.queryByTestId("add-asset-dialog")).not.toBeInTheDocument();
+        expect(screen.queryByText(REDIRECT_MARKER)).not.toBeInTheDocument();
+    });
+
+    it("redirects to assets list when asset not found and no location state", () => {
+        const otherAsset = createAsset({ id: 10, name: "Other" });
+
+        renderPage({
+            url: "/projects/1/assets/999/edit",
+            preloadedState: {
+                assets: { ids: [10], entities: { 10: otherAsset }, isPending: false },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+            },
+        });
+
+        expect(screen.getByText(REDIRECT_MARKER)).toBeInTheDocument();
+        expect(screen.queryByTestId("add-asset-dialog")).not.toBeInTheDocument();
+    });
+
+    it("renders dialog with asset from store, projectId, userRole, and onDialogClose", () => {
+        const asset = createAsset({ id: 5, name: "Server DB" });
+        const project = createProject({ id: 1 });
+
+        renderPage({
+            url: "/projects/1/assets/5/edit",
+            preloadedState: {
+                assets: { ids: [5], entities: { 5: asset }, isPending: false },
+                projects: { ids: [], entities: {}, isPending: false, current: project },
+            },
+        });
+
+        const dialog = screen.getByTestId("add-asset-dialog");
+        expect(dialog).toHaveAttribute("data-project-id", "1");
+        expect(dialog).toHaveAttribute("data-user-role", USER_ROLES.EDITOR);
+        expect(dialog).toHaveAttribute("data-has-asset", "true");
+        expect(dialog).toHaveAttribute("data-has-on-dialog-close", "true");
+    });
+
+    it("renders dialog from location state without onDialogClose when no assetId", () => {
+        renderPage({
+            url: { pathname: "/projects/1/assets/edit", state: { asset: { name: "New Asset" } } },
+            preloadedState: {
+                assets: { ids: [], entities: {}, isPending: false },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+            },
+        });
+
+        const dialog = screen.getByTestId("add-asset-dialog");
+        expect(dialog).toHaveAttribute("data-has-asset", "true");
+        expect(dialog).toHaveAttribute("data-has-on-dialog-close", "false");
+    });
+});

--- a/apps/frontend/src/view/pages/asset-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/asset-dialog.page.tsx
@@ -29,9 +29,7 @@ const AssetDialogPage = () => {
     const assetFromStore = useAppSelector((state) =>
         assetId ? assetsSelectors.selectById(state, Number(assetId)) : undefined
     );
-    const isAssetsLoaded = useAppSelector(
-        (state) => !state.assets.isPending && assetsSelectors.selectAll(state).length > 0
-    );
+    const isAssetsLoaded = useAppSelector((state) => !state.assets.isPending);
 
     const handleEditorClose = useCallback(() => {
         navigate(`/projects/${projectId}/system`, { replace: true });

--- a/apps/frontend/src/view/pages/asset-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/asset-dialog.page.tsx
@@ -3,8 +3,10 @@
  *     page for the assets.
  */
 
-import { useLocation, useNavigate, useParams, type Location } from "react-router-dom";
+import { useCallback } from "react";
+import { Navigate, useLocation, useNavigate, useParams, type Location } from "react-router-dom";
 import { useAppSelector } from "#application/hooks/use-app-redux.hook.ts";
+import { assetsSelectors } from "#application/selectors/assets.selectors.ts";
 import type { Asset } from "#api/types/asset.types.ts";
 import AddAssetDialog from "../dialogs/add-asset.dialog";
 
@@ -20,21 +22,40 @@ interface AssetDialogLocationState {
  */
 const AssetDialogPage = () => {
     const navigate = useNavigate();
-    const { projectId = "" } = useParams<{ projectId?: string }>();
+    const { projectId = "", assetId } = useParams<{ projectId?: string; assetId?: string }>();
     const userRole = useAppSelector((state) => state.projects.current?.role);
     const { state } = useLocation() as Location<AssetDialogLocationState | undefined>;
 
-    if (state) {
-        const asset = state.asset;
+    const assetFromStore = useAppSelector((state) =>
+        assetId ? assetsSelectors.selectById(state, Number(assetId)) : undefined
+    );
+    const isAssetsLoaded = useAppSelector(
+        (state) => !state.assets.isPending && assetsSelectors.selectAll(state).length > 0
+    );
 
-        return (
-            <AddAssetDialog open={true} projectId={Number(projectId) || undefined} asset={asset} userRole={userRole} />
-        );
-    } else {
-        navigate(`/projects/${projectId}/assets`, { replace: true });
+    const handleEditorClose = useCallback(() => {
+        navigate(`/projects/${projectId}/system`, { replace: true });
+    }, [navigate, projectId]);
 
+    if (assetId && !assetFromStore && !isAssetsLoaded) {
         return null;
     }
+
+    const asset = assetFromStore ?? state?.asset;
+
+    if (!asset && !state) {
+        return <Navigate to={`/projects/${projectId}/assets`} replace />;
+    }
+
+    return (
+        <AddAssetDialog
+            open={true}
+            projectId={Number(projectId) || undefined}
+            {...(asset && { asset })}
+            userRole={userRole}
+            {...(assetId && { onDialogClose: handleEditorClose })}
+        />
+    );
 };
 
 export default AssetDialogPage;

--- a/apps/frontend/src/view/pages/editor.page.test.tsx
+++ b/apps/frontend/src/view/pages/editor.page.test.tsx
@@ -1,0 +1,265 @@
+import { screen, act } from "@testing-library/react";
+import { Route, Routes } from "react-router-dom";
+import { EditorPage } from "./editor.page";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset } from "#test-utils/builders.ts";
+import { mockUseConfirm, mockUseAlert, mockUseEditor, mockUseAssets } from "#test-utils/mock-hooks.ts";
+import type { useEditor } from "#application/hooks/use-editor.hook.ts";
+import { EditorSidebar } from "../components/editor-components/editor-sidebar.component";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+// --- Hook spies (module-level, persist across tests) ---
+
+const editorSpy = mockUseEditor();
+mockUseAssets();
+mockUseConfirm();
+mockUseAlert();
+
+// --- Child component mocks (isolate page from canvas/sidebar internals) ---
+
+vi.mock("../components/with-menu.component", () => ({
+    CreatePage: (_Header: unknown, Body: unknown) => Body,
+    HeaderNavigation: () => null,
+}));
+
+vi.mock("../components/editor-components/editor-sidebar.component", () => ({
+    EditorSidebar: vi.fn(({ sidebarRef }: { sidebarRef?: React.RefObject<HTMLDivElement | null> }) => (
+        <div data-testid="editor-sidebar" ref={sidebarRef} />
+    )),
+}));
+
+vi.mock("../components/editor-components/editor-stage.component", () => ({
+    EditorStage: ({ children }: { children: React.ReactNode }) => <div data-testid="editor-stage">{children}</div>,
+}));
+
+vi.mock("../components/editor-components/system-component.component", () => ({
+    SystemComponent: () => null,
+}));
+
+vi.mock("../components/editor-components/system-component-connection.component", () => ({
+    SystemComponentConnection: () => null,
+}));
+
+vi.mock("../components/editor-components/connection-preview.component", () => ({
+    ConnectionPreview: () => null,
+}));
+
+vi.mock("../components/editor-components/editor-communication-interface-context-menu.component", () => ({
+    CommunicationContextMenu: () => null,
+}));
+
+vi.mock("../dialogs/add-communication-interface.dialog", () => ({
+    default: () => null,
+}));
+
+vi.mock("./asset-dialog.page", () => ({
+    default: () => <div data-testid="asset-dialog-page" />,
+}));
+
+vi.mock("./component-dialog.page", () => ({
+    default: () => <div data-testid="component-dialog-page" />,
+}));
+
+vi.mock("react-konva", () => ({
+    Group: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Layer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Line: () => null,
+}));
+
+vi.mock("../components/editor-components/contexts/LineDrawingProvider", () => ({
+    LineDrawingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../components/page.component", () => ({
+    Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("#hooks/useDebounce.ts", () => ({
+    useDebounce: (fn: () => void) => fn,
+}));
+
+// --- Helpers ---
+
+/**
+ * Returns the mock object from the last useEditor() call (populated after render).
+ * Since mockImplementation creates fresh vi.fn() per call and clearMocks: true
+ * resets spy results between tests, each test gets independent fn instances.
+ */
+const getEditorMock = () => {
+    const { results } = editorSpy.mock;
+    return results[results.length - 1]!.value as ReturnType<typeof useEditor>;
+};
+
+const getSidebarProps = () => {
+    const calls = vi.mocked(EditorSidebar).mock.calls;
+    return calls[calls.length - 1]![0];
+};
+
+interface RenderEditorPageOptions {
+    initialEntries?: string[];
+    role?: USER_ROLES;
+}
+
+const renderEditorPage = ({
+    initialEntries = ["/projects/1/system"],
+    role = USER_ROLES.EDITOR,
+}: RenderEditorPageOptions = {}) => {
+    return renderWithProviders(
+        <Routes>
+            <Route path="/projects/:projectId/system/*" element={<EditorPage />} />
+        </Routes>,
+        {
+            initialEntries,
+            preloadedState: {
+                projects: { current: { role } } as never,
+                editor: { stageScale: 1, stagePosition: { x: 0, y: 0 } } as never,
+            },
+        }
+    );
+};
+
+// --- Tests ---
+
+describe("EditorPage", () => {
+    describe("sidebar handler orchestration", () => {
+        describe("handlePointOfAttackLabelClick", () => {
+            it("clears search and selects the point of attack", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handlePointOfAttackLabelClick("poa-1", "comp-1");
+                });
+
+                expect(mockEditor.setAssetSearchValue).toHaveBeenCalledWith("");
+                expect(mockEditor.selectPointOfAttack).toHaveBeenCalledWith("poa-1");
+            });
+
+            it("with componentId: selects component, deselects connection/connectionPoint, opens sidebar", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handlePointOfAttackLabelClick("poa-1", "comp-1");
+                });
+
+                expect(mockEditor.deselectConnection).toHaveBeenCalledOnce();
+                expect(mockEditor.deselectConnectionPoint).toHaveBeenCalledOnce();
+                expect(mockEditor.selectComponent).toHaveBeenCalledWith("comp-1");
+                expect(screen.getByTestId("editor-sidebar").style.right).toBe("40px");
+            });
+
+            it("without componentId: does not select a component", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handlePointOfAttackLabelClick("poa-1");
+                });
+
+                expect(mockEditor.selectComponent).not.toHaveBeenCalled();
+                expect(screen.getByTestId("editor-sidebar").style.right).not.toBe("40px");
+            });
+        });
+
+        describe("handleAssetNameClick", () => {
+            it("navigates to the asset edit route", () => {
+                renderEditorPage();
+                const props = getSidebarProps();
+                const asset = createAsset({ id: 5, name: "My Asset" });
+
+                act(() => {
+                    props.handleAssetNameClick(asset);
+                });
+
+                expect(screen.getByTestId("asset-dialog-page")).toBeInTheDocument();
+            });
+        });
+
+        describe("handleComponentBreadcrumbClick", () => {
+            it("deselects the point of attack", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleComponentBreadcrumbClick();
+                });
+
+                expect(mockEditor.deselectPointOfAttack).toHaveBeenCalledOnce();
+            });
+        });
+
+        describe("handleSelectConnectedComponent", () => {
+            it("clears search and deselects connection", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleSelectConnectedComponent("comp-2", "ci-1");
+                });
+
+                expect(mockEditor.setAssetSearchValue).toHaveBeenCalledWith("");
+                expect(mockEditor.deselectConnection).toHaveBeenCalledOnce();
+            });
+
+            it("with communicationInterfaceId: selects connectionPoint and POA, deselects component", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleSelectConnectedComponent("comp-2", "ci-1");
+                });
+
+                expect(mockEditor.selectConnectionPoint).toHaveBeenCalledWith("ci-1");
+                expect(mockEditor.selectPointOfAttack).toHaveBeenCalledWith("ci-1");
+                expect(mockEditor.deselectComponent).toHaveBeenCalledOnce();
+                expect(mockEditor.selectComponent).not.toHaveBeenCalled();
+                expect(screen.getByTestId("editor-sidebar").style.right).toBe("40px");
+            });
+
+            it("without communicationInterfaceId: selects component, deselects POA/connectionPoint", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleSelectConnectedComponent("comp-2");
+                });
+
+                expect(mockEditor.deselectPointOfAttack).toHaveBeenCalledOnce();
+                expect(mockEditor.selectComponent).toHaveBeenCalledWith("comp-2");
+                expect(mockEditor.deselectConnectionPoint).toHaveBeenCalledOnce();
+                expect(mockEditor.selectConnectionPoint).not.toHaveBeenCalled();
+                expect(screen.getByTestId("editor-sidebar").style.right).toBe("40px");
+            });
+
+            it("treats null communicationInterfaceId same as undefined", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleSelectConnectedComponent("comp-2", null);
+                });
+
+                expect(mockEditor.deselectPointOfAttack).toHaveBeenCalledOnce();
+                expect(mockEditor.selectComponent).toHaveBeenCalledWith("comp-2");
+                expect(mockEditor.deselectConnectionPoint).toHaveBeenCalledOnce();
+            });
+        });
+    });
+
+    describe("routing", () => {
+        it("renders AssetDialogPage at assets/:assetId/edit", () => {
+            renderEditorPage({ initialEntries: ["/projects/1/system/assets/5/edit"] });
+
+            expect(screen.getByTestId("asset-dialog-page")).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -755,6 +755,14 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         deselectPointOfAttack();
     };
 
+    const handleInterfaceBreadcrumbClick = (): void => {
+        if (selectedConnectionPoint?.componentId) {
+            deselectConnectionPoint();
+            deselectPointOfAttack();
+            selectComponent(selectedConnectionPoint.componentId);
+        }
+    };
+
     const handleSelectConnectedComponent = (componentId: string, communicationInterfaceId?: string | null): void => {
         setAssetSearchValue("");
         deselectConnection();
@@ -1331,6 +1339,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                     handleAssetNameClick={handleAssetNameClick}
                     handleSelectConnectedComponent={handleSelectConnectedComponent}
                     handleComponentBreadcrumbClick={handleComponentBreadcrumbClick}
+                    handleInterfaceBreadcrumbClick={handleInterfaceBreadcrumbClick}
                 />
 
                 <Routes>

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -31,6 +31,7 @@ import { Page } from "../components/page.component";
 import { SystemComponentConnection } from "../components/editor-components/system-component-connection.component";
 import { SystemComponent } from "../components/editor-components/system-component.component";
 import { CreatePage, HeaderNavigation } from "../components/with-menu.component";
+import AssetDialogPage from "./asset-dialog.page";
 import ComponentDialogPage from "./component-dialog.page";
 import { CommunicationContextMenu } from "../components/editor-components/editor-communication-interface-context-menu.component";
 import { useAlert } from "../../application/hooks/use-alert.hook";
@@ -223,8 +224,8 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
             stageRef.current.scale({ x: 1, y: 1 });
             setLayerPositionEvent(0, 0);
             setStageScaleEvent(1, { x: 0, y: 0 });
+            navigate(location.pathname, { replace: true, state: {} });
         }
-        navigate(location.pathname, { replace: true, state: {} });
     }, [shouldCenter, navigate, location.pathname]);
 
     useEffect(() => {
@@ -349,7 +350,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         autoSaveBlocked();
     });
 
-    const handlComponentDragStart = (_event: KonvaEventObject<DragEvent>, componentId: string): void => {
+    const handleComponentDragStart = (_event: KonvaEventObject<DragEvent>, componentId: string): void => {
         addInUseComponent(componentId);
         selectComponent(componentId);
         deselectConnection();
@@ -382,7 +383,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         });
     };
 
-    const handlComponentDragEnd = (event: KonvaEventObject<DragEvent>, componentId: string): void => {
+    const handleComponentDragEnd = (event: KonvaEventObject<DragEvent>, componentId: string): void => {
         removeInUseComponent(componentId);
         setShowHelpLines(false);
         updateConnectionsOfComponent();
@@ -735,6 +736,42 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         }
     };
 
+    const handlePointOfAttackLabelClick = (pointOfAttackId: string, componentId?: string): void => {
+        setAssetSearchValue("");
+        selectPointOfAttack(pointOfAttackId);
+        if (componentId) {
+            deselectConnection();
+            deselectConnectionPoint();
+            selectComponent(componentId);
+            showSideBar();
+        }
+    };
+
+    const handleAssetNameClick = (asset: Asset): void => {
+        navigate(`assets/${asset.id}/edit`);
+    };
+
+    const handleComponentBreadcrumbClick = (): void => {
+        deselectPointOfAttack();
+    };
+
+    const handleSelectConnectedComponent = (componentId: string, communicationInterfaceId?: string | null): void => {
+        setAssetSearchValue("");
+        deselectConnection();
+
+        if (communicationInterfaceId) {
+            selectConnectionPoint(communicationInterfaceId);
+            selectPointOfAttack(communicationInterfaceId);
+            deselectComponent();
+        } else {
+            deselectPointOfAttack();
+            selectComponent(componentId);
+            deselectConnectionPoint();
+        }
+
+        showSideBar();
+    };
+
     const handleChangePointOfAttack = (
         e: ChangeEvent<HTMLInputElement>,
         type: POINTS_OF_ATTACK,
@@ -987,242 +1024,264 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
     }
 
     return (
-        <>
-            <LineDrawingProvider>
-                <Page
+        <LineDrawingProvider>
+            <Page
+                sx={{
+                    p: 0,
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                }}
+            >
+                <Box
                     sx={{
-                        p: 0,
-                        paddingLeft: 0,
-                        paddingRight: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        bgcolor: "background.paper",
+                        boxShadow: 8,
+                        height: "100%",
+                        position: "realtive",
                     }}
                 >
-                    <Box
-                        sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "space-between",
-                            bgcolor: "background.paper",
-                            boxShadow: 8,
-                            height: "100%",
-                            position: "realtive",
-                        }}
+                    <EditorStage
+                        ref={stageRef}
+                        handleMouseDown={handleMouseDown}
+                        handleMouseMove={handleMouseMove}
+                        handleMouseUp={handleMouseUp}
+                        onContextMenuOpen={handleContextMenuOpen}
+                        onContextMenuAction={handleContextMenuAction}
+                        onMouseLeave={handleMouseOut}
+                        onKeyUp={handleKeyUp}
+                        mousePointers={mousePointers}
+                        onScale={onStageScale}
+                        scale={stageScale}
+                        position={stagePosition}
+                        userRole={userRole}
                     >
-                        <EditorStage
-                            ref={stageRef}
-                            handleMouseDown={handleMouseDown}
-                            handleMouseMove={handleMouseMove}
-                            handleMouseUp={handleMouseUp}
-                            onContextMenuOpen={handleContextMenuOpen}
-                            onContextMenuAction={handleContextMenuAction}
-                            onMouseLeave={handleMouseOut}
-                            onKeyUp={handleKeyUp}
-                            mousePointers={mousePointers}
-                            onScale={onStageScale}
-                            scale={stageScale}
-                            position={stagePosition}
-                            userRole={userRole}
-                        >
-                            <Layer>
-                                {lineArray.map((_item, index) => (
+                        <Layer>
+                            {lineArray.map((_item, index) => (
+                                <Line
+                                    key={index}
+                                    points={[
+                                        layerPosition.x - gridRenderConfig.offsetX - gridRenderConfig.stageOffsetX,
+                                        layerPosition.y -
+                                            gridRenderConfig.offsetY +
+                                            index * GRID_CONFIG.renderedGridSizeY -
+                                            gridRenderConfig.stageOffsetY,
+                                        500000,
+                                        layerPosition.y -
+                                            gridRenderConfig.offsetY +
+                                            index * GRID_CONFIG.renderedGridSizeY -
+                                            gridRenderConfig.stageOffsetY,
+                                    ]}
+                                    stroke={GRID_CONFIG.gridLineColor}
+                                    strokeWidth={0.75}
+                                />
+                            ))}
+
+                            {lineArray.map((_item, index) => {
+                                let stageOffsetX = 0;
+                                let stageOffsetY = 0;
+                                if (stageRef?.current) {
+                                    stageOffsetX = stageRef.current.x() / stageRef.current.scale().x;
+                                    stageOffsetY = stageRef.current.y() / stageRef.current.scale().y;
+                                }
+                                const columnsToTheTop =
+                                    Math.floor(layerPosition.y / GRID_CONFIG.renderedGridSizeY) + 75;
+                                const offsetY = columnsToTheTop * GRID_CONFIG.renderedGridSizeY;
+                                const columnsToTheLeft =
+                                    Math.floor(layerPosition.x / GRID_CONFIG.renderedGridSizeX) + 75;
+                                const offsetX = columnsToTheLeft * GRID_CONFIG.renderedGridSizeX;
+                                return (
                                     <Line
                                         key={index}
                                         points={[
-                                            layerPosition.x - gridRenderConfig.offsetX - gridRenderConfig.stageOffsetX,
-                                            layerPosition.y -
-                                                gridRenderConfig.offsetY +
-                                                index * GRID_CONFIG.renderedGridSizeY -
-                                                gridRenderConfig.stageOffsetY,
+                                            layerPosition.x -
+                                                offsetX +
+                                                index * GRID_CONFIG.renderedGridSizeX -
+                                                stageOffsetX,
+                                            layerPosition.y - offsetY - stageOffsetY,
+                                            layerPosition.x -
+                                                offsetX +
+                                                index * GRID_CONFIG.renderedGridSizeX -
+                                                stageOffsetX,
                                             500000,
-                                            layerPosition.y -
-                                                gridRenderConfig.offsetY +
-                                                index * GRID_CONFIG.renderedGridSizeY -
-                                                gridRenderConfig.stageOffsetY,
                                         ]}
                                         stroke={GRID_CONFIG.gridLineColor}
                                         strokeWidth={0.75}
                                     />
-                                ))}
+                                );
+                            })}
 
-                                {lineArray.map((_item, index) => {
-                                    let stageOffsetX = 0;
-                                    let stageOffsetY = 0;
-                                    if (stageRef?.current) {
-                                        stageOffsetX = stageRef.current.x() / stageRef.current.scale().x;
-                                        stageOffsetY = stageRef.current.y() / stageRef.current.scale().y;
-                                    }
-                                    const columnsToTheTop =
-                                        Math.floor(layerPosition.y / GRID_CONFIG.renderedGridSizeY) + 75;
-                                    const offsetY = columnsToTheTop * GRID_CONFIG.renderedGridSizeY;
-                                    const columnsToTheLeft =
-                                        Math.floor(layerPosition.x / GRID_CONFIG.renderedGridSizeX) + 75;
-                                    const offsetX = columnsToTheLeft * GRID_CONFIG.renderedGridSizeX;
-                                    return (
-                                        <Line
-                                            key={index}
-                                            points={[
-                                                layerPosition.x -
-                                                    offsetX +
-                                                    index * GRID_CONFIG.renderedGridSizeX -
-                                                    stageOffsetX,
-                                                layerPosition.y - offsetY - stageOffsetY,
-                                                layerPosition.x -
-                                                    offsetX +
-                                                    index * GRID_CONFIG.renderedGridSizeX -
-                                                    stageOffsetX,
-                                                500000,
-                                            ]}
-                                            stroke={GRID_CONFIG.gridLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                    );
-                                })}
+                            {showHelpLines && currentHelpLinesRef.current && (
+                                <Group>
+                                    <Line
+                                        points={[
+                                            -1000,
+                                            currentHelpLinesRef.current.y,
+                                            10000,
+                                            currentHelpLinesRef.current.y,
+                                        ]}
+                                        stroke={GRID_CONFIG.helpLineColor}
+                                        strokeWidth={0.75}
+                                    />
+                                    <Line
+                                        points={[
+                                            -1000,
+                                            currentHelpLinesRef.current.y2,
+                                            10000,
+                                            currentHelpLinesRef.current.y2,
+                                        ]}
+                                        stroke={GRID_CONFIG.helpLineColor}
+                                        strokeWidth={0.75}
+                                    />
+                                    <Line
+                                        points={[
+                                            currentHelpLinesRef.current.x,
+                                            -1000,
+                                            currentHelpLinesRef.current.x,
+                                            10000,
+                                        ]}
+                                        stroke={GRID_CONFIG.helpLineColor}
+                                        strokeWidth={0.75}
+                                    />
+                                    <Line
+                                        points={[
+                                            currentHelpLinesRef.current.x2,
+                                            -1000,
+                                            currentHelpLinesRef.current.x2,
+                                            10000,
+                                        ]}
+                                        stroke={GRID_CONFIG.helpLineColor}
+                                        strokeWidth={0.75}
+                                    />
+                                </Group>
+                            )}
+                        </Layer>
 
-                                {showHelpLines && currentHelpLinesRef.current && (
-                                    <Group>
-                                        <Line
-                                            points={[
-                                                -1000,
-                                                currentHelpLinesRef.current.y,
-                                                10000,
-                                                currentHelpLinesRef.current.y,
-                                            ]}
-                                            stroke={GRID_CONFIG.helpLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                        <Line
-                                            points={[
-                                                -1000,
-                                                currentHelpLinesRef.current.y2,
-                                                10000,
-                                                currentHelpLinesRef.current.y2,
-                                            ]}
-                                            stroke={GRID_CONFIG.helpLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                        <Line
-                                            points={[
-                                                currentHelpLinesRef.current.x,
-                                                -1000,
-                                                currentHelpLinesRef.current.x,
-                                                10000,
-                                            ]}
-                                            stroke={GRID_CONFIG.helpLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                        <Line
-                                            points={[
-                                                currentHelpLinesRef.current.x2,
-                                                -1000,
-                                                currentHelpLinesRef.current.x2,
-                                                10000,
-                                            ]}
-                                            stroke={GRID_CONFIG.helpLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                    </Group>
-                                )}
-                            </Layer>
+                        <Layer x={layerPosition.x} y={layerPosition.y}>
+                            {newConnection && newConnectionPreviewComponent && (
+                                <ConnectionPreview
+                                    key={`new-connection-${newConnection.from.id}-${Date.now()}`}
+                                    component={newConnectionPreviewComponent}
+                                    newConnectionMousePosition={newConnectionMousePosition}
+                                />
+                            )}
 
-                            <Layer x={layerPosition.x} y={layerPosition.y}>
-                                {newConnection && newConnectionPreviewComponent && (
+                            {componentConnectionLines.map((line, index) => {
+                                const key = `connection-preview-${line.otherComponentInfo.id}-${line.draggedComponentInfo.id}-${index}`;
+                                const otherComponent = components.filter(
+                                    (component) => component.id === line.otherComponentInfo.id
+                                )[0];
+                                const draggedComponent = components.filter(
+                                    (component) => component.id === line.draggedComponentInfo.id
+                                )[0];
+                                if (!otherComponent || !draggedComponent) return null;
+
+                                return (
                                     <ConnectionPreview
-                                        key={`new-connection-${newConnection.from.id}-${Date.now()}`}
-                                        component={newConnectionPreviewComponent}
-                                        newConnectionMousePosition={newConnectionMousePosition}
+                                        key={key}
+                                        component={otherComponent}
+                                        draggedComponent={draggedComponent}
                                     />
-                                )}
+                                );
+                            })}
+                        </Layer>
 
-                                {componentConnectionLines.map((line, index) => {
-                                    const key = `connection-preview-${line.otherComponentInfo.id}-${line.draggedComponentInfo.id}-${index}`;
-                                    const otherComponent = components.filter(
-                                        (component) => component.id === line.otherComponentInfo.id
-                                    )[0];
-                                    const draggedComponent = components.filter(
-                                        (component) => component.id === line.draggedComponentInfo.id
-                                    )[0];
-                                    if (!otherComponent || !draggedComponent) return null;
+                        <Layer x={layerPosition.x} y={layerPosition.y} ref={componentLayerRef}>
+                            {connections.map((connection, i) => {
+                                if (connection.visible === false) {
+                                    return <Group key={i}></Group>;
+                                }
 
-                                    return (
-                                        <ConnectionPreview
-                                            key={key}
-                                            component={otherComponent}
-                                            draggedComponent={draggedComponent}
-                                        />
-                                    );
-                                })}
-                            </Layer>
+                                const fromComponent = components.filter(
+                                    (component) => component.id === connection.from.id
+                                )[0];
+                                const toComponent = components.filter(
+                                    (component) => component.id === connection.to.id
+                                )[0];
+                                if (!fromComponent || !toComponent) return null;
 
-                            <Layer x={layerPosition.x} y={layerPosition.y} ref={componentLayerRef}>
-                                {connections.map((connection, i) => {
-                                    if (connection.visible === false) {
-                                        return <Group key={i}></Group>;
-                                    }
-
-                                    const fromComponent = components.filter(
-                                        (component) => component.id === connection.from.id
-                                    )[0];
-                                    const toComponent = components.filter(
-                                        (component) => component.id === connection.to.id
-                                    )[0];
-                                    if (!fromComponent || !toComponent) return null;
-
-                                    return (
-                                        <SystemComponentConnection
-                                            key={i}
-                                            {...connection}
-                                            onClick={handleSelectConnection}
-                                            onPointOfAttackClicked={handleOnPointOfAttackClicked}
-                                            fromComponent={fromComponent}
-                                            toComponent={toComponent}
-                                            components={components}
-                                            selected={selectedConnectionId === connection.id}
-                                            recalculate={connection.recalculate}
-                                            onRecalculated={onRecalculated}
-                                            onConnectionPointClicked={handleOnConnectionPointClicked}
-                                            selectedConnectionPointId={selectedConnectionPointId}
-                                            stageRef={stageRef}
-                                        />
-                                    );
-                                })}
-                                {components.map((component, i) => (
-                                    <SystemComponent
+                                return (
+                                    <SystemComponentConnection
                                         key={i}
-                                        {...component}
-                                        onSelectAnchor={handleSelectAnchor}
-                                        selectedAnchor={
-                                            newConnection
-                                                ? newConnection.from.id === component.id
-                                                    ? newConnection.from.anchor
-                                                    : ""
-                                                : ""
-                                        }
-                                        onDragMove={(e) => handleComponentDragMove(e, component.id)}
-                                        onClick={(e) => handleSelectComponent(e, component.id)}
-                                        onDragEnd={(e) => handlComponentDragEnd(e, component.id)}
-                                        onDragStart={(e) => handlComponentDragStart(e, component.id)}
+                                        {...connection}
+                                        onClick={handleSelectConnection}
                                         onPointOfAttackClicked={handleOnPointOfAttackClicked}
-                                        selectedPointOfAttackId={selectedPointOfAttack ? selectedPointOfAttack.id : ""}
-                                        component={component}
+                                        fromComponent={fromComponent}
+                                        toComponent={toComponent}
+                                        components={components}
+                                        selected={selectedConnectionId === connection.id}
+                                        recalculate={connection.recalculate}
+                                        onRecalculated={onRecalculated}
+                                        onConnectionPointClicked={handleOnConnectionPointClicked}
+                                        selectedConnectionPointId={selectedConnectionPointId}
                                         stageRef={stageRef}
-                                        userRole={userRole}
-                                        toggleCommunicationInterfacesMenu={toggleCommunicationInterfacesMenu}
                                     />
-                                ))}
-                            </Layer>
-                        </EditorStage>
+                                );
+                            })}
+                            {components.map((component, i) => (
+                                <SystemComponent
+                                    key={i}
+                                    {...component}
+                                    onSelectAnchor={handleSelectAnchor}
+                                    selectedAnchor={
+                                        newConnection
+                                            ? newConnection.from.id === component.id
+                                                ? newConnection.from.anchor
+                                                : ""
+                                            : ""
+                                    }
+                                    onDragMove={(e) => handleComponentDragMove(e, component.id)}
+                                    onClick={(e) => handleSelectComponent(e, component.id)}
+                                    onDragEnd={(e) => handleComponentDragEnd(e, component.id)}
+                                    onDragStart={(e) => handleComponentDragStart(e, component.id)}
+                                    onPointOfAttackClicked={handleOnPointOfAttackClicked}
+                                    selectedPointOfAttackId={selectedPointOfAttack ? selectedPointOfAttack.id : ""}
+                                    component={component}
+                                    stageRef={stageRef}
+                                    userRole={userRole}
+                                    toggleCommunicationInterfacesMenu={toggleCommunicationInterfacesMenu}
+                                />
+                            ))}
+                        </Layer>
+                    </EditorStage>
 
-                        <Box
+                    <Box
+                        sx={{
+                            position: "absolute",
+                            top: 8,
+                            left: 8,
+                            width: "38px",
+                            marginLeft: "auto",
+                            marginRight: "auto",
+                        }}
+                    >
+                        <IconButton
+                            onClick={handleCenterEditor}
                             sx={{
-                                position: "absolute",
-                                top: 8,
-                                left: 8,
-                                width: "38px",
-                                marginLeft: "auto",
-                                marginRight: "auto",
+                                backgroundColor: "background.paperIntransparent",
+                                "&:hover": {
+                                    backgroundColor: "rgba(149, 163, 181, 0.7)",
+                                },
                             }}
                         >
+                            <CenterFocusWeak sx={{ fontSize: 30, color: "primary.main" }} />
+                        </IconButton>
+                    </Box>
+                    <Box
+                        sx={{
+                            position: "absolute",
+                            top: 60,
+                            left: 8,
+                            width: "38px",
+                            marginLeft: "auto",
+                            marginRight: "auto",
+                        }}
+                    >
+                        <Tooltip title={t("canvas.exportSystemImage")}>
                             <IconButton
-                                onClick={handleCenterEditor}
+                                onClick={handleDownloadSystemView}
                                 sx={{
                                     backgroundColor: "background.paperIntransparent",
                                     "&:hover": {
@@ -1230,97 +1289,78 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                                     },
                                 }}
                             >
-                                <CenterFocusWeak sx={{ fontSize: 30, color: "primary.main" }} />
-                            </IconButton>
-                        </Box>
-                        <Box
-                            sx={{
-                                position: "absolute",
-                                top: 60,
-                                left: 8,
-                                width: "38px",
-                                marginLeft: "auto",
-                                marginRight: "auto",
-                            }}
-                        >
-                            <Tooltip title={t("canvas.exportSystemImage")}>
-                                <IconButton
-                                    onClick={handleDownloadSystemView}
+                                <Download
                                     sx={{
-                                        backgroundColor: "background.paperIntransparent",
-                                        "&:hover": {
-                                            backgroundColor: "rgba(149, 163, 181, 0.7)",
-                                        },
+                                        fontSize: 30,
+                                        color: "primary.main",
                                     }}
-                                >
-                                    <Download
-                                        sx={{
-                                            fontSize: 30,
-                                            color: "primary.main",
-                                        }}
-                                    />
-                                </IconButton>
-                            </Tooltip>
-                        </Box>
+                                />
+                            </IconButton>
+                        </Tooltip>
                     </Box>
+                </Box>
 
-                    <EditorSidebar
-                        sidebarRef={sidebarRef}
-                        selectedComponent={selectedComponent}
-                        selectedComponentId={selectedComponentId}
-                        selectedPointOfAttack={selectedPointOfAttack}
-                        handleDeleteComponent={handleDeleteComponent}
-                        handleOnNameChange={handleOnNameChange}
-                        handleChangePointOfAttack={handleChangePointOfAttack}
-                        handleAddAssetToAllPointsOfAttack={handleAddAssetToAllPointsOfAttack}
-                        handleRemoveAssetFromAllPointsOfAttack={handleRemoveAssetFromAllPointsOfAttack}
-                        assetSearchValue={assetSearchValue}
-                        handleAssetSearchChanged={handleAssetSearchChanged}
-                        items={items}
-                        pointsOfAttackOfSelectedComponent={pointsOfAttackOfSelectedComponent}
-                        selectedConnectionId={selectedConnectionId}
-                        selectedConnection={selectedConnection}
-                        handleDeleteConnection={handleDeleteConnection}
-                        handleOnConnectionNameChange={handleConnectionNameChange}
-                        handleOnAssetChanged={handleOnAssetChanged}
-                        selectedConnectionPoint={selectedConnectionPoint}
-                        userRole={userRole}
-                        handleOnDescriptionChange={handleOnDescriptionChange}
-                        connectedComponents={getConnectedComponents(selectedComponentId)}
-                        handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
-                        handleOnConnectionPointDescriptionChange={handleOnConnectionPointDescriptionChange}
-                        handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
-                        handleDeleteCommunicationInterface={handleDeleteCommunicationInterfaceDialog}
+                <EditorSidebar
+                    sidebarRef={sidebarRef}
+                    selectedComponent={selectedComponent}
+                    selectedComponentId={selectedComponentId}
+                    selectedPointOfAttack={selectedPointOfAttack}
+                    handleDeleteComponent={handleDeleteComponent}
+                    handleOnNameChange={handleOnNameChange}
+                    handleChangePointOfAttack={handleChangePointOfAttack}
+                    handleAddAssetToAllPointsOfAttack={handleAddAssetToAllPointsOfAttack}
+                    handleRemoveAssetFromAllPointsOfAttack={handleRemoveAssetFromAllPointsOfAttack}
+                    assetSearchValue={assetSearchValue}
+                    handleAssetSearchChanged={handleAssetSearchChanged}
+                    items={items}
+                    pointsOfAttackOfSelectedComponent={pointsOfAttackOfSelectedComponent}
+                    selectedConnectionId={selectedConnectionId}
+                    selectedConnection={selectedConnection}
+                    handleDeleteConnection={handleDeleteConnection}
+                    handleOnConnectionNameChange={handleConnectionNameChange}
+                    handleOnAssetChanged={handleOnAssetChanged}
+                    selectedConnectionPoint={selectedConnectionPoint}
+                    userRole={userRole}
+                    handleOnDescriptionChange={handleOnDescriptionChange}
+                    connectedComponents={getConnectedComponents(selectedComponentId)}
+                    handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
+                    handleOnConnectionPointDescriptionChange={handleOnConnectionPointDescriptionChange}
+                    handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
+                    handleDeleteCommunicationInterface={handleDeleteCommunicationInterfaceDialog}
+                    handlePointOfAttackLabelClick={handlePointOfAttackLabelClick}
+                    handleAssetNameClick={handleAssetNameClick}
+                    handleSelectConnectedComponent={handleSelectConnectedComponent}
+                    handleComponentBreadcrumbClick={handleComponentBreadcrumbClick}
+                />
+
+                <Routes>
+                    <Route path="components/edit" element={<ComponentDialogPage />} />
+                    <Route path="assets/:assetId/edit" element={<AssetDialogPage />} />
+                </Routes>
+
+                <CommunicationContextMenu
+                    stageRef={stageRef}
+                    open={communicationMenuOpen}
+                    componentName={communicationMenuComponent?.name}
+                    onSelect={handleCommunicationSelect}
+                    onCreateNew={handleOpenCommunicationInterfaceDialog}
+                    onClose={handleCloseCommunicationMenu}
+                    onSelectAnchor={handleSelectAnchor}
+                    componentId={communicationMenuComponent?.id}
+                    componentType={communicationMenuComponent?.type}
+                    components={components}
+                    connections={connections}
+                    handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
+                />
+                {isCommunicationInterfaceDialogOpen && (
+                    <CommunicationInterfaceDialog
+                        open={true}
+                        onClose={handleCloseCommunicationInterfaceDialog}
+                        handleCreateNew={handleCreateNewCommunicationInterface}
                     />
-
-                    <Routes>
-                        <Route path="components/edit" element={<ComponentDialogPage />} />
-                    </Routes>
-
-                    <CommunicationContextMenu
-                        stageRef={stageRef}
-                        open={communicationMenuOpen}
-                        componentName={communicationMenuComponent?.name}
-                        onSelect={handleCommunicationSelect}
-                        onCreateNew={handleOpenCommunicationInterfaceDialog}
-                        onClose={handleCloseCommunicationMenu}
-                        onSelectAnchor={handleSelectAnchor}
-                        componentId={communicationMenuComponent?.id}
-                        componentType={communicationMenuComponent?.type}
-                        components={components}
-                        connections={connections}
-                        handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
-                    />
-                    {isCommunicationInterfaceDialogOpen && (
-                        <CommunicationInterfaceDialog
-                            open={true}
-                            onClose={handleCloseCommunicationInterfaceDialog}
-                            handleCreateNew={handleCreateNewCommunicationInterface}
-                        />
-                    )}
-                </Page>
-            </LineDrawingProvider>
-        </>
+                )}
+            </Page>
+        </LineDrawingProvider>
     );
 };
 

--- a/apps/frontend/tests/editor.page.spec.ts
+++ b/apps/frontend/tests/editor.page.spec.ts
@@ -4,6 +4,11 @@ import { getProjects, importProject, deleteProject, deleteCatalog } from "./test
 import threatsFixture from "./fixtures/threats.json" with { type: "json" };
 import type { USER_ROLES } from "#api/types/user-roles.types.ts";
 
+// Canvas click positions for fixture components (center of each component body):
+// Users:  (500, 340)  — fixture pos (465, 305), size 80x80
+// Client: (845, 340)  — fixture pos (810, 305), size 80x80
+// Client CI connector: (885, 370) — opens communication interface context menu
+
 async function addCommunication(page: Page) {
     await page
         .locator("canvas")
@@ -50,7 +55,11 @@ test.afterEach(async ({ page, request }) => {
     const project = projects.find((project) => project.name === exportedProject.project.name)!;
     await deleteProject(request, token, project.id);
 
-    await deleteCatalog(request, token, project.catalogId);
+    try {
+        await deleteCatalog(request, token, project.catalogId);
+    } catch {
+        // Catalog cleanup may fail if ownership wasn't set up during import
+    }
 });
 
 test.describe("Editor Page Tests", () => {
@@ -259,6 +268,77 @@ test.describe("Editor Page Tests", () => {
             await page.locator('[data-testid="selected-communication-asset-search-field"] input').fill("NonExistent");
             const results = page.getByTestId("asset-search-results");
             await expect(results).toHaveCount(0);
+        });
+    });
+
+    test.describe("Asset Name Click Navigation Tests", () => {
+        test("Clicking asset name in component sidebar opens edit dialog", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("selected-component-asset-search-results").first().click();
+            await expect(page).toHaveURL(/\/system\/assets\/\d+\/edit/);
+            await expect(page.locator('[data-testid="asset-creation-modal_name-input"]')).toBeVisible();
+        });
+
+        test("Closing asset edit dialog returns to editor", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("selected-component-asset-search-results").first().click();
+            await expect(page).toHaveURL(/\/system\/assets\/\d+\/edit/);
+            await page.getByTestId("cancel-button").click();
+            await expect(page).toHaveURL(/\/system$/);
+        });
+
+        test("Clicking asset name in POA sidebar opens edit dialog", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("poa-switch-USER_INTERFACE").click();
+            await expect(page.locator('[data-testid="selected-point-of-attack-asset-search-field"]')).toBeVisible();
+            await page.getByTestId("asset-search-results").first().click();
+            await expect(page).toHaveURL(/\/system\/assets\/\d+\/edit/);
+        });
+    });
+
+    test.describe("POA Navigation Tests", () => {
+        test("Clicking POA label switches sidebar to POA view", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("poa-switch-USER_INTERFACE").click();
+            await expect(page.locator('[data-testid="selected-point-of-attack-asset-search-field"]')).toBeVisible();
+            await expect(page.getByTestId("poa-breadcrumb-component")).toBeVisible();
+            await expect(page.getByTestId("poa-breadcrumb-component")).toContainText("Client");
+        });
+
+        test("Clicking breadcrumb component name returns to component sidebar", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("poa-switch-USER_INTERFACE").click();
+            await expect(page.locator('[data-testid="selected-point-of-attack-asset-search-field"]')).toBeVisible();
+            await page.getByTestId("poa-breadcrumb-component").click();
+            await expect(page.locator('[data-testid="selected-component-asset-search-field"]')).toBeVisible();
+            await expect(page.locator('[data-testid="selected-point-of-attack-asset-search-field"]')).not.toBeVisible();
+        });
+    });
+
+    test.describe("Connected Component Navigation Tests", () => {
+        test("Clicking connected component name switches sidebar to that component", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await expect(page.getByTestId("connected-component-name").first()).toBeVisible();
+            await page.getByTestId("connected-component-name").first().click();
+            await expect(page.getByTestId("connected-component-name").first()).toContainText("Client");
         });
     });
 

--- a/apps/frontend/tests/editor.page.spec.ts
+++ b/apps/frontend/tests/editor.page.spec.ts
@@ -55,11 +55,7 @@ test.afterEach(async ({ page, request }) => {
     const project = projects.find((project) => project.name === exportedProject.project.name)!;
     await deleteProject(request, token, project.id);
 
-    try {
-        await deleteCatalog(request, token, project.catalogId);
-    } catch {
-        // Catalog cleanup may fail if ownership wasn't set up during import
-    }
+    await deleteCatalog(request, token, project.catalogId);
 });
 
 test.describe("Editor Page Tests", () => {

--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -6,5 +6,6 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
 }

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -6,6 +6,9 @@
     },
     {
       "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
     }
   ],
   "compilerOptions": {

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "vitest.setup.ts"]
+  "include": ["src", "vitest.setup.ts"],
+  "exclude": []
 }


### PR DESCRIPTION
 ### Summary

  Resolves #582 and #583

  - Add clickable navigation in the editor sidebar — clicking asset names opens the asset edit dialog, clicking point-of-attack labels selects the POA, and clicking
   connected component names navigates to that component's sidebar view
  - Add breadcrumb navigation for communication interfaces `(Component > Interface:)` with clickable component name to navigate back
  - Add inline edit mode for communication interface names within the selected component sidebar
  - Add deep-linkable route `(assets/:assetId/edit)` so asset editing can be opened directly from the editor

  ### Changes

  - `editor.page.tsx` — new click handlers for sidebar navigation (POA labels, asset names, breadcrumbs, connected components)
  - `editor-sidebar-selected-component.component.tsx` — inline interface name editing, pass-through navigation handlers
  - `editor-sidebar-selected-communication-interface.component.tsx` — breadcrumb UI with clickable component name, asset hover popover
  - `asset-dialog.page.tsx` — support opening via URL param **_(assetId)_** in addition to route state

  ### Tests

  - Unit tests for sidebar components (**_editor-sidebar, editor-sidebar-asset-list, editor-sidebar-selected-component, editor-sidebar-selected-communication-interface, point-of-attack-switch_**)
  - Shared test utilities **_([builders.ts,](https://github.com/MaibornWolff/ThreatSea/blob/feature/editor-sidebar-interactivity/apps/frontend/src/test-utils/builders.ts) [mock-hooks.ts)](https://github.com/MaibornWolff/ThreatSea/blob/feature/editor-sidebar-interactivity/apps/frontend/src/test-utils/mock-hooks.ts)_**
  - E2e tests for asset navigation, POA sidebar, and connected component interactions
  
  ### Screenshots

- asset name click opening the edit dialog

<img width="1455" height="690" alt="asset name click opening the edit dialog" src="https://github.com/user-attachments/assets/aa4c78af-0249-49cb-b092-eb04f36e6377" />

-  breadcrumb navigation in the interface sidebar
<img width="1076" height="690" alt="breadcrumb navigation in the interface sidebar" src="https://github.com/user-attachments/assets/41942e71-f780-48ab-a6d5-ed31e86e339e" />

- inline interface name editing
<img width="1022" height="681" alt="inline interface name editing" src="https://github.com/user-attachments/assets/97894b07-273e-4db8-a573-e858b8dc4190" />
