### PR TITLE
feat(editor): distinguish user-component connections with pink color                                                                                    

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -34,7 +34,7 @@
     "dotenv": "17.4.2",
     "drizzle-orm": "0.45.2",
     "express": "5.2.1",
-    "express-rate-limit": "8.3.2",
+    "express-rate-limit": "8.4.0",
     "express-session": "1.19.0",
     "express-ws": "5.0.2",
     "helmet": "8.1.0",

--- a/apps/backend/src/routers/auth.router.ts
+++ b/apps/backend/src/routers/auth.router.ts
@@ -16,12 +16,17 @@ import {
 export const authRouter = express.Router();
 
 const authLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100, // limit each IP to 100 authentication requests per windowMs
+    windowMs: 15 * 60 * 1000,
+    max: 100,
+});
+
+const authStatusLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 500,
 });
 
 authRouter.get("/authenticationMode", authenticationMode);
-authRouter.get("/status", authLimiter, getAuthStatus);
+authRouter.get("/status", authStatusLimiter, getAuthStatus);
 
 authRouter.get("/login", authLimiter, authenticate);
 

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -62,8 +62,8 @@ app.use(LogHandler);
 app.use(csrfSynchronisedProtection);
 
 const apiRateLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100, // limit each IP to 100 authentication requests per windowMs
+    windowMs: 15 * 60 * 1000,
+    max: 3000,
     standardHeaders: true,
     legacyHeaders: false,
 });

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -72,7 +72,7 @@
     "jsdom": "29.0.2",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
-    "vite": "8.0.9",
+    "vite": "8.0.10",
     "vite-plugin-svgr": "5.2.0",
     "vitest": "4.1.5"
   },

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -29,9 +29,9 @@
   "dependencies": {
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@mui/icons-material": "6.5.0",
-    "@mui/material": "6.5.0",
-    "@mui/system": "6.5.0",
+    "@mui/icons-material": "9.0.0",
+    "@mui/material": "9.0.0",
+    "@mui/system": "9.0.0",
     "@react-pdf/renderer": "4.5.1",
     "@react-pdf/types": "2.11.1",
     "@react-pdf/zlib": "2.0.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -37,7 +37,7 @@
     "@react-pdf/zlib": "2.0.0",
     "@reduxjs/toolkit": "2.11.2",
     "exceljs": "4.4.0",
-    "i18next": "26.0.6",
+    "i18next": "26.0.7",
     "json-stable-stringify": "1.3.0",
     "jwt-decode": "4.0.0",
     "konva": "10.2.5",

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
             use: {
                 ...devices["Desktop Chrome"],
                 // Use prepared auth state.
-                storageState: "tmp/.auth/chromium-user.json",
+                storageState: path.join(__dirname, "tmp/.auth/chromium-user.json"),
             },
             dependencies: ["setup chromium"],
         },
@@ -65,7 +65,7 @@ export default defineConfig({
             use: {
                 ...devices["Desktop Firefox"],
                 // Use prepared auth state.
-                storageState: "tmp/.auth/firefox-user.json",
+                storageState: path.join(__dirname, "tmp/.auth/firefox-user.json"),
             },
             dependencies: ["setup firefox"],
         },
@@ -81,7 +81,7 @@ export default defineConfig({
             use: {
                 ...devices["Desktop Safari"],
                 // Use prepared auth state.
-                storageState: "tmp/.auth/webkit-user.json",
+                storageState: path.join(__dirname, "tmp/.auth/webkit-user.json"),
             },
             dependencies: ["setup webkit"],
         },

--- a/apps/frontend/src/application/selectors/assets.selectors.test.ts
+++ b/apps/frontend/src/application/selectors/assets.selectors.test.ts
@@ -1,0 +1,27 @@
+import { assetsSelectors } from "./assets.selectors";
+import { createAsset } from "#test-utils/builders.ts";
+import { assetsAdapter } from "../adapters/asset.adapter";
+import type { RootState } from "../store.types";
+import type { Asset } from "../../api/types/asset.types";
+
+const withAssets = (assets: Asset[]) =>
+    ({
+        assets: assetsAdapter.upsertMany(assetsAdapter.getInitialState({ isPending: false }), assets),
+    }) as RootState;
+
+describe("assetsSelectors", () => {
+    describe("selectById", () => {
+        it("returns the asset when it exists", () => {
+            const asset = createAsset({ id: 42 });
+            const state = withAssets([asset]);
+
+            expect(assetsSelectors.selectById(state, 42)).toEqual(asset);
+        });
+
+        it("returns undefined when the id does not exist", () => {
+            const state = withAssets([createAsset({ id: 1 })]);
+
+            expect(assetsSelectors.selectById(state, 999)).toBeUndefined();
+        });
+    });
+});

--- a/apps/frontend/src/application/selectors/assets.selectors.ts
+++ b/apps/frontend/src/application/selectors/assets.selectors.ts
@@ -6,10 +6,11 @@ import { assetsAdapter } from "../adapters/asset.adapter";
 const selectAssetsEntities = (state: RootState) => state.assets.entities;
 const selectProjectId = (_state: RootState, projectId: number) => projectId;
 
+const { selectById } = assetsAdapter.getSelectors((state: RootState) => state.assets);
+
 export const assetsSelectors = {
     selectByProjectId: createSelector([selectAssetsEntities, selectProjectId], (entities, projectId): Asset[] => {
         return Object.values(entities).filter((item) => item.projectId === projectId);
     }),
-
-    selectAll: assetsAdapter.getSelectors((state: RootState) => state.assets).selectAll,
+    selectById,
 };

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -3,6 +3,7 @@ import type { ExtendedProject } from "#api/types/project.types.ts";
 import {
     AnchorOrientation,
     type AugmentedSystemComponent,
+    type ConnectionAnchor,
     type SystemConnection,
     type SystemPointOfAttack,
 } from "#api/types/system.types.ts";
@@ -81,6 +82,14 @@ export const createProject = (overrides: Partial<ExtendedProject> = {}): Extende
     updatedAt: new Date("2025-01-01"),
     role: USER_ROLES.EDITOR,
     image: null,
+    ...overrides,
+});
+
+export const createConnectionAnchor = (overrides: Partial<ConnectionAnchor> = {}) => ({
+    id: "comp-1",
+    anchor: AnchorOrientation.right,
+    type: STANDARD_COMPONENT_TYPES.CLIENT,
+    component: undefined,
     ...overrides,
 });
 

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -1,0 +1,101 @@
+import type { Asset } from "#api/types/asset.types.ts";
+import type { ExtendedProject } from "#api/types/project.types.ts";
+import {
+    AnchorOrientation,
+    type AugmentedSystemComponent,
+    type SystemConnection,
+    type SystemPointOfAttack,
+} from "#api/types/system.types.ts";
+import type { SystemConnectionPoint } from "#application/adapters/system-connection-point.adapter.ts";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { CONFIDENTIALITY_LEVELS } from "#utils/confidentiality.ts";
+
+export const createAsset = (overrides: Partial<Asset> = {}): Asset => ({
+    id: 1,
+    name: "Test Asset",
+    description: "",
+    confidentiality: 3,
+    integrity: 3,
+    availability: 2,
+    confidentialityJustification: "",
+    integrityJustification: "",
+    availabilityJustification: "",
+    projectId: 1,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    ...overrides,
+});
+
+export const createSystemComponent = (overrides: Partial<AugmentedSystemComponent> = {}): AugmentedSystemComponent => ({
+    id: "comp-1",
+    name: "Test Component",
+    description: "",
+    type: STANDARD_COMPONENT_TYPES.CLIENT,
+    x: 0,
+    y: 0,
+    gridX: 0,
+    gridY: 0,
+    width: 100,
+    height: 100,
+    selected: true,
+    projectId: 1,
+    symbol: null,
+    pointsOfAttack: [],
+    ...overrides,
+});
+
+export const createPointOfAttack = (overrides: Partial<SystemPointOfAttack> = {}): SystemPointOfAttack => ({
+    id: "poa-1",
+    name: null,
+    type: POINTS_OF_ATTACK.USER_INTERFACE,
+    componentId: "comp-1",
+    connectionId: null,
+    projectId: 1,
+    connectionPointId: null,
+    assets: [],
+    componentName: "Test Component",
+    ...overrides,
+});
+
+export const createConnectionPoint = (overrides: Partial<SystemConnectionPoint> = {}): SystemConnectionPoint => ({
+    id: "cp-1",
+    name: "eth0",
+    connectionId: "conn-1",
+    projectId: 1,
+    componentId: "comp-1",
+    componentName: "Test Component",
+    description: "",
+    ...overrides,
+});
+
+export const createProject = (overrides: Partial<ExtendedProject> = {}): ExtendedProject => ({
+    id: 1,
+    catalogId: 1,
+    name: "Test Project",
+    confidentialityLevel: CONFIDENTIALITY_LEVELS.INTERNAL,
+    lineOfToleranceGreen: 3,
+    lineOfToleranceRed: 6,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    role: USER_ROLES.EDITOR,
+    image: null,
+    ...overrides,
+});
+
+export const createConnection = (overrides: Partial<SystemConnection> = {}): SystemConnection => ({
+    id: "conn-1",
+    name: "Test Connection",
+    from: { id: "comp-1", anchor: AnchorOrientation.right, type: STANDARD_COMPONENT_TYPES.CLIENT },
+    to: { id: "comp-2", anchor: AnchorOrientation.left, type: STANDARD_COMPONENT_TYPES.SERVER },
+    connectionPoints: [],
+    connectionPointsMeta: [],
+    waypoints: [],
+    recalculate: false,
+    projectId: 1,
+    visible: true,
+    communicationInterfaceId: null,
+    communicationInterface: null,
+    ...overrides,
+});

--- a/apps/frontend/src/test-utils/mock-hooks.ts
+++ b/apps/frontend/src/test-utils/mock-hooks.ts
@@ -1,0 +1,153 @@
+import { type MockInstance, vi } from "vitest";
+import * as dialogHook from "#application/hooks/use-dialog.hook.ts";
+import * as confirmHook from "#application/hooks/use-confirm.hook.ts";
+import * as alertHook from "#application/hooks/use-alert.hook.ts";
+import * as editorHook from "#application/hooks/use-editor.hook.ts";
+import * as assetsHook from "#application/hooks/use-assets.hook.ts";
+
+/**
+ * @module mock-hooks - Reusable hook spies.
+ *
+ * Each function spies on the real hook module and returns the MockInstance.
+ * Import and call — no vi.mock() needed in the test file.
+ *
+ * Usage:
+ *   import { mockUseDialog } from "#test-utils/mock-hooks.ts";
+ *
+ *   const spy = mockUseDialog();
+ *   const spy = mockUseDialog({ cancelDialog: myTrackedFn });
+ */
+
+type UseDialogResult = ReturnType<typeof dialogHook.useDialog>;
+type UseConfirmResult = ReturnType<typeof confirmHook.useConfirm>;
+type UseAlertResult = ReturnType<typeof alertHook.useAlert>;
+type UseEditorResult = ReturnType<typeof editorHook.useEditor>;
+type UseAssetsResult = ReturnType<typeof assetsHook.useAssets>;
+
+export const mockUseDialog = (config?: Partial<UseDialogResult>): MockInstance => {
+    return vi.spyOn(dialogHook, "useDialog").mockImplementation(() => ({
+        values: null,
+        setValue: vi.fn(),
+        cancelDialog: vi.fn(),
+        confirmDialog: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseConfirm = (config?: Partial<UseConfirmResult>): MockInstance => {
+    return vi.spyOn(confirmHook, "useConfirm").mockImplementation(() => ({
+        openConfirm: vi.fn(),
+        cancelConfirm: vi.fn(),
+        acceptConfirm: vi.fn(),
+        acceptColor: undefined,
+        open: false,
+        message: "",
+        cancelText: "",
+        acceptText: "",
+        ...config,
+    }));
+};
+
+export const mockUseAlert = (config?: Partial<UseAlertResult>): MockInstance => {
+    return vi.spyOn(alertHook, "useAlert").mockImplementation(() => ({
+        type: "",
+        text: "",
+        visible: false,
+        close: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showSuccessMessage: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseEditor = (config?: Partial<UseEditorResult>): MockInstance => {
+    return vi.spyOn(editorHook, "useEditor").mockImplementation(() => ({
+        deleteCustomComponent: vi.fn(),
+        autoSaveBlocked: vi.fn(),
+        addComponent: vi.fn(),
+        moveComponent: vi.fn(),
+        selectComponent: vi.fn(),
+        deselectComponent: vi.fn(),
+        removeComponent: vi.fn(),
+        selectConnector: vi.fn(),
+        deselectConnector: vi.fn(),
+        selectConnection: vi.fn(),
+        deselectConnection: vi.fn(),
+        loadSystem: vi.fn(),
+        systemPending: false,
+        saveCurrentSystem: vi.fn(),
+        setLayerPosition: vi.fn(),
+        setShowHelpLines: vi.fn(),
+        setComponentsGridPosition: vi.fn(),
+        setSelectedComponentName: vi.fn(),
+        setSelectedComponentDescription: vi.fn(),
+        setSelectedConnectionPointDescription: vi.fn(),
+        addPointOfAttack: vi.fn(),
+        removePointOfAttack: vi.fn(),
+        removeConnection: vi.fn(),
+        removeConnectionById: vi.fn(),
+        selectPointOfAttack: vi.fn(),
+        deselectPointOfAttack: vi.fn(),
+        addAssetToSelectedPointOfAttack: vi.fn(),
+        removeAssetToSelectedPointOfAttack: vi.fn(),
+        updateConnectionsOfComponent: vi.fn(),
+        connectionRecalculated: vi.fn(),
+        selectConnectionPoint: vi.fn(),
+        deselectConnectionPoint: vi.fn(),
+        setMousePointers: vi.fn(),
+        addAssetToPointOfAttack: vi.fn(),
+        removeAssetFromPointOfAttack: vi.fn(),
+        setAssetSearchValue: vi.fn(),
+        setStageScale: vi.fn(),
+        loadComponentTypes: vi.fn(),
+        setConnectionVisibility: vi.fn(),
+        setAlwaysShowAnchorsOfComponent: vi.fn(),
+        addComponentConnectionLine: vi.fn(),
+        removeComponentConnectionLine: vi.fn(),
+        clearComponentConnectionLines: vi.fn(),
+        addInUseComponent: vi.fn(),
+        removeInUseComponent: vi.fn(),
+        setSelectedConnectionName: vi.fn(),
+        setSelectedConnectionPointName: vi.fn(),
+        setAutoSaveStatus: vi.fn(),
+        handleChangeCommunicationInterfaceName: vi.fn(),
+        handleDeleteCommunicationInterface: vi.fn(),
+        addCommunicationInterface: vi.fn(),
+        initialized: true,
+        components: [],
+        connections: [],
+        hasSystemChanged: false,
+        layerPosition: { x: 0, y: 0 },
+        showHelpLines: false,
+        selectedComponent: undefined,
+        selectedComponentId: null,
+        selectedConnection: undefined,
+        selectedConnectionId: null,
+        selectedPointOfAttack: undefined,
+        selectedConnectionPointId: null,
+        mousePointers: [] as never,
+        newConnection: null,
+        pointsOfAttackOfSelectedComponent: [],
+        assetSearchValue: "",
+        blockAutoSave: false,
+        connectionsOfComponent: [],
+        componentConnectionLines: [],
+        isAnyComponentInUse: false,
+        selectedConnectionPoint: undefined,
+        autoSaveStatus: "uninitialized" as const,
+        makeScreenshot: false,
+        stageScale: 1,
+        stagePosition: { x: 0, y: 0 },
+        ...config,
+    }));
+};
+
+export const mockUseAssets = (config?: Partial<UseAssetsResult>): MockInstance => {
+    return vi.spyOn(assetsHook, "useAssets").mockImplementation(() => ({
+        items: [],
+        isPending: false,
+        loadAssets: vi.fn(),
+        deleteAsset: vi.fn(),
+        ...config,
+    }));
+};

--- a/apps/frontend/src/test-utils/render-with-providers.tsx
+++ b/apps/frontend/src/test-utils/render-with-providers.tsx
@@ -16,7 +16,7 @@ import type { ReactNode } from "react";
 import { render } from "@testing-library/react";
 import type { RenderOptions, RenderResult } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, type InitialEntry } from "react-router-dom";
 import { I18nextProvider } from "react-i18next";
 import { createStore } from "../application/store";
 import type { RootState } from "../application/store";
@@ -26,7 +26,7 @@ interface RenderWithProvidersOptions extends Omit<RenderOptions, "wrapper"> {
     /** Partial Redux state to pre-load into the store. */
     preloadedState?: Partial<RootState>;
     /** Initial URL entries for MemoryRouter. Defaults to ["/"]. */
-    initialEntries?: string[];
+    initialEntries?: InitialEntry[];
 }
 
 /**

--- a/apps/frontend/src/view/components/addableMember.component.tsx
+++ b/apps/frontend/src/view/components/addableMember.component.tsx
@@ -162,11 +162,10 @@ export const AddableMember = <TFieldValues extends BaseAddableMemberFormValues>(
                                     primary={name}
                                     slotProps={{
                                         primary: {
-                                            fontSize: "0.85em",
+                                            sx: { fontSize: "0.85em" },
                                         },
                                         secondary: {
-                                            color: "#5e666e",
-                                            fontSize: "0.8em",
+                                            sx: { color: "#5e666e", fontSize: "0.8em" },
                                         },
                                     }}
                                     secondary={email}

--- a/apps/frontend/src/view/components/button.component.test.tsx
+++ b/apps/frontend/src/view/components/button.component.test.tsx
@@ -9,7 +9,6 @@
 /// <reference types="@testing-library/jest-dom" />
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
 import { Button } from "./button.component";
 
 describe("Button", () => {

--- a/apps/frontend/src/view/components/confirm.component.tsx
+++ b/apps/frontend/src/view/components/confirm.component.tsx
@@ -19,7 +19,16 @@ export const Confirm = () => {
     const confirmButtonColor = acceptColor as ComponentProps<typeof Button>["color"];
 
     return (
-        <Dialog open={open} maxWidth={"xs"} fullWidth={false} onBackdropClick={cancelConfirm}>
+        <Dialog
+            open={open}
+            maxWidth={"xs"}
+            fullWidth={false}
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    cancelConfirm?.();
+                }
+            }}
+        >
             <Box>
                 <Typography>
                     {typeof message === "object"

--- a/apps/frontend/src/view/components/dialog.component.tsx
+++ b/apps/frontend/src/view/components/dialog.component.tsx
@@ -1,18 +1,20 @@
 import { Dialog as MaterialDialog } from "@mui/material";
 import type { DialogProps } from "@mui/material/Dialog";
 
-export const Dialog = ({ open, onBackdropClick, children, ...props }: DialogProps) => {
+export const Dialog = ({ open, onClose, children, ...props }: DialogProps) => {
     return (
         <MaterialDialog
             open={open}
-            onBackdropClick={onBackdropClick}
+            onClose={onClose}
             maxWidth="md"
             fullWidth
-            PaperProps={{
-                sx: {
-                    bgcolor: "#e6e8ec",
-                    borderRadius: 5,
-                    padding: "30px",
+            slotProps={{
+                paper: {
+                    sx: {
+                        bgcolor: "#e6e8ec",
+                        borderRadius: 5,
+                        padding: "30px",
+                    },
                 },
             }}
             {...props}

--- a/apps/frontend/src/view/components/editor-components/connection-preview.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/connection-preview.component.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { POA_COLORS } from "../../colors/pointsOfAttack.colors";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { createSystemComponent } from "#test-utils/builders.ts";
+import { ConnectionPreview } from "./connection-preview.component";
+
+vi.mock("react-konva", () => ({
+    Line: (props: Record<string, unknown>) => (
+        <div data-testid="konva-line" data-stroke={props["stroke"]} data-points={JSON.stringify(props["points"])} />
+    ),
+}));
+
+describe("ConnectionPreview", () => {
+    it("renders with blue stroke when component is not USERS type", () => {
+        render(
+            <ConnectionPreview
+                component={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                newConnectionMousePosition={{ x: 300, y: 300 }}
+            />
+        );
+
+        const line = screen.getByTestId("konva-line");
+        expect(line).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE].normal);
+    });
+
+    it("renders with pink stroke when component type is USERS", () => {
+        render(
+            <ConnectionPreview
+                component={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                newConnectionMousePosition={{ x: 300, y: 300 }}
+            />
+        );
+
+        const line = screen.getByTestId("konva-line");
+        expect(line).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal);
+    });
+
+    it("renders with pink stroke when draggedComponent type is USERS", () => {
+        render(
+            <ConnectionPreview
+                component={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                draggedComponent={createSystemComponent({
+                    id: "comp-2",
+                    type: STANDARD_COMPONENT_TYPES.USERS,
+                    x: 300,
+                    y: 300,
+                })}
+            />
+        );
+
+        const line = screen.getByTestId("konva-line");
+        expect(line).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal);
+    });
+
+    it("calculates padded points when draggedComponent is provided", () => {
+        const component = createSystemComponent({ x: 0, y: 0, width: 100, height: 100 });
+        const draggedComponent = createSystemComponent({ id: "comp-2", x: 200, y: 0, width: 100, height: 100 });
+
+        render(<ConnectionPreview component={component} draggedComponent={draggedComponent} />);
+
+        const line = screen.getByTestId("konva-line");
+        const points: number[] = JSON.parse(line.dataset["points"]!);
+
+        // Both components have center at (50,50) and (250,50) respectively.
+        // The line between them is horizontal (200px apart), padded inward by 45px on each end.
+        expect(points).toHaveLength(4);
+        expect(points[0]).toBeGreaterThan(50);
+        expect(points[2]).toBeLessThan(250);
+        // Y coordinates stay at 50 (centers aligned horizontally)
+        expect(points[1]).toBe(50);
+        expect(points[3]).toBe(50);
+    });
+
+    it("uses raw center-to-mouse points when newConnectionMousePosition is provided", () => {
+        const component = createSystemComponent({ x: 0, y: 0, width: 100, height: 100 });
+        const mousePosition = { x: 400, y: 300 };
+
+        render(<ConnectionPreview component={component} newConnectionMousePosition={mousePosition} />);
+
+        const line = screen.getByTestId("konva-line");
+        const points: number[] = JSON.parse(line.dataset["points"]!);
+
+        expect(points).toEqual([50, 50, 400, 300]);
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/connection-preview.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/connection-preview.component.tsx
@@ -2,6 +2,9 @@ import { useRef } from "react";
 import { Line } from "react-konva";
 import type { Line as KonvaLine } from "konva/lib/shapes/Line";
 import type { Coordinate, SystemComponent } from "#api/types/system.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { POA_COLORS } from "../../colors/pointsOfAttack.colors";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 
 interface ConnectionPreviewProps {
     component: SystemComponent;
@@ -50,5 +53,11 @@ export const ConnectionPreview = ({
         points = [componentCenter.x, componentCenter.y, newConnectionMousePosition.x, newConnectionMousePosition.y];
     }
 
-    return <Line points={points} stroke={"#3889ff"} strokeWidth={2} ref={lineRef} dash={[20, 5]} dashEnabled />;
+    const isUserConnection =
+        component.type === STANDARD_COMPONENT_TYPES.USERS || draggedComponent?.type === STANDARD_COMPONENT_TYPES.USERS;
+    const strokeColor = isUserConnection
+        ? POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal
+        : POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE].normal;
+
+    return <Line points={points} stroke={strokeColor} strokeWidth={2} ref={lineRef} dash={[20, 5]} dashEnabled />;
 };

--- a/apps/frontend/src/view/components/editor-components/editor-context-menu.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-context-menu.component.tsx
@@ -326,15 +326,17 @@ const ComponentListItem = ({ label, symbol, onEdit, onClickDelete, sx = {}, ...p
                             anchorEl={anchorEl}
                             open={open}
                             onClose={handleClose}
-                            MenuListProps={{
-                                sx: {
-                                    p: 0,
-                                    bgcolor: "background.mainIntransparent",
+                            slotProps={{
+                                list: {
+                                    sx: {
+                                        p: 0,
+                                        bgcolor: "background.mainIntransparent",
+                                    },
                                 },
-                            }}
-                            PaperProps={{
-                                sx: {
-                                    borderRadius: 5,
+                                paper: {
+                                    sx: {
+                                        borderRadius: 5,
+                                    },
                                 },
                             }}
                         >

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EditorSidebarAssetList, type EditorSidebarAssetListProps } from "./editor-sidebar-asset-list.component";
+import { createAsset } from "#test-utils/builders.ts";
+
+const setup = (propsOverride: Partial<EditorSidebarAssetListProps> = {}) => {
+    const props = {
+        items: [createAsset({ id: 1, name: "DB Server" }), createAsset({ id: 2, name: "Web App" })],
+        checkedAssets: [1],
+        onChangeHandler: vi.fn(),
+        onAssetNameClick: vi.fn(),
+        onAssetHover: vi.fn(),
+        onAssetLeave: vi.fn(),
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    render(<EditorSidebarAssetList {...props} />);
+    return { props, user };
+};
+
+describe("EditorSidebarAssetList", () => {
+    it("renders each asset name as visible text", () => {
+        setup();
+
+        expect(screen.getByText("DB Server")).toBeInTheDocument();
+        expect(screen.getByText("Web App")).toBeInTheDocument();
+    });
+
+    it("checked assets have their switch turned on", () => {
+        setup({ checkedAssets: [1] });
+
+        const switches = screen.getAllByRole("checkbox");
+        expect(switches[0]).toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "DB Server" })).toBeChecked();
+    });
+
+    it("assets not in checkedAssets have their switch turned off", () => {
+        setup({ checkedAssets: [1] });
+
+        const switches = screen.getAllByRole("checkbox");
+        expect(switches[1]).not.toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "Web App" })).not.toBeChecked();
+    });
+
+    it("toggling a switch calls onChangeHandler with the correct asset", async () => {
+        const { props, user } = setup();
+
+        await user.click(screen.getByRole("checkbox", { name: "Web App" }));
+
+        expect(props.onChangeHandler).toHaveBeenCalledOnce();
+        expect(props.onChangeHandler).toHaveBeenCalledWith(expect.any(Object), props.items[1]);
+    });
+
+    it("clicking an asset name calls onAssetNameClick with that asset", async () => {
+        const { props, user } = setup();
+
+        await user.click(screen.getByText("DB Server"));
+
+        expect(props.onAssetNameClick).toHaveBeenCalledOnce();
+        expect(props.onAssetNameClick).toHaveBeenCalledWith(props.items[0]);
+    });
+
+    it("clicking an asset name does not toggle the switch", async () => {
+        const { props, user } = setup();
+
+        await user.click(screen.getByText("Web App"));
+
+        expect(props.onChangeHandler).not.toHaveBeenCalled();
+    });
+
+    it("hovering an asset name calls onAssetHover", async () => {
+        const { props, user } = setup();
+
+        await user.hover(screen.getByText("DB Server"));
+
+        expect(props.onAssetHover).toHaveBeenCalledOnce();
+        expect(props.onAssetHover).toHaveBeenCalledWith(expect.any(Object), props.items[0]);
+    });
+
+    it("leaving an asset name calls onAssetLeave", async () => {
+        const { props, user } = setup();
+
+        await user.hover(screen.getByText("DB Server"));
+        await user.unhover(screen.getByText("DB Server"));
+
+        expect(props.onAssetLeave).toHaveBeenCalled();
+    });
+
+    it("renders nothing when items is empty", () => {
+        setup({ items: [] });
+
+        expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+        expect(screen.queryByText("DB Server")).not.toBeInTheDocument();
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.test.tsx
@@ -29,23 +29,23 @@ describe("EditorSidebarAssetList", () => {
     it("checked assets have their switch turned on", () => {
         setup({ checkedAssets: [1] });
 
-        const switches = screen.getAllByRole("checkbox");
+        const switches = screen.getAllByRole("switch");
         expect(switches[0]).toBeChecked();
-        expect(screen.getByRole("checkbox", { name: "DB Server" })).toBeChecked();
+        expect(screen.getByRole("switch", { name: "DB Server" })).toBeChecked();
     });
 
     it("assets not in checkedAssets have their switch turned off", () => {
         setup({ checkedAssets: [1] });
 
-        const switches = screen.getAllByRole("checkbox");
+        const switches = screen.getAllByRole("switch");
         expect(switches[1]).not.toBeChecked();
-        expect(screen.getByRole("checkbox", { name: "Web App" })).not.toBeChecked();
+        expect(screen.getByRole("switch", { name: "Web App" })).not.toBeChecked();
     });
 
     it("toggling a switch calls onChangeHandler with the correct asset", async () => {
         const { props, user } = setup();
 
-        await user.click(screen.getByRole("checkbox", { name: "Web App" }));
+        await user.click(screen.getByRole("switch", { name: "Web App" }));
 
         expect(props.onChangeHandler).toHaveBeenCalledOnce();
         expect(props.onChangeHandler).toHaveBeenCalledWith(expect.any(Object), props.items[1]);
@@ -89,7 +89,7 @@ describe("EditorSidebarAssetList", () => {
     it("renders nothing when items is empty", () => {
         setup({ items: [] });
 
-        expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+        expect(screen.queryAllByRole("switch")).toHaveLength(0);
         expect(screen.queryByText("DB Server")).not.toBeInTheDocument();
     });
 });

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
@@ -1,14 +1,24 @@
 import { FormControlLabel, FormGroup, Switch, Typography } from "@mui/material";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import type { Asset } from "#api/types/asset.types.ts";
 
-interface EditorSidebarAssetListProps {
+export interface EditorSidebarAssetListProps {
     items: Asset[];
     checkedAssets: number[];
     onChangeHandler: (event: ChangeEvent<HTMLInputElement>, asset: Asset) => void;
+    onAssetNameClick: (asset: Asset) => void;
+    onAssetHover: (event: MouseEvent<HTMLElement>, asset: Asset) => void;
+    onAssetLeave: () => void;
 }
 
-export const EditorSidebarAssetList = ({ items, checkedAssets, onChangeHandler }: EditorSidebarAssetListProps) => {
+export const EditorSidebarAssetList = ({
+    items,
+    checkedAssets,
+    onChangeHandler,
+    onAssetNameClick,
+    onAssetHover,
+    onAssetLeave,
+}: EditorSidebarAssetListProps) => {
     return (
         <FormGroup sx={{ color: "text.primary", paddingLeft: 0.5 }}>
             {items.map((asset, index) => {
@@ -34,10 +44,19 @@ export const EditorSidebarAssetList = ({ items, checkedAssets, onChangeHandler }
                         }
                         label={
                             <Typography
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    onAssetNameClick(asset);
+                                }}
+                                onMouseEnter={(e) => onAssetHover(e, asset)}
+                                onMouseLeave={onAssetLeave}
                                 sx={{
                                     fontSize: "0.75rem",
                                     fontWeight: "bold",
                                     marginLeft: 1,
+                                    cursor: "pointer",
+                                    "&:hover": { textDecoration: "underline" },
                                 }}
                                 data-testid="asset-search-results"
                             >

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.test.tsx
@@ -1,0 +1,91 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+    EditorSidebarSelectedCommunicationInterface,
+    type EditorSidebarSelectedCommunicationInterfaceProps,
+} from "./editor-sidebar-selected-communication-interface.component";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createConnectionPoint, createPointOfAttack } from "#test-utils/builders.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+const setup = (propsOverride: Partial<EditorSidebarSelectedCommunicationInterfaceProps> = {}) => {
+    const props = {
+        selectedConnectionPoint: createConnectionPoint({ componentName: "Test Component" }),
+        selectedPointOfAttack: createPointOfAttack({ assets: [1] }),
+        assetSearchValue: "",
+        handleAssetSearchChanged: vi.fn(),
+        items: [
+            createAsset({ id: 1, name: "DB Server", confidentiality: 3, integrity: 2, availability: 1 }),
+            createAsset({ id: 2, name: "Web App", confidentiality: 1, integrity: 3, availability: 2 }),
+        ],
+        handleOnAssetChanged: vi.fn(),
+        handleOnConnectionPointDescriptionChange: vi.fn(),
+        handleChangeCommunicationInterfaceName: vi.fn(),
+        handleDeleteCommunicationInterface: vi.fn(),
+        handleAssetNameClick: vi.fn(),
+        handleInterfaceBreadcrumbClick: vi.fn(),
+        userRole: USER_ROLES.EDITOR,
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    renderWithProviders(<EditorSidebarSelectedCommunicationInterface {...props} />);
+    return { props, user };
+};
+
+describe("EditorSidebarSelectedCommunicationInterface", () => {
+    describe("breadcrumb", () => {
+        it("renders the component name, separator, and Interface label", () => {
+            setup();
+
+            expect(screen.getByText("Test Component")).toBeInTheDocument();
+            expect(screen.getByText(">")).toBeInTheDocument();
+            expect(screen.getByText("Interface:")).toBeInTheDocument();
+        });
+
+        it("clicking the component name calls handleInterfaceBreadcrumbClick", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("Test Component"));
+
+            expect(props.handleInterfaceBreadcrumbClick).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("asset name click", () => {
+        it("calls handleAssetNameClick with the correct asset when an asset name is clicked", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("DB Server"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledOnce();
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[0]);
+        });
+    });
+
+    describe("Popper hover tooltip", () => {
+        it("shows CIA values when hovering over an asset name", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("DB Server"));
+
+            expect(screen.getByText("(C 3 / I 2 / A 1)")).toBeInTheDocument();
+        });
+
+        it("hides CIA tooltip when mouse leaves the asset name", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("DB Server"));
+            await user.unhover(screen.getByText("DB Server"));
+
+            expect(screen.queryByText("(C 3 / I 2 / A 1)")).not.toBeInTheDocument();
+        });
+
+        it("shows correct CIA values for a different asset", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("Web App"));
+
+            expect(screen.getByText("(C 1 / I 3 / A 2)")).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-communication-interface.component.tsx
@@ -1,17 +1,18 @@
-import { IconButton, Typography } from "@mui/material";
+import { IconButton, Popper, Typography } from "@mui/material";
 import { Box } from "@mui/system";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EditorSidebarAssetList } from "./editor-sidebar-asset-list.component";
 import { SearchField } from "../search-field.component";
 import { TextField } from "../textfield.component";
 import { checkUserRole, USER_ROLES } from "../../../api/types/user-roles.types";
 import { Delete } from "@mui/icons-material";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import type { SystemConnectionPoint } from "#application/adapters/system-connection-point.adapter.ts";
 import type { Asset } from "#api/types/asset.types.ts";
 import type { SystemPointOfAttack } from "#api/types/system.types.ts";
 
-interface EditorSidebarSelectedCommunicationInterfaceProps {
+export interface EditorSidebarSelectedCommunicationInterfaceProps {
     selectedConnectionPoint: SystemConnectionPoint;
     selectedPointOfAttack: SystemPointOfAttack | null | undefined;
     assetSearchValue: string;
@@ -27,6 +28,8 @@ interface EditorSidebarSelectedCommunicationInterfaceProps {
         isFromCommunicationInterfaceSidebar?: boolean
     ) => void;
     userRole: USER_ROLES | undefined;
+    handleAssetNameClick: (asset: Asset) => void;
+    handleInterfaceBreadcrumbClick: () => void;
 }
 
 export const EditorSidebarSelectedCommunicationInterface = ({
@@ -40,232 +43,283 @@ export const EditorSidebarSelectedCommunicationInterface = ({
     handleChangeCommunicationInterfaceName,
     handleDeleteCommunicationInterface,
     userRole,
+    handleAssetNameClick,
+    handleInterfaceBreadcrumbClick,
 }: EditorSidebarSelectedCommunicationInterfaceProps) => {
     const { t } = useTranslation("editorPage");
+    const [assetAnchorEl, setAssetAnchorEl] = useState<HTMLElement | null>(null);
+    const [hoveredAsset, setHoveredAsset] = useState<Asset | null>(null);
+
+    const handleAssetHover = (event: MouseEvent<HTMLElement>, asset: Asset) => {
+        setHoveredAsset(asset);
+        setAssetAnchorEl(event.currentTarget);
+    };
+
+    const handleAssetLeave = () => {
+        setHoveredAsset(null);
+        setAssetAnchorEl(null);
+    };
     return (
-        <>
-            <Box>
+        <Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#f2f4f500",
+                    borderRadius: 15,
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                    alignItems: "flex-start",
+                    justifyContent: "space-between",
+                    marginBottom: "-10px",
+                }}
+            >
                 <Box
                     sx={{
                         display: "flex",
+                        flexDirection: "column",
                         backgroundColor: "#f2f4f500",
                         borderRadius: 15,
                         paddingLeft: 0,
                         paddingRight: 0,
                         alignItems: "flex-start",
-                        justifyContent: "space-between",
-                        marginBottom: "-10px",
+                        marginBottom: "8px",
                     }}
                 >
+                    <Typography
+                        sx={{
+                            display: "inline",
+                            fontWeight: "bold",
+                            fontSize: "0.875rem",
+                            color: "text.primary",
+                            marginBottom: "4px",
+                        }}
+                    >
+                        <Typography
+                            component="span"
+                            onClick={handleInterfaceBreadcrumbClick}
+                            sx={{
+                                fontWeight: "bold",
+                                fontSize: "0.875rem",
+                                cursor: "pointer",
+                                "&:hover": { textDecoration: "underline" },
+                            }}
+                        >
+                            {selectedConnectionPoint?.componentName}
+                        </Typography>
+                        <Typography component="span" sx={{ display: "inline", marginLeft: 1, marginRight: 1 }}>
+                            &gt;
+                        </Typography>
+                        Interface:
+                    </Typography>
+                    <TextField
+                        value={selectedConnectionPoint?.name ? selectedConnectionPoint.name : ""}
+                        onChange={(e) => {
+                            if (!selectedConnectionPoint.componentId) {
+                                return;
+                            }
+                            handleChangeCommunicationInterfaceName(
+                                selectedConnectionPoint.componentId,
+                                selectedConnectionPoint.id,
+                                e.target.value
+                            );
+                        }}
+                        onKeyUp={(event) => {
+                            if (event.key === "Delete") {
+                                event.stopPropagation();
+                            }
+                        }}
+                        sx={{
+                            border: "none !important",
+                            width: "100%",
+                            "& .MuiInputBase-root": {
+                                borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
+                            },
+                            "*": {
+                                border: "none !important",
+                                padding: "0 !important",
+                                borderRadius: "0 !important",
+                            },
+                            "& .Mui-focused": {
+                                borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
+                            },
+                            input: {
+                                fontSize: "0.875rem !important",
+                                width: "100% !important",
+                            },
+                            color: "text.primary !important",
+                            padding: "0 !important",
+                        }}
+                    />
+                </Box>
+                {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                    <IconButton
+                        onClick={() => {
+                            if (!selectedConnectionPoint.componentId) {
+                                return;
+                            }
+                            handleDeleteCommunicationInterface(
+                                selectedConnectionPoint.componentId,
+                                selectedConnectionPoint.id,
+                                selectedConnectionPoint.name,
+                                true
+                            );
+                        }}
+                        sx={{
+                            "&:hover": {
+                                color: "#ef5350",
+                                backgroundColor: "background.paperIntransparent",
+                            },
+                            marginTop: -1,
+                        }}
+                    >
+                        <Delete sx={{ fontSize: 18 }} />
+                    </IconButton>
+                )}
+            </Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.description.title")}
+                </Typography>
+            </Box>
+            <TextField
+                value={selectedConnectionPoint?.description ? selectedConnectionPoint.description : ""}
+                onChange={handleOnConnectionPointDescriptionChange}
+                onKeyUp={(event) => {
+                    if (event.key === "Delete") {
+                        event.stopPropagation();
+                    }
+                }}
+                multiline
+                minRows={1}
+                maxRows={Infinity}
+                sx={{
+                    border: "none !important",
+                    width: "100%",
+                    "& .MuiInputBase-root": {
+                        borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
+                    },
+                    "*": {
+                        border: "none !important",
+                        padding: "0 !important",
+                        borderRadius: "0 !important",
+                    },
+                    "& .Mui-focused": {
+                        borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
+                    },
+                    textarea: {
+                        fontSize: "0.875rem !important",
+                        width: "100% !important",
+                        lineHeight: "1.5 !important",
+                    },
+                    color: "text.primary !important",
+                    padding: "0 !important",
+                }}
+            />
+
+            {selectedPointOfAttack !== undefined && selectedPointOfAttack != null && (
+                <Box>
                     <Box
                         sx={{
                             display: "flex",
-                            flexDirection: "column",
-                            backgroundColor: "#f2f4f500",
+                            backgroundColor: "#fff",
                             borderRadius: 15,
-                            paddingLeft: 0,
+                            height: "31px",
+                            paddingLeft: 8,
                             paddingRight: 0,
-                            alignItems: "flex-start",
-                            marginBottom: "8px",
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            marginTop: 4,
+                            marginBottom: 2,
+                            marginLeft: -8,
+                            marginRight: -8,
                         }}
                     >
                         <Typography
                             sx={{
                                 fontWeight: "bold",
-                                fontSize: "0.875rem",
+                                fontSize: "0.75rem",
                                 color: "text.primary",
-                                marginBottom: "4px",
                             }}
                         >
-                            {selectedConnectionPoint?.componentName} Interface:
+                            {t("sidebar.assets.title")}
                         </Typography>
-                        <TextField
-                            value={selectedConnectionPoint?.name ? selectedConnectionPoint.name : ""}
-                            onChange={(e) => {
-                                if (!selectedConnectionPoint.componentId) {
-                                    return;
-                                }
-                                handleChangeCommunicationInterfaceName(
-                                    selectedConnectionPoint.componentId,
-                                    selectedConnectionPoint.id,
-                                    e.target.value
-                                );
-                            }}
-                            onKeyUp={(event) => {
-                                if (event.key === "Delete") {
-                                    event.stopPropagation();
-                                }
-                            }}
-                            sx={{
-                                border: "none !important",
-                                width: "100%",
-                                "& .MuiInputBase-root": {
-                                    borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
-                                },
-                                "*": {
-                                    border: "none !important",
-                                    padding: "0 !important",
-                                    borderRadius: "0 !important",
-                                },
-                                "& .Mui-focused": {
-                                    borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                                },
-                                input: {
-                                    fontSize: "0.875rem !important",
-                                    width: "100% !important",
-                                },
-                                color: "text.primary !important",
-                                padding: "0 !important",
-                            }}
-                        />
                     </Box>
-                    {checkUserRole(userRole, USER_ROLES.EDITOR) && (
-                        <IconButton
-                            onClick={() => {
-                                if (!selectedConnectionPoint.componentId) {
-                                    return;
-                                }
-                                handleDeleteCommunicationInterface(
-                                    selectedConnectionPoint.componentId,
-                                    selectedConnectionPoint.id,
-                                    selectedConnectionPoint.name,
-                                    true
-                                );
-                            }}
-                            sx={{
-                                "&:hover": {
-                                    color: "#ef5350",
-                                    backgroundColor: "background.paperIntransparent",
-                                },
-                                marginTop: -1,
-                            }}
-                        >
-                            <Delete sx={{ fontSize: 18 }} />
-                        </IconButton>
-                    )}
-                </Box>
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
-                    }}
-                >
-                    <Typography
+
+                    <SearchField
                         sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
+                            marginBottom: 2,
+                            marginLeft: -0.5,
+                            width: "40%",
+                            height: "31px",
+                            borderRadius: 5,
+                        }}
+                        inputSx={{ fontSize: "0.75rem" }}
+                        value={assetSearchValue}
+                        onChange={handleAssetSearchChanged}
+                        data-testid="selected-communication-asset-search-field"
+                    />
+
+                    <EditorSidebarAssetList
+                        items={
+                            assetSearchValue != ""
+                                ? items.filter((item) => {
+                                      const lcSearchValue = assetSearchValue.toLowerCase();
+                                      return (
+                                          assetSearchValue === "" ||
+                                          item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
+                                      );
+                                  })
+                                : items
+                        }
+                        checkedAssets={selectedPointOfAttack.assets}
+                        onChangeHandler={handleOnAssetChanged}
+                        onAssetNameClick={handleAssetNameClick}
+                        onAssetHover={handleAssetHover}
+                        onAssetLeave={handleAssetLeave}
+                    />
+
+                    <Popper
+                        open={assetAnchorEl != null}
+                        anchorEl={assetAnchorEl}
+                        placement="bottom-start"
+                        sx={{
+                            backgroundColor: "background.defaultIntransparent",
+                            borderRadius: 5,
+                            boxShadow: 1,
+                            zIndex: 1000,
                         }}
                     >
-                        {t("sidebar.description.title")}
-                    </Typography>
+                        {hoveredAsset && (
+                            <Box sx={{ padding: 1, margin: 0.5 }}>
+                                <Typography sx={{ fontSize: "0.75rem" }}>
+                                    {`(C ${hoveredAsset.confidentiality} / I ${hoveredAsset.integrity} / A ${hoveredAsset.availability})`}
+                                </Typography>
+                            </Box>
+                        )}
+                    </Popper>
                 </Box>
-                <TextField
-                    value={selectedConnectionPoint?.description ? selectedConnectionPoint.description : ""}
-                    onChange={handleOnConnectionPointDescriptionChange}
-                    onKeyUp={(event) => {
-                        if (event.key === "Delete") {
-                            event.stopPropagation();
-                        }
-                    }}
-                    multiline
-                    minRows={1}
-                    maxRows={Infinity}
-                    sx={{
-                        border: "none !important",
-                        width: "100%",
-                        "& .MuiInputBase-root": {
-                            borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
-                        },
-                        "*": {
-                            border: "none !important",
-                            padding: "0 !important",
-                            borderRadius: "0 !important",
-                        },
-                        "& .Mui-focused": {
-                            borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                        },
-                        textarea: {
-                            fontSize: "0.875rem !important",
-                            width: "100% !important",
-                            lineHeight: "1.5 !important",
-                        },
-                        color: "text.primary !important",
-                        padding: "0 !important",
-                    }}
-                />
-
-                {selectedPointOfAttack !== undefined && selectedPointOfAttack != null && (
-                    <Box>
-                        <Box
-                            sx={{
-                                display: "flex",
-                                backgroundColor: "#fff",
-                                borderRadius: 15,
-                                height: "31px",
-                                paddingLeft: 8,
-                                paddingRight: 0,
-                                alignItems: "center",
-                                justifyContent: "space-between",
-                                marginTop: 4,
-                                marginBottom: 2,
-                                marginLeft: -8,
-                                marginRight: -8,
-                            }}
-                        >
-                            <Typography
-                                sx={{
-                                    fontWeight: "bold",
-                                    fontSize: "0.75rem",
-                                    color: "text.primary",
-                                }}
-                            >
-                                {t("sidebar.assets.title")}
-                            </Typography>
-                        </Box>
-
-                        <SearchField
-                            sx={{
-                                marginBottom: 2,
-                                marginLeft: -0.5,
-                                width: "40%",
-                                height: "31px",
-                                borderRadius: 5,
-                            }}
-                            inputSx={{ fontSize: "0.75rem" }}
-                            value={assetSearchValue}
-                            onChange={handleAssetSearchChanged}
-                            data-testid="selected-communication-asset-search-field"
-                        />
-
-                        <EditorSidebarAssetList
-                            items={
-                                assetSearchValue != ""
-                                    ? items.filter((item) => {
-                                          const lcSearchValue = assetSearchValue.toLowerCase();
-                                          return (
-                                              assetSearchValue === "" ||
-                                              item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
-                                          );
-                                      })
-                                    : items
-                            }
-                            checkedAssets={selectedPointOfAttack.assets}
-                            onChangeHandler={handleOnAssetChanged}
-                        />
-                    </Box>
-                )}
-            </Box>
-        </>
+            )}
+        </Box>
     );
 };

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.test.tsx
@@ -1,0 +1,227 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+    EditorSidebarSelectedComponent,
+    type EditorSidebarSelectedComponentProps,
+} from "./editor-sidebar-selected-component.component";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createSystemComponent, createPointOfAttack } from "#test-utils/builders.ts";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import {
+    AnchorOrientation,
+    type ConnectionEndpointWithComponent,
+    type SystemCommunicationInterface,
+} from "#api/types/system.types.ts";
+
+const setup = (propsOverride: Partial<EditorSidebarSelectedComponentProps> = {}) => {
+    const props = {
+        selectedComponent: createSystemComponent(),
+        handleDeleteComponent: vi.fn(),
+        handleOnNameChange: vi.fn(),
+        handleChangePointOfAttack: vi.fn(),
+        handleAddAssetToAllPointsOfAttack: vi.fn(),
+        handleRemoveAssetFromAllPointsOfAttack: vi.fn(),
+        assetSearchValue: "",
+        handleAssetSearchChanged: vi.fn(),
+        items: [createAsset({ id: 1, name: "DB Server" }), createAsset({ id: 2, name: "Web App" })],
+        pointsOfAttackOfSelectedComponent: [],
+        userRole: USER_ROLES.EDITOR,
+        handleOnDescriptionChange: vi.fn(),
+        connectedComponents: [] as ConnectionEndpointWithComponent[],
+        handleDeleteConnectionBetweenComponents: vi.fn(),
+        handleChangeCommunicationInterfaceName: vi.fn(),
+        handleDeleteCommunicationInterface: vi.fn(),
+        handlePointOfAttackLabelClick: vi.fn(),
+        handleAssetNameClick: vi.fn(),
+        handleSelectConnectedComponent: vi.fn(),
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    renderWithProviders(<EditorSidebarSelectedComponent {...props} />);
+    return { props, user };
+};
+
+describe("EditorSidebarSelectedComponent — new click handlers", () => {
+    describe("handleAssetNameClick", () => {
+        it("clicking an asset name calls handleAssetNameClick with the asset", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("DB Server"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledOnce();
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[0]);
+        });
+
+        it("clicking a different asset passes the correct asset", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("Web App"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[1]);
+        });
+    });
+
+    describe("handlePointOfAttackLabelClick", () => {
+        it("clicking a checked POA label calls handlePointOfAttackLabelClick with the POA id and component id", async () => {
+            const poa = createPointOfAttack({ id: "poa-ui", type: POINTS_OF_ATTACK.USER_INTERFACE });
+            const component = createSystemComponent({ id: "comp-1", pointsOfAttack: [poa] });
+
+            const { props, user } = setup({ selectedComponent: component });
+
+            // The label text comes from common translations: "User Interface"
+            await user.click(screen.getByText("User Interface"));
+
+            expect(props.handlePointOfAttackLabelClick).toHaveBeenCalledOnce();
+            expect(props.handlePointOfAttackLabelClick).toHaveBeenCalledWith("poa-ui", "comp-1");
+        });
+
+        it("clicking a POA label when the POA is NOT checked does not call handlePointOfAttackLabelClick", async () => {
+            // Component with no pointsOfAttack means no currPointOfAttack for any type
+            const component = createSystemComponent({ pointsOfAttack: [] });
+
+            const { props, user } = setup({ selectedComponent: component });
+
+            // The label still renders (as an unchecked switch label)
+            await user.click(screen.getByText("User Interface"));
+
+            expect(props.handlePointOfAttackLabelClick).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("handleSelectConnectedComponent", () => {
+        it("clicking a connected component name calls handleSelectConnectedComponent with the correct ids", async () => {
+            const connectedComponents: ConnectionEndpointWithComponent[] = [
+                {
+                    id: "comp-2",
+                    anchor: AnchorOrientation.left,
+                    type: STANDARD_COMPONENT_TYPES.SERVER,
+                    communicationInterfaceId: "ci-1",
+                    component: {
+                        id: "comp-2",
+                        name: "Backend Server",
+                        type: STANDARD_COMPONENT_TYPES.SERVER,
+                        x: 0,
+                        y: 0,
+                        gridX: 0,
+                        gridY: 0,
+                        width: 100,
+                        height: 100,
+                        selected: false,
+                        projectId: 1,
+                        symbol: null,
+                    },
+                },
+            ];
+
+            const { props, user } = setup({ connectedComponents });
+
+            await user.click(screen.getByTestId("connected-component-name"));
+
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledOnce();
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledWith("comp-2", "ci-1");
+        });
+
+        it("passes null communicationInterfaceId when connection has none", async () => {
+            const connectedComponents: ConnectionEndpointWithComponent[] = [
+                {
+                    id: "comp-3",
+                    anchor: AnchorOrientation.right,
+                    type: STANDARD_COMPONENT_TYPES.DATABASE,
+                    communicationInterfaceId: null,
+                    component: {
+                        id: "comp-3",
+                        name: "Main DB",
+                        type: STANDARD_COMPONENT_TYPES.DATABASE,
+                        x: 0,
+                        y: 0,
+                        gridX: 0,
+                        gridY: 0,
+                        width: 100,
+                        height: 100,
+                        selected: false,
+                        projectId: 1,
+                        symbol: null,
+                    },
+                },
+            ];
+
+            const { props, user } = setup({ connectedComponents });
+
+            await user.click(screen.getByText("Main DB"));
+
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledWith("comp-3", null);
+        });
+    });
+
+    describe("communication interface items", () => {
+        const communicationInterfaces: SystemCommunicationInterface[] = [
+            {
+                id: "ci-1",
+                name: "API Gateway",
+                icon: null,
+                type: "REST",
+                projectId: 1,
+                componentId: "comp-1",
+                componentName: "Test Component",
+            },
+        ];
+
+        const componentWithInterfaces = createSystemComponent({ communicationInterfaces });
+
+        it("clicking an interface name calls handleSelectConnectedComponent with component and interface ids", async () => {
+            const { props, user } = setup({ selectedComponent: componentWithInterfaces });
+
+            await user.click(screen.getByText("API Gateway"));
+
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledOnce();
+            expect(props.handleSelectConnectedComponent).toHaveBeenCalledWith("comp-1", "ci-1");
+        });
+
+        it("clicking the edit icon shows a text input for renaming", async () => {
+            const { user } = setup({ selectedComponent: componentWithInterfaces });
+
+            expect(screen.getByText("API Gateway")).toBeInTheDocument();
+
+            const editIcon = screen.getByTestId("EditIcon");
+            await user.click(editIcon);
+
+            // The interface name should now be in a textbox, not as plain text
+            const textboxes = screen.getAllByRole("textbox");
+            const interfaceInput = textboxes.find((input) => (input as HTMLInputElement).value === "API Gateway");
+            expect(interfaceInput).toBeDefined();
+            expect(screen.queryByText("API Gateway")).not.toBeInTheDocument();
+        });
+
+        it("blurring the text input exits edit mode and shows clickable text again", async () => {
+            const { user } = setup({ selectedComponent: componentWithInterfaces });
+
+            await user.click(screen.getByTestId("EditIcon"));
+
+            await user.tab(); // moves focus away
+
+            expect(screen.getByText("API Gateway")).toBeInTheDocument();
+        });
+
+        it("pressing Enter in the text input exits edit mode", async () => {
+            const { user } = setup({ selectedComponent: componentWithInterfaces });
+
+            await user.click(screen.getByTestId("EditIcon"));
+
+            await user.keyboard("{Enter}");
+
+            expect(screen.getByText("API Gateway")).toBeInTheDocument();
+        });
+
+        it("edit and delete icons are not rendered for non-editor roles", () => {
+            setup({
+                selectedComponent: componentWithInterfaces,
+                userRole: USER_ROLES.VIEWER,
+            });
+
+            expect(screen.queryByTestId("EditIcon")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("DeleteIcon")).not.toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { PointOfAttackSwitch } from "./point-of-attack-switch.component";
 import { POINTS_OF_ATTACK } from "../../../api/types/points-of-attack.types";
 import { POA_COLORS } from "../../colors/pointsOfAttack.colors";
-import { Delete } from "@mui/icons-material";
+import { Delete, Edit } from "@mui/icons-material";
 import { TextField } from "../textfield.component";
 import { SearchField } from "../search-field.component";
 import { ToggleButtons } from "../toggle-buttons.component";
@@ -22,7 +22,7 @@ import type {
 
 const muiIconMap = MuiIcons as Record<string, ElementType>;
 
-interface EditorSidebarSelectedComponentProps {
+export interface EditorSidebarSelectedComponentProps {
     selectedComponent: AugmentedSystemComponent | undefined;
     handleDeleteComponent: () => void;
     handleOnNameChange: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -48,6 +48,9 @@ interface EditorSidebarSelectedComponentProps {
         interfaceName: string | null,
         doCloseSidebar?: boolean
     ) => void;
+    handlePointOfAttackLabelClick: (pointOfAttackId: string, componentId?: string) => void;
+    handleAssetNameClick: (asset: Asset) => void;
+    handleSelectConnectedComponent: (componentId: string, communicationInterfaceId?: string | null) => void;
 }
 
 const getSortValueForPointOfAttack = (pointOfAttack: POINTS_OF_ATTACK) => {
@@ -81,12 +84,16 @@ export const EditorSidebarSelectedComponent = ({
     handleDeleteConnectionBetweenComponents,
     handleChangeCommunicationInterfaceName,
     handleDeleteCommunicationInterface,
+    handlePointOfAttackLabelClick,
+    handleAssetNameClick,
+    handleSelectConnectedComponent,
 }: EditorSidebarSelectedComponentProps) => {
     const { t } = useTranslation("editorPage");
     const [communicationInterfaces, setCommunicationInterfaces] = useState<SystemCommunicationInterface[]>([]);
     const [localName, setLocalName] = useState<string>("");
     const [localDescription, setLocalDescription] = useState<string>("");
     const [interfaceNames, setInterfaceNames] = useState<Record<string, string>>({});
+    const [editingInterfaceId, setEditingInterfaceId] = useState<string | null>(null);
 
     const debouncedHandleNameChange = useDebounce(handleOnNameChange);
     const debouncedHandleDescriptionChange = useDebounce(handleOnDescriptionChange);
@@ -132,110 +139,32 @@ export const EditorSidebarSelectedComponent = ({
     }
 
     return (
-        <>
-            <Box>
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#f2f4f500",
-                        borderRadius: 15,
-                        paddingLeft: 0,
-                        paddingRight: 0,
-                        alignItems: "flex-start",
-                        justifyContent: "space-between",
-                        marginBottom: "-10px",
-                    }}
-                >
-                    <TextField
-                        value={localName}
-                        onChange={handleLocalNameChange}
-                        autoFocus={false}
-                        // Don't delete the whole Component if Delete is pressed
-                        onKeyUp={(event) => {
-                            if (event.key === "Delete") {
-                                event.stopPropagation();
-                            }
-                        }}
-                        sx={{
-                            border: "none !important",
-                            width: "82.5%",
-                            "& .MuiInputBase-root": {
-                                borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
-                            },
-                            "*": {
-                                border: "none !important",
-                                padding: "0 !important",
-                                borderRadius: "0 !important",
-                                fontWeight: "bold",
-                            },
-                            "& .Mui-focused": {
-                                borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                            },
-                            input: {
-                                fontSize: "0.875rem !important",
-                                width: "100% !important",
-                            },
-                            color: "text.primary !important",
-                            padding: "0 !important",
-                        }}
-                    />
-                    {checkUserRole(userRole, USER_ROLES.EDITOR) && (
-                        <IconButton
-                            onClick={handleDeleteComponent}
-                            sx={{
-                                "&:hover": {
-                                    color: "#ef5350",
-                                    backgroundColor: "background.paperIntransparent",
-                                },
-                                marginTop: -1,
-                            }}
-                        >
-                            <Delete sx={{ fontSize: 18 }} />
-                        </IconButton>
-                    )}
-                </Box>
-
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
-                    }}
-                >
-                    <Typography
-                        sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
-                        }}
-                    >
-                        {t("sidebar.description.title")}
-                    </Typography>
-                </Box>
+        <Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#f2f4f500",
+                    borderRadius: 15,
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                    alignItems: "flex-start",
+                    justifyContent: "space-between",
+                    marginBottom: "-10px",
+                }}
+            >
                 <TextField
-                    value={localDescription}
-                    onChange={handleLocalDescriptionChange}
+                    value={localName}
+                    onChange={handleLocalNameChange}
+                    autoFocus={false}
+                    // Don't delete the whole Component if Delete is pressed
                     onKeyUp={(event) => {
                         if (event.key === "Delete") {
                             event.stopPropagation();
                         }
                     }}
-                    autoFocus={false}
-                    multiline
-                    minRows={1} // Start with the height of just 1 line
-                    maxRows={Infinity} // Allow it to grow as needed
                     sx={{
                         border: "none !important",
-                        width: "100%",
+                        width: "82.5%",
                         "& .MuiInputBase-root": {
                             borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
                         },
@@ -243,196 +172,279 @@ export const EditorSidebarSelectedComponent = ({
                             border: "none !important",
                             padding: "0 !important",
                             borderRadius: "0 !important",
+                            fontWeight: "bold",
                         },
                         "& .Mui-focused": {
                             borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
                         },
-                        textarea: {
+                        input: {
                             fontSize: "0.875rem !important",
                             width: "100% !important",
-                            lineHeight: "1.5 !important",
                         },
                         color: "text.primary !important",
                         padding: "0 !important",
                     }}
                 />
-
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
-                    }}
-                >
-                    <Typography
+                {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                    <IconButton
+                        onClick={handleDeleteComponent}
                         sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
+                            "&:hover": {
+                                color: "#ef5350",
+                                backgroundColor: "background.paperIntransparent",
+                            },
+                            marginTop: -1,
                         }}
                     >
-                        {t("sidebar.pointsofattack.title")}
-                    </Typography>
-                </Box>
-                <FormGroup sx={{ marginLeft: 0.5 }}>
-                    {Object.values(POINTS_OF_ATTACK)
-                        .filter((type) => type !== POINTS_OF_ATTACK.COMMUNICATION_INTERFACES)
-                        .filter((type) => {
-                            switch (selectedComponent?.type) {
-                                case "USERS":
-                                    return (
-                                        type === POINTS_OF_ATTACK.USER_BEHAVIOUR &&
-                                        // @ts-expect-error TODO: Bug? Should it be type !== POINTS_OF_ATTACK.USER_BEHAVIOUR or || instead of &&?
-                                        type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
-                                    );
-                                case "CLIENT":
+                        <Delete sx={{ fontSize: 18 }} />
+                    </IconButton>
+                )}
+            </Box>
+
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.description.title")}
+                </Typography>
+            </Box>
+            <TextField
+                value={localDescription}
+                onChange={handleLocalDescriptionChange}
+                onKeyUp={(event) => {
+                    if (event.key === "Delete") {
+                        event.stopPropagation();
+                    }
+                }}
+                autoFocus={false}
+                multiline
+                minRows={1} // Start with the height of just 1 line
+                maxRows={Infinity} // Allow it to grow as needed
+                sx={{
+                    border: "none !important",
+                    width: "100%",
+                    "& .MuiInputBase-root": {
+                        borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
+                    },
+                    "*": {
+                        border: "none !important",
+                        padding: "0 !important",
+                        borderRadius: "0 !important",
+                    },
+                    "& .Mui-focused": {
+                        borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
+                    },
+                    textarea: {
+                        fontSize: "0.875rem !important",
+                        width: "100% !important",
+                        lineHeight: "1.5 !important",
+                    },
+                    color: "text.primary !important",
+                    padding: "0 !important",
+                }}
+            />
+
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.pointsofattack.title")}
+                </Typography>
+            </Box>
+            <FormGroup sx={{ marginLeft: 0.5 }}>
+                {Object.values(POINTS_OF_ATTACK)
+                    .filter((type) => type !== POINTS_OF_ATTACK.COMMUNICATION_INTERFACES)
+                    .filter((type) => {
+                        switch (selectedComponent?.type) {
+                            case "USERS":
+                                return (
+                                    type === POINTS_OF_ATTACK.USER_BEHAVIOUR &&
+                                    // @ts-expect-error TODO: Bug? Should it be type !== POINTS_OF_ATTACK.USER_BEHAVIOUR or || instead of &&?
+                                    type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
+                                );
+                            case "CLIENT":
+                                return (
+                                    type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
+                                    type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
+                                );
+                            case "SERVER":
+                                return (
+                                    type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
+                                    type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
+                                );
+                            case "DATABASE":
+                                return (
+                                    type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
+                                    type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
+                                );
+                            case "COMMUNICATION_INFRASTRUCTURE":
+                                return type === POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE;
+                            default:
+                                // For custom components (where type is an integer)
+                                if (Number.isInteger(selectedComponent?.type)) {
                                     return (
                                         type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
                                         type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
                                     );
-                                case "SERVER":
-                                    return (
-                                        type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
-                                        type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
-                                    );
-                                case "DATABASE":
-                                    return (
-                                        type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
-                                        type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
-                                    );
-                                case "COMMUNICATION_INFRASTRUCTURE":
-                                    return type === POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE;
-                                default:
-                                    // For custom components (where type is an integer)
-                                    if (Number.isInteger(selectedComponent?.type)) {
-                                        return (
-                                            type !== POINTS_OF_ATTACK.USER_BEHAVIOUR &&
-                                            type !== POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE
-                                        );
+                                }
+                                return true;
+                        }
+                    })
+                    .sort((a, b) => {
+                        return getSortValueForPointOfAttack(a) < getSortValueForPointOfAttack(b) ? -1 : 1;
+                    })
+                    .map((type, i) => {
+                        const currPointOfAttack = selectedComponent?.pointsOfAttack?.find((item) => item.type === type);
+                        return (
+                            <PointOfAttackSwitch
+                                key={i}
+                                label={
+                                    <Typography
+                                        component="span"
+                                        data-testid={`poa-switch-${type}`}
+                                        sx={{
+                                            fontSize: "0.75rem",
+                                            fontWeight: "bold",
+                                        }}
+                                    >
+                                        {t(`pointsOfAttackList.${type}`)}
+                                    </Typography>
+                                }
+                                color={POA_COLORS[type].normal}
+                                onChange={(e) => handleChangePointOfAttack(e, type, currPointOfAttack)}
+                                checked={currPointOfAttack !== undefined}
+                                onLabelClick={() => {
+                                    if (currPointOfAttack) {
+                                        handlePointOfAttackLabelClick(currPointOfAttack.id, selectedComponent?.id);
                                     }
-                                    return true;
-                            }
-                        })
-                        .sort((a, b) => {
-                            return getSortValueForPointOfAttack(a) < getSortValueForPointOfAttack(b) ? -1 : 1;
-                        })
-                        .map((type, i) => {
-                            const currPointOfAttack = selectedComponent?.pointsOfAttack?.find(
-                                (item) => item.type === type
-                            );
-                            return (
-                                <PointOfAttackSwitch
-                                    key={i}
-                                    label={
-                                        <Typography
-                                            sx={{
-                                                fontSize: "0.75rem",
-                                                fontWeight: "bold",
-                                            }}
-                                        >
-                                            {t(`pointsOfAttackList.${type}`)}
-                                        </Typography>
-                                    }
-                                    color={POA_COLORS[type].normal}
-                                    onChange={(e) => handleChangePointOfAttack(e, type, currPointOfAttack)}
-                                    checked={currPointOfAttack !== undefined}
-                                />
-                            );
-                        })}
-                </FormGroup>
-                {/* Display the communication interfaces section */}
-                {communicationInterfaces.length > 0 && (
-                    <>
+                                }}
+                            />
+                        );
+                    })}
+            </FormGroup>
+            {/* Display the communication interfaces section */}
+            {communicationInterfaces.length > 0 && (
+                <>
+                    <Box
+                        sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            borderRadius: 15,
+                            height: "31px",
+                            paddingLeft: 8,
+                            paddingRight: 0,
+                            justifyContent: "space-between",
+                            marginTop: 4,
+                            marginLeft: -8,
+                            marginRight: -8,
+                            padding: 0,
+                            margin: 0,
+                            marginBottom: 1,
+                        }}
+                    >
                         <Box
                             sx={{
                                 display: "flex",
                                 alignItems: "center",
-                                borderRadius: 15,
-                                height: "31px",
-                                paddingLeft: 8,
-                                paddingRight: 0,
-                                justifyContent: "space-between",
-                                marginTop: 4,
-                                marginLeft: -8,
-                                marginRight: -8,
-                                padding: 0,
-                                margin: 0,
-                                marginBottom: 1,
                             }}
                         >
                             <Box
                                 sx={{
-                                    display: "flex",
-                                    alignItems: "center",
+                                    backgroundColor: POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INTERFACES].normal,
+                                    width: "16px",
+                                    height: "16px",
+                                    marginLeft: 1,
+                                    borderRadius: 50,
+                                }}
+                            ></Box>
+                            <Typography
+                                sx={{
+                                    fontWeight: "bold",
+                                    fontSize: "0.75rem",
+                                    color: "text.primary",
+                                    marginLeft: 2,
                                 }}
                             >
+                                Communication Interfaces
+                            </Typography>
+                        </Box>
+                    </Box>
+                    <Box sx={{ paddingLeft: 4 }}>
+                        {communicationInterfaces.map((communicationInterface, index) => {
+                            const IconComponent =
+                                communicationInterface.icon != null
+                                    ? muiIconMap[communicationInterface.icon]
+                                    : undefined;
+
+                            return (
                                 <Box
+                                    key={index}
                                     sx={{
-                                        backgroundColor: POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INTERFACES].normal,
-                                        width: "16px",
-                                        height: "16px",
-                                        marginLeft: 1,
-                                        borderRadius: 50,
-                                    }}
-                                ></Box>
-                                <Typography
-                                    sx={{
-                                        fontWeight: "bold",
-                                        fontSize: "0.75rem",
-                                        color: "text.primary",
-                                        marginLeft: 2,
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "space-between",
+                                        marginBottom: 0,
                                     }}
                                 >
-                                    Communication Interfaces
-                                </Typography>
-                            </Box>
-                        </Box>
-                        <Box sx={{ paddingLeft: 4 }}>
-                            {communicationInterfaces.map((communicationInterface, index) => {
-                                const IconComponent =
-                                    communicationInterface.icon != null
-                                        ? muiIconMap[communicationInterface.icon]
-                                        : undefined;
-
-                                return (
-                                    <Box
-                                        key={index}
+                                    <ListItemAvatar
                                         sx={{
-                                            display: "flex",
-                                            alignItems: "center",
-                                            justifyContent: "space-between",
-                                            marginBottom: 0,
+                                            marginTop: "-8px",
+                                            minWidth: "0px",
+                                            marginRight: "13px",
                                         }}
                                     >
-                                        <ListItemAvatar
+                                        <Avatar
                                             sx={{
-                                                marginTop: "-8px",
-                                                minWidth: "0px",
-                                                marginRight: "13px",
+                                                width: 20,
+                                                height: 20,
+                                                fontSize: 15,
+                                                padding: 0.25,
+                                                bgcolor: "transparent",
+                                                color: "primary.main",
                                             }}
                                         >
-                                            <Avatar
-                                                sx={{
-                                                    width: 20,
-                                                    height: 20,
-                                                    fontSize: 15,
-                                                    padding: 0.25,
-                                                    bgcolor: "transparent",
-                                                    color: "primary.main",
-                                                }}
-                                            >
-                                                {IconComponent ? <IconComponent /> : null}
-                                            </Avatar>
-                                        </ListItemAvatar>
+                                            {IconComponent ? <IconComponent /> : null}
+                                        </Avatar>
+                                    </ListItemAvatar>
+                                    {editingInterfaceId === communicationInterface.id ? (
                                         <TextField
                                             value={interfaceNames[communicationInterface.id] || ""}
                                             onChange={(event) =>
@@ -442,17 +454,21 @@ export const EditorSidebarSelectedComponent = ({
                                                     event.target.value
                                                 )
                                             }
+                                            onBlur={() => setEditingInterfaceId(null)}
                                             onKeyUp={(event) => {
+                                                if (event.key === "Enter") {
+                                                    setEditingInterfaceId(null);
+                                                }
                                                 if (event.key === "Delete") {
                                                     event.stopPropagation();
                                                 }
                                             }}
-                                            autoFocus={false}
+                                            autoFocus
                                             sx={{
                                                 border: "none !important",
                                                 width: "82.5%",
                                                 "& .MuiInputBase-root": {
-                                                    borderBottom: "1px solid rgba(35, 60, 87, 0) !important",
+                                                    borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
                                                 },
                                                 "*": {
                                                     border: "none !important",
@@ -460,167 +476,177 @@ export const EditorSidebarSelectedComponent = ({
                                                     borderRadius: "0 !important",
                                                     fontWeight: "bold",
                                                 },
-                                                "& .Mui-focused": {
-                                                    borderBottom: "1px solid rgba(35, 60, 87, 1) !important",
-                                                },
                                                 input: {
-                                                    fontSize: "0.875rem !important",
+                                                    fontSize: "0.75rem !important",
                                                     width: "100% !important",
                                                 },
                                                 color: "text.primary !important",
                                                 padding: "0 !important",
                                             }}
                                         />
-                                        <IconButton
+                                    ) : (
+                                        <Typography
                                             onClick={() =>
-                                                handleDeleteCommunicationInterface(
+                                                handleSelectConnectedComponent(
                                                     selectedComponent.id,
-                                                    communicationInterface.id,
-                                                    communicationInterface.name
+                                                    communicationInterface.id
                                                 )
                                             }
                                             sx={{
-                                                "&:hover": {
-                                                    color: "#ef5350",
-                                                    backgroundColor: "background.paperIntransparent",
-                                                },
+                                                fontSize: "0.75rem",
+                                                fontWeight: "bold",
+                                                cursor: "pointer",
+                                                width: "82.5%",
+                                                "&:hover": { textDecoration: "underline" },
                                             }}
                                         >
-                                            <Delete sx={{ fontSize: 18 }} />
-                                        </IconButton>
+                                            {interfaceNames[communicationInterface.id] || ""}
+                                        </Typography>
+                                    )}
+                                    <Box sx={{ display: "flex", alignItems: "center" }}>
+                                        {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                                            <IconButton
+                                                onClick={() => setEditingInterfaceId(communicationInterface.id)}
+                                                sx={{
+                                                    "&:hover": {
+                                                        backgroundColor: "background.paperIntransparent",
+                                                    },
+                                                }}
+                                            >
+                                                <Edit sx={{ fontSize: 18 }} />
+                                            </IconButton>
+                                        )}
+                                        {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                                            <IconButton
+                                                onClick={() =>
+                                                    handleDeleteCommunicationInterface(
+                                                        selectedComponent.id,
+                                                        communicationInterface.id,
+                                                        communicationInterface.name
+                                                    )
+                                                }
+                                                sx={{
+                                                    "&:hover": {
+                                                        color: "#ef5350",
+                                                        backgroundColor: "background.paperIntransparent",
+                                                    },
+                                                }}
+                                            >
+                                                <Delete sx={{ fontSize: 18 }} />
+                                            </IconButton>
+                                        )}
                                     </Box>
-                                );
-                            })}
-                        </Box>
-                    </>
-                )}
+                                </Box>
+                            );
+                        })}
+                    </Box>
+                </>
+            )}
 
-                <Box
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
                     sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
                     }}
                 >
-                    <Typography
-                        sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
-                        }}
-                    >
-                        {t("sidebar.assets.title")}
-                    </Typography>
-                </Box>
-                <Box>
-                    <SearchField
-                        sx={{
-                            marginBottom: 1,
-                            marginLeft: -0.5,
-                            width: "40%",
-                            height: "31px",
-                            borderRadius: 5,
-                        }}
-                        inputSx={{ fontSize: "0.75rem" }}
-                        //don't delete the whole Component if Delete is pressed
-                        onKeyUp={(event) => {
-                            if (event.key === "Delete") {
-                                event.stopPropagation();
-                            }
-                        }}
-                        value={assetSearchValue}
-                        onChange={handleAssetSearchChanged}
-                        data-testid="selected-component-asset-search-field"
-                    />
-                    {items
-                        .filter((item) => {
-                            const lcSearchValue = assetSearchValue.toLowerCase();
-                            return (
-                                assetSearchValue === "" ||
-                                item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
-                            );
-                        })
-                        .map((asset, index) => {
-                            let assetIsSetOnCommunicationInterfaces = false;
-                            return (
+                    {t("sidebar.assets.title")}
+                </Typography>
+            </Box>
+            <Box>
+                <SearchField
+                    sx={{
+                        marginBottom: 1,
+                        marginLeft: -0.5,
+                        width: "40%",
+                        height: "31px",
+                        borderRadius: 5,
+                    }}
+                    inputSx={{ fontSize: "0.75rem" }}
+                    //don't delete the whole Component if Delete is pressed
+                    onKeyUp={(event) => {
+                        if (event.key === "Delete") {
+                            event.stopPropagation();
+                        }
+                    }}
+                    value={assetSearchValue}
+                    onChange={handleAssetSearchChanged}
+                    data-testid="selected-component-asset-search-field"
+                />
+                {items
+                    .filter((item) => {
+                        const lcSearchValue = assetSearchValue.toLowerCase();
+                        return (
+                            assetSearchValue === "" ||
+                            item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
+                        );
+                    })
+                    .map((asset, index) => {
+                        let assetIsSetOnCommunicationInterfaces = false;
+                        return (
+                            <Box
+                                key={index}
+                                sx={{
+                                    display: "flex",
+                                    flexDirection: "row",
+                                    alignItems: "center",
+                                    marginBottom: 1,
+                                }}
+                            >
+                                <Typography
+                                    onClick={() => handleAssetNameClick(asset)}
+                                    sx={{
+                                        minWidth: "130px",
+                                        maxWidth: "130px",
+                                        color: "text.primary",
+                                        fontSize: "0.75rem",
+                                        fontWeight: "bold",
+                                        cursor: "pointer",
+                                        "&:hover": { textDecoration: "underline" },
+                                    }}
+                                    data-testid="selected-component-asset-search-results"
+                                >
+                                    {asset.name}
+                                </Typography>
                                 <Box
-                                    key={index}
                                     sx={{
                                         display: "flex",
                                         flexDirection: "row",
-                                        alignItems: "center",
-                                        marginBottom: 1,
+                                        minWidth: "104px",
                                     }}
                                 >
-                                    <Typography
-                                        sx={{
-                                            minWidth: "130px",
-                                            maxWidth: "130px",
-                                            color: "text.primary",
-                                            fontSize: "0.75rem",
-                                            fontWeight: "bold",
-                                        }}
-                                        data-testid="selected-component-asset-search-results"
-                                    >
-                                        {asset.name}
-                                    </Typography>
-                                    <Box
-                                        sx={{
-                                            display: "flex",
-                                            flexDirection: "row",
-                                            minWidth: "104px",
-                                        }}
-                                    >
-                                        {pointsOfAttackOfSelectedComponent
-                                            .sort((a, b) => b.type.localeCompare(a.type))
-                                            .map((pointOfAttack, pointOfAttackIndex) => {
-                                                if (
-                                                    !assetIsSetOnCommunicationInterfaces &&
-                                                    pointOfAttack.type === POINTS_OF_ATTACK.COMMUNICATION_INTERFACES
-                                                ) {
-                                                    assetIsSetOnCommunicationInterfaces = true;
-                                                    const communicationInterfaces =
-                                                        pointsOfAttackOfSelectedComponent.filter(
-                                                            (poa) =>
-                                                                poa.type === POINTS_OF_ATTACK.COMMUNICATION_INTERFACES
-                                                        );
-                                                    const setInterfaces = communicationInterfaces.filter((poa) =>
-                                                        poa.assets.includes(asset.id)
+                                    {pointsOfAttackOfSelectedComponent
+                                        .sort((a, b) => b.type.localeCompare(a.type))
+                                        .map((pointOfAttack, pointOfAttackIndex) => {
+                                            if (
+                                                !assetIsSetOnCommunicationInterfaces &&
+                                                pointOfAttack.type === POINTS_OF_ATTACK.COMMUNICATION_INTERFACES
+                                            ) {
+                                                assetIsSetOnCommunicationInterfaces = true;
+                                                const communicationInterfaces =
+                                                    pointsOfAttackOfSelectedComponent.filter(
+                                                        (poa) => poa.type === POINTS_OF_ATTACK.COMMUNICATION_INTERFACES
                                                     );
-                                                    if (setInterfaces.length > 0) {
-                                                        return (
-                                                            <Box key={pointOfAttackIndex}>
-                                                                <Box
-                                                                    sx={{
-                                                                        backgroundColor:
-                                                                            POA_COLORS[pointOfAttack.type].normal,
-                                                                        width: "16px",
-                                                                        height: "16px",
-                                                                        marginLeft: 1,
-                                                                        borderRadius: 50,
-                                                                        clipPath:
-                                                                            setInterfaces.length ===
-                                                                            communicationInterfaces.length
-                                                                                ? "circle(50%)"
-                                                                                : "polygon(0% 0%, 50% 0%, 50% 100%, 0% 100%)",
-                                                                    }}
-                                                                ></Box>
-                                                            </Box>
-                                                        );
-                                                    }
-                                                } else if (
-                                                    pointOfAttack.type !== POINTS_OF_ATTACK.COMMUNICATION_INTERFACES &&
-                                                    pointOfAttack.assets.includes(asset.id)
-                                                ) {
+                                                const setInterfaces = communicationInterfaces.filter((poa) =>
+                                                    poa.assets.includes(asset.id)
+                                                );
+                                                if (setInterfaces.length > 0) {
                                                     return (
                                                         <Box key={pointOfAttackIndex}>
                                                             <Box
@@ -631,147 +657,173 @@ export const EditorSidebarSelectedComponent = ({
                                                                     height: "16px",
                                                                     marginLeft: 1,
                                                                     borderRadius: 50,
+                                                                    clipPath:
+                                                                        setInterfaces.length ===
+                                                                        communicationInterfaces.length
+                                                                            ? "circle(50%)"
+                                                                            : "polygon(0% 0%, 50% 0%, 50% 100%, 0% 100%)",
                                                                 }}
                                                             ></Box>
                                                         </Box>
                                                     );
                                                 }
-                                                return null;
-                                            })}
-                                    </Box>
-                                    <Box
-                                        sx={{
-                                            display: "flex",
-                                            flexDirection: "row",
-                                            marginLeft: "auto",
-                                        }}
-                                    >
-                                        <ToggleButtons
-                                            value={(() => {
-                                                // Count how many POAs (including com interfaces) have this asset
-                                                const totalAssetOccurrences = pointsOfAttackOfSelectedComponent.reduce(
-                                                    (count, poa) => count + (poa.assets.includes(asset.id) ? 1 : 0),
-                                                    0
+                                            } else if (
+                                                pointOfAttack.type !== POINTS_OF_ATTACK.COMMUNICATION_INTERFACES &&
+                                                pointOfAttack.assets.includes(asset.id)
+                                            ) {
+                                                return (
+                                                    <Box key={pointOfAttackIndex}>
+                                                        <Box
+                                                            sx={{
+                                                                backgroundColor: POA_COLORS[pointOfAttack.type].normal,
+                                                                width: "16px",
+                                                                height: "16px",
+                                                                marginLeft: 1,
+                                                                borderRadius: 50,
+                                                            }}
+                                                        ></Box>
+                                                    </Box>
                                                 );
-
-                                                if (totalAssetOccurrences === 0) {
-                                                    return "unsetAll";
-                                                }
-
-                                                if (
-                                                    totalAssetOccurrences === pointsOfAttackOfSelectedComponent.length
-                                                ) {
-                                                    return "setAll";
-                                                }
-
-                                                return "";
-                                            })()}
-                                            buttonProps={{
-                                                width: "87px",
-                                            }}
-                                            buttons={[
-                                                {
-                                                    value: "setAll",
-                                                    text: t("setAllBtn"),
-                                                    onClick: (e) => handleAddAssetToAllPointsOfAttack(e, asset),
-                                                },
-                                                {
-                                                    value: "unsetAll",
-                                                    text: t("unsetAllBtn"),
-                                                    onClick: (e) => handleRemoveAssetFromAllPointsOfAttack(e, asset),
-                                                },
-                                            ]}
-                                        />
-                                    </Box>
+                                            }
+                                            return null;
+                                        })}
                                 </Box>
-                            );
-                        })}
-                </Box>
-                <Box
-                    sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
-                    }}
-                >
-                    <Typography
-                        sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
-                        }}
-                    >
-                        {t("sidebar.connected_components.title")}
-                    </Typography>
-                </Box>
-                <Box>
-                    {connectedComponents.map((connection, index) => {
-                        const connectedComponent = connection.component;
-                        if (!connectedComponent) {
-                            return null;
-                        }
-
-                        const communicationInterfaceName =
-                            selectedComponent.type === "COMMUNICATION_INFRASTRUCTURE"
-                                ? connectedComponent.communicationInterfaces?.find(
-                                      (communicationInterface) =>
-                                          communicationInterface.id === connection.communicationInterfaceId
-                                  )?.name
-                                : undefined;
-
-                        const label =
-                            connectedComponent.name +
-                            (communicationInterfaceName ? ` > ${communicationInterfaceName}` : "");
-
-                        return (
-                            <Box
-                                key={index}
-                                sx={{
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "space-between",
-                                    marginBottom: 1,
-                                }}
-                            >
-                                <Typography
+                                <Box
                                     sx={{
-                                        fontSize: "0.75rem",
-                                        fontWeight: "bold",
-                                        color: "text.primary",
+                                        display: "flex",
+                                        flexDirection: "row",
+                                        marginLeft: "auto",
                                     }}
                                 >
-                                    {label}
-                                </Typography>
-                                <IconButton
-                                    onClick={() =>
-                                        handleDeleteConnectionBetweenComponents(
-                                            selectedComponent.id,
-                                            connectedComponent.id
-                                        )
-                                    }
-                                    sx={{
-                                        "&:hover": {
-                                            color: "#ef5350",
-                                            backgroundColor: "background.paperIntransparent",
-                                        },
-                                    }}
-                                >
-                                    <Delete sx={{ fontSize: 18 }} />
-                                </IconButton>
+                                    <ToggleButtons
+                                        value={(() => {
+                                            // Count how many POAs (including com interfaces) have this asset
+                                            const totalAssetOccurrences = pointsOfAttackOfSelectedComponent.reduce(
+                                                (count, poa) => count + (poa.assets.includes(asset.id) ? 1 : 0),
+                                                0
+                                            );
+
+                                            if (totalAssetOccurrences === 0) {
+                                                return "unsetAll";
+                                            }
+
+                                            if (totalAssetOccurrences === pointsOfAttackOfSelectedComponent.length) {
+                                                return "setAll";
+                                            }
+
+                                            return "";
+                                        })()}
+                                        buttonProps={{
+                                            width: "87px",
+                                        }}
+                                        buttons={[
+                                            {
+                                                value: "setAll",
+                                                text: t("setAllBtn"),
+                                                onClick: (e) => handleAddAssetToAllPointsOfAttack(e, asset),
+                                            },
+                                            {
+                                                value: "unsetAll",
+                                                text: t("unsetAllBtn"),
+                                                onClick: (e) => handleRemoveAssetFromAllPointsOfAttack(e, asset),
+                                            },
+                                        ]}
+                                    />
+                                </Box>
                             </Box>
                         );
                     })}
-                </Box>
             </Box>
-        </>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
+                    }}
+                >
+                    {t("sidebar.connected_components.title")}
+                </Typography>
+            </Box>
+            <Box>
+                {connectedComponents.map((connection, index) => {
+                    const connectedComponent = connection.component;
+                    if (!connectedComponent) {
+                        return null;
+                    }
+
+                    const communicationInterfaceName =
+                        selectedComponent.type === "COMMUNICATION_INFRASTRUCTURE"
+                            ? connectedComponent.communicationInterfaces?.find(
+                                  (communicationInterface) =>
+                                      communicationInterface.id === connection.communicationInterfaceId
+                              )?.name
+                            : undefined;
+
+                    const label =
+                        connectedComponent.name +
+                        (communicationInterfaceName ? ` > ${communicationInterfaceName}` : "");
+
+                    return (
+                        <Box
+                            key={index}
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "space-between",
+                                marginBottom: 1,
+                            }}
+                        >
+                            <Typography
+                                onClick={() =>
+                                    handleSelectConnectedComponent(
+                                        connectedComponent.id,
+                                        connection.communicationInterfaceId
+                                    )
+                                }
+                                sx={{
+                                    fontSize: "0.75rem",
+                                    fontWeight: "bold",
+                                    color: "text.primary",
+                                    cursor: "pointer",
+                                    "&:hover": { textDecoration: "underline" },
+                                }}
+                                data-testid="connected-component-name"
+                            >
+                                {label}
+                            </Typography>
+                            <IconButton
+                                onClick={() =>
+                                    handleDeleteConnectionBetweenComponents(selectedComponent.id, connectedComponent.id)
+                                }
+                                sx={{
+                                    "&:hover": {
+                                        color: "#ef5350",
+                                        backgroundColor: "background.paperIntransparent",
+                                    },
+                                }}
+                            >
+                                <Delete sx={{ fontSize: 18 }} />
+                            </IconButton>
+                        </Box>
+                    );
+                })}
+            </Box>
+        </Box>
     );
 };

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.test.tsx
@@ -1,0 +1,86 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+    EditorSidebarSelectedPointOfAttack,
+    type EditorSidebarSelectedPointOfAttackProps,
+} from "./editor-sidebar-selected-point-of-attack.component";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createSystemComponent, createPointOfAttack } from "#test-utils/builders.ts";
+
+const setup = (propsOverride: Partial<EditorSidebarSelectedPointOfAttackProps> = {}) => {
+    const props = {
+        selectedComponent: createSystemComponent({ name: "My Component" }),
+        selectedPointOfAttack: createPointOfAttack(),
+        assetSearchValue: "",
+        handleAssetSearchChanged: vi.fn(),
+        items: [
+            createAsset({ id: 1, name: "DB Server", confidentiality: 3, integrity: 3, availability: 2 }),
+            createAsset({ id: 2, name: "Web App", confidentiality: 1, integrity: 2, availability: 3 }),
+        ],
+        handleOnAssetChanged: vi.fn(),
+        handleAssetNameClick: vi.fn(),
+        handleComponentBreadcrumbClick: vi.fn(),
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    renderWithProviders(<EditorSidebarSelectedPointOfAttack {...props} />);
+    return { props, user };
+};
+
+describe("EditorSidebarSelectedPointOfAttack", () => {
+    describe("breadcrumb click", () => {
+        it("calls handleComponentBreadcrumbClick when the component name is clicked", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("My Component"));
+
+            expect(props.handleComponentBreadcrumbClick).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("asset name click", () => {
+        it("calls handleAssetNameClick with the correct asset", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("DB Server"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledOnce();
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[0]);
+        });
+
+        it("calls handleAssetNameClick with a different asset", async () => {
+            const { props, user } = setup();
+
+            await user.click(screen.getByText("Web App"));
+
+            expect(props.handleAssetNameClick).toHaveBeenCalledWith(props.items[1]);
+        });
+    });
+
+    describe("Popper hover tooltip", () => {
+        it("shows CIA values when hovering over an asset name", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("DB Server"));
+
+            expect(screen.getByText("(C 3 / I 3 / A 2)")).toBeInTheDocument();
+        });
+
+        it("hides CIA tooltip when mouse leaves the asset name", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("DB Server"));
+            await user.unhover(screen.getByText("DB Server"));
+
+            expect(screen.queryByText("(C 3 / I 3 / A 2)")).not.toBeInTheDocument();
+        });
+
+        it("shows correct CIA values for a different asset", async () => {
+            const { user } = setup();
+
+            await user.hover(screen.getByText("Web App"));
+
+            expect(screen.getByText("(C 1 / I 2 / A 3)")).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
@@ -1,19 +1,22 @@
-import { Typography } from "@mui/material";
+import { Popper, Typography } from "@mui/material";
 import { Box } from "@mui/system";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EditorSidebarAssetList } from "./editor-sidebar-asset-list.component";
 import { SearchField } from "../search-field.component";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import type { Asset } from "#api/types/asset.types.ts";
 import type { SystemComponent, SystemPointOfAttack } from "#api/types/system.types.ts";
 
-interface EditorSidebarSelectedPointOfAttackProps {
+export interface EditorSidebarSelectedPointOfAttackProps {
     selectedComponent: SystemComponent & { pointsOfAttack?: SystemPointOfAttack[] };
     selectedPointOfAttack: SystemPointOfAttack;
     assetSearchValue: string;
     handleAssetSearchChanged: (event: ChangeEvent<HTMLInputElement>) => void;
     items: Asset[];
     handleOnAssetChanged: (event: ChangeEvent<HTMLInputElement>, asset: Asset) => void;
+    handleAssetNameClick: (asset: Asset) => void;
+    handleComponentBreadcrumbClick: () => void;
 }
 
 export const EditorSidebarSelectedPointOfAttack = ({
@@ -23,96 +26,146 @@ export const EditorSidebarSelectedPointOfAttack = ({
     handleAssetSearchChanged,
     items,
     handleOnAssetChanged,
+    handleAssetNameClick,
+    handleComponentBreadcrumbClick,
 }: EditorSidebarSelectedPointOfAttackProps) => {
     const { t } = useTranslation("editorPage");
+    const [assetAnchorEl, setAssetAnchorEl] = useState<HTMLElement | null>(null);
+    const [hoveredAsset, setHoveredAsset] = useState<Asset | null>(null);
+
+    const handleAssetHover = (event: MouseEvent<HTMLElement>, asset: Asset) => {
+        setHoveredAsset(asset);
+        setAssetAnchorEl(event.currentTarget);
+    };
+
+    const handleAssetLeave = () => {
+        setHoveredAsset(null);
+        setAssetAnchorEl(null);
+    };
+
     return (
-        <>
-            <Box>
-                <Box
+        <Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#f2f4f500",
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                    alignItems: "flex-start",
+                    marginBottom: "-10px",
+                    height: "26px",
+                    border: "none",
+                }}
+            >
+                <Typography
                     sx={{
-                        display: "flex",
-                        backgroundColor: "#f2f4f500",
-                        paddingLeft: 0,
-                        paddingRight: 0,
-                        alignItems: "flex-start",
-                        marginBottom: "-10px",
-                        height: "26px",
+                        display: "inline",
+                        marginTop: "-0.5px",
+                        fontWeight: "bold",
+                        fontSize: "0.875rem",
+                        color: "text.primary",
                         border: "none",
                     }}
                 >
                     <Typography
+                        component="span"
+                        onClick={handleComponentBreadcrumbClick}
+                        data-testid="poa-breadcrumb-component"
                         sx={{
-                            display: "inline",
-                            marginTop: "-0.5px",
                             fontWeight: "bold",
                             fontSize: "0.875rem",
-                            color: "text.primary",
-                            border: "none",
+                            cursor: "pointer",
+                            "&:hover": { textDecoration: "underline" },
                         }}
                     >
                         {selectedComponent.name}
-                        <Typography sx={{ display: "inline", marginLeft: 1, marginRight: 1 }}>&gt;</Typography>
-                        {t(`pointsOfAttackList.${selectedPointOfAttack.type}`)}
                     </Typography>
-                </Box>
+                    <Typography component="span" sx={{ display: "inline", marginLeft: 1, marginRight: 1 }}>
+                        &gt;
+                    </Typography>
+                    {t(`pointsOfAttackList.${selectedPointOfAttack.type}`)}
+                </Typography>
+            </Box>
 
-                <Box
+            <Box
+                sx={{
+                    display: "flex",
+                    backgroundColor: "#fff",
+                    borderRadius: 15,
+                    height: "31px",
+                    paddingLeft: 8,
+                    paddingRight: 0,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginTop: 4,
+                    marginBottom: 2,
+                    marginLeft: -8,
+                    marginRight: -8,
+                }}
+            >
+                <Typography
                     sx={{
-                        display: "flex",
-                        backgroundColor: "#fff",
-                        borderRadius: 15,
-                        height: "31px",
-                        paddingLeft: 8,
-                        paddingRight: 0,
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        marginTop: 4,
-                        marginBottom: 2,
-                        marginLeft: -8,
-                        marginRight: -8,
+                        fontWeight: "bold",
+                        fontSize: "0.75rem",
+                        color: "text.primary",
                     }}
                 >
-                    <Typography
-                        sx={{
-                            fontWeight: "bold",
-                            fontSize: "0.75rem",
-                            color: "text.primary",
-                        }}
-                    >
-                        {t("sidebar.assets.title")}
-                    </Typography>
-                </Box>
-
-                <SearchField
-                    sx={{
-                        marginBottom: 2,
-                        marginLeft: -0.5,
-                        height: "31px",
-                        width: "40%",
-                        borderRadius: 5,
-                    }}
-                    inputSx={{ fontSize: "0.75rem" }}
-                    value={assetSearchValue}
-                    onChange={handleAssetSearchChanged}
-                    data-testid="selected-point-of-attack-asset-search-field"
-                />
-
-                <EditorSidebarAssetList
-                    items={
-                        assetSearchValue != ""
-                            ? items.filter((item) => {
-                                  const lcSearchValue = assetSearchValue.toLowerCase();
-                                  return (
-                                      assetSearchValue === "" ||
-                                      item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
-                                  );
-                              })
-                            : items
-                    }
-                    checkedAssets={selectedPointOfAttack.assets}
-                    onChangeHandler={handleOnAssetChanged}
-                />
+                    {t("sidebar.assets.title")}
+                </Typography>
             </Box>
-        </>
+
+            <SearchField
+                sx={{
+                    marginBottom: 2,
+                    marginLeft: -0.5,
+                    height: "31px",
+                    width: "40%",
+                    borderRadius: 5,
+                }}
+                inputSx={{ fontSize: "0.75rem" }}
+                value={assetSearchValue}
+                onChange={handleAssetSearchChanged}
+                data-testid="selected-point-of-attack-asset-search-field"
+            />
+
+            <EditorSidebarAssetList
+                items={
+                    assetSearchValue != ""
+                        ? items.filter((item) => {
+                              const lcSearchValue = assetSearchValue.toLowerCase();
+                              return (
+                                  assetSearchValue === "" ||
+                                  item.name.replace(/_/g, " ").toLowerCase().includes(lcSearchValue)
+                              );
+                          })
+                        : items
+                }
+                checkedAssets={selectedPointOfAttack.assets}
+                onChangeHandler={handleOnAssetChanged}
+                onAssetNameClick={handleAssetNameClick}
+                onAssetHover={handleAssetHover}
+                onAssetLeave={handleAssetLeave}
+            />
+
+            <Popper
+                open={assetAnchorEl != null}
+                anchorEl={assetAnchorEl}
+                placement="bottom-start"
+                sx={{
+                    backgroundColor: "background.defaultIntransparent",
+                    borderRadius: 5,
+                    boxShadow: 1,
+                    zIndex: 1000,
+                }}
+            >
+                {hoveredAsset && (
+                    <Box sx={{ padding: 1, margin: 0.5 }}>
+                        <Typography sx={{ fontSize: "0.75rem" }}>
+                            {`(C ${hoveredAsset.confidentiality} / I ${hoveredAsset.integrity} / A ${hoveredAsset.availability})`}
+                        </Typography>
+                    </Box>
+                )}
+            </Popper>
+        </Box>
     );
 };

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar.component.test.tsx
@@ -1,0 +1,141 @@
+import { screen } from "@testing-library/react";
+import { createRef } from "react";
+import { EditorSidebar, type EditorSidebarProps } from "./editor-sidebar.component";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import {
+    createAsset,
+    createSystemComponent,
+    createPointOfAttack,
+    createConnectionPoint,
+    createConnection,
+} from "#test-utils/builders.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+vi.mock("./editor-sidebar-selected-component.component", () => ({
+    EditorSidebarSelectedComponent: () => <div data-testid="selected-component" />,
+}));
+vi.mock("./editor-sidebar-selected-connection.component", () => ({
+    EditorSidebarSelectedConnection: () => <div data-testid="selected-connection" />,
+}));
+vi.mock("./editor-sidebar-selected-communication-interface.component", () => ({
+    EditorSidebarSelectedCommunicationInterface: () => <div data-testid="selected-communication-interface" />,
+}));
+vi.mock("./editor-sidebar-selected-point-of-attack.component", () => ({
+    EditorSidebarSelectedPointOfAttack: () => <div data-testid="selected-point-of-attack" />,
+}));
+
+const setup = (propsOverride: Partial<EditorSidebarProps> = {}) => {
+    const props = {
+        sidebarRef: createRef<HTMLDivElement>(),
+        selectedComponent: undefined,
+        selectedComponentId: undefined,
+        selectedPointOfAttack: undefined,
+        handleDeleteComponent: vi.fn(),
+        handleOnNameChange: vi.fn(),
+        handleChangePointOfAttack: vi.fn(),
+        handleAddAssetToAllPointsOfAttack: vi.fn(),
+        handleRemoveAssetFromAllPointsOfAttack: vi.fn(),
+        assetSearchValue: "",
+        handleAssetSearchChanged: vi.fn(),
+        items: [createAsset()],
+        pointsOfAttackOfSelectedComponent: [],
+        selectedConnectionId: undefined,
+        selectedConnection: undefined,
+        handleDeleteConnection: vi.fn(),
+        handleOnConnectionNameChange: vi.fn(),
+        handleOnAssetChanged: vi.fn(),
+        selectedConnectionPoint: undefined,
+        userRole: USER_ROLES.EDITOR,
+        handleOnDescriptionChange: vi.fn(),
+        connectedComponents: [],
+        handleDeleteConnectionBetweenComponents: vi.fn(),
+        handleOnConnectionPointDescriptionChange: vi.fn(),
+        handleChangeCommunicationInterfaceName: vi.fn(),
+        handleDeleteCommunicationInterface: vi.fn(),
+        handlePointOfAttackLabelClick: vi.fn(),
+        handleAssetNameClick: vi.fn(),
+        handleSelectConnectedComponent: vi.fn(),
+        handleComponentBreadcrumbClick: vi.fn(),
+        handleInterfaceBreadcrumbClick: vi.fn(),
+        ...propsOverride,
+    };
+    renderWithProviders(<EditorSidebar {...props} />);
+    return { props };
+};
+
+describe("EditorSidebar", () => {
+    describe("conditional rendering", () => {
+        it("renders nothing when no selection is active", () => {
+            setup();
+
+            expect(screen.queryByTestId("selected-component")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("selected-connection")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("selected-communication-interface")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("selected-point-of-attack")).not.toBeInTheDocument();
+        });
+
+        it("renders EditorSidebarSelectedComponent when a component is selected without a POA", () => {
+            setup({
+                selectedComponentId: "comp-1",
+                selectedComponent: createSystemComponent(),
+                selectedPointOfAttack: null,
+            });
+
+            expect(screen.getByTestId("selected-component")).toBeInTheDocument();
+            expect(screen.queryByTestId("selected-point-of-attack")).not.toBeInTheDocument();
+        });
+
+        it("renders EditorSidebarSelectedConnection when a connection is selected", () => {
+            setup({
+                selectedConnectionId: "conn-1",
+                selectedConnection: createConnection(),
+            });
+
+            expect(screen.getByTestId("selected-connection")).toBeInTheDocument();
+        });
+
+        it("renders EditorSidebarSelectedCommunicationInterface when a connection point is selected", () => {
+            setup({
+                selectedConnectionPoint: createConnectionPoint(),
+            });
+
+            expect(screen.getByTestId("selected-communication-interface")).toBeInTheDocument();
+        });
+
+        it("renders EditorSidebarSelectedPointOfAttack when a component and POA are both selected", () => {
+            setup({
+                selectedComponent: createSystemComponent(),
+                selectedComponentId: "comp-1",
+                selectedPointOfAttack: createPointOfAttack(),
+            });
+
+            expect(screen.getByTestId("selected-point-of-attack")).toBeInTheDocument();
+            expect(screen.queryByTestId("selected-component")).not.toBeInTheDocument();
+        });
+
+        it("does not render POA panel when selectedConnectionPoint is set", () => {
+            setup({
+                selectedComponent: createSystemComponent(),
+                selectedComponentId: "comp-1",
+                selectedPointOfAttack: createPointOfAttack(),
+                selectedConnectionPoint: createConnectionPoint(),
+            });
+
+            expect(screen.queryByTestId("selected-point-of-attack")).not.toBeInTheDocument();
+            expect(screen.getByTestId("selected-communication-interface")).toBeInTheDocument();
+        });
+
+        it("does not render POA panel when selectedConnection is set", () => {
+            setup({
+                selectedComponent: createSystemComponent(),
+                selectedComponentId: "comp-1",
+                selectedPointOfAttack: createPointOfAttack(),
+                selectedConnectionId: "conn-1",
+                selectedConnection: createConnection(),
+            });
+
+            expect(screen.queryByTestId("selected-point-of-attack")).not.toBeInTheDocument();
+            expect(screen.getByTestId("selected-connection")).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar.component.tsx
@@ -15,7 +15,7 @@ import type {
     SystemPointOfAttack,
 } from "#api/types/system.types.ts";
 
-interface EditorSidebarProps {
+export interface EditorSidebarProps {
     sidebarRef: RefObject<HTMLDivElement | null>;
     selectedComponent: AugmentedSystemComponent | undefined;
     selectedComponentId: string | null | undefined;
@@ -51,6 +51,11 @@ interface EditorSidebarProps {
         interfaceName: string | null,
         doCloseSidebar?: boolean
     ) => void;
+    handlePointOfAttackLabelClick: (pointOfAttackId: string, componentId?: string) => void;
+    handleAssetNameClick: (asset: Asset) => void;
+    handleSelectConnectedComponent: (componentId: string, communicationInterfaceId?: string | null) => void;
+    handleComponentBreadcrumbClick: () => void;
+    handleInterfaceBreadcrumbClick: () => void;
 }
 
 export const EditorSidebar = ({
@@ -80,106 +85,116 @@ export const EditorSidebar = ({
     handleOnConnectionPointDescriptionChange,
     handleChangeCommunicationInterfaceName,
     handleDeleteCommunicationInterface,
+    handlePointOfAttackLabelClick,
+    handleAssetNameClick,
+    handleSelectConnectedComponent,
+    handleComponentBreadcrumbClick,
+    handleInterfaceBreadcrumbClick,
 }: EditorSidebarProps) => {
     return (
-        <>
+        <Box
+            sx={{
+                position: "fixed",
+                top: "125px",
+                right: "-600px",
+                bottom: "40px",
+                width: "480px",
+                zIndex: 999,
+                bgcolor: "#e5e8ebEE",
+                boxShadow: 6,
+                borderRadius: 5,
+                transition: "right 0.3s",
+                overflow: "hidden",
+            }}
+            ref={sidebarRef}
+        >
             <Box
                 sx={{
-                    position: "fixed",
-                    top: "125px",
-                    right: "-600px",
-                    bottom: "40px",
-                    width: "480px",
-                    zIndex: 999,
-                    bgcolor: "#e5e8ebEE",
-                    boxShadow: 6,
-                    borderRadius: 5,
-                    transition: "right 0.3s",
-                    overflow: "hidden",
+                    display: "flex",
+                    flexDirection: "column",
+                    height: "100%",
+                    width: "100%",
+                    overflowX: "hidden",
+                    overflowY: "auto",
+                    padding: "30px",
+                    boxSizing: "border-box",
+                    "::-webkit-scrollbar-track": {
+                        borderTopLeftRadius: 0,
+                        borderBottomLeftRadius: 0,
+                        borderBottomRightRadius: 500,
+                        borderTopRightRadius: 500,
+                    },
                 }}
-                ref={sidebarRef}
             >
-                <Box
-                    sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        height: "100%",
-                        width: "100%",
-                        overflowX: "hidden",
-                        overflowY: "auto",
-                        padding: "30px",
-                        boxSizing: "border-box",
-                        "::-webkit-scrollbar-track": {
-                            borderTopLeftRadius: 0,
-                            borderBottomLeftRadius: 0,
-                            borderBottomRightRadius: 500,
-                            borderTopRightRadius: 500,
-                        },
-                    }}
-                >
-                    {selectedComponentId !== undefined &&
-                        selectedComponentId != null &&
-                        (selectedPointOfAttack === null || selectedPointOfAttack === undefined) && (
-                            <EditorSidebarSelectedComponent
-                                handleDeleteComponent={handleDeleteComponent}
-                                handleChangePointOfAttack={handleChangePointOfAttack}
-                                handleAddAssetToAllPointsOfAttack={handleAddAssetToAllPointsOfAttack}
-                                handleRemoveAssetFromAllPointsOfAttack={handleRemoveAssetFromAllPointsOfAttack}
-                                selectedComponent={selectedComponent}
-                                handleOnNameChange={handleOnNameChange}
-                                assetSearchValue={assetSearchValue}
-                                handleAssetSearchChanged={handleAssetSearchChanged}
-                                items={items}
-                                pointsOfAttackOfSelectedComponent={pointsOfAttackOfSelectedComponent}
-                                userRole={userRole}
-                                handleOnDescriptionChange={handleOnDescriptionChange}
-                                connectedComponents={connectedComponents}
-                                handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
-                                handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
-                                handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
-                            />
-                        )}
-
-                    {selectedConnectionId !== undefined && selectedConnectionId != null && (
-                        <EditorSidebarSelectedConnection
-                            selectedConnection={selectedConnection}
-                            handleDeleteConnection={handleDeleteConnection}
-                            handleOnConnectionNameChange={handleOnConnectionNameChange}
-                            userRole={userRole}
-                        />
-                    )}
-
-                    {selectedConnectionPoint !== undefined && selectedConnectionPoint != null && (
-                        <EditorSidebarSelectedCommunicationInterface
-                            selectedConnectionPoint={selectedConnectionPoint}
-                            handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
+                {selectedComponentId !== undefined &&
+                    selectedComponentId != null &&
+                    (selectedPointOfAttack === null || selectedPointOfAttack === undefined) && (
+                        <EditorSidebarSelectedComponent
+                            handleDeleteComponent={handleDeleteComponent}
+                            handleChangePointOfAttack={handleChangePointOfAttack}
+                            handleAddAssetToAllPointsOfAttack={handleAddAssetToAllPointsOfAttack}
+                            handleRemoveAssetFromAllPointsOfAttack={handleRemoveAssetFromAllPointsOfAttack}
+                            selectedComponent={selectedComponent}
+                            handleOnNameChange={handleOnNameChange}
                             assetSearchValue={assetSearchValue}
                             handleAssetSearchChanged={handleAssetSearchChanged}
-                            handleOnAssetChanged={handleOnAssetChanged}
                             items={items}
-                            selectedPointOfAttack={selectedPointOfAttack}
-                            handleOnConnectionPointDescriptionChange={handleOnConnectionPointDescriptionChange}
-                            handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
+                            pointsOfAttackOfSelectedComponent={pointsOfAttackOfSelectedComponent}
                             userRole={userRole}
+                            handleOnDescriptionChange={handleOnDescriptionChange}
+                            connectedComponents={connectedComponents}
+                            handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
+                            handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
+                            handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
+                            handlePointOfAttackLabelClick={handlePointOfAttackLabelClick}
+                            handleAssetNameClick={handleAssetNameClick}
+                            handleSelectConnectedComponent={handleSelectConnectedComponent}
                         />
                     )}
 
-                    {selectedComponent &&
-                        !selectedConnectionPoint &&
-                        !selectedConnection &&
-                        selectedPointOfAttack !== undefined &&
-                        selectedPointOfAttack != null && (
-                            <EditorSidebarSelectedPointOfAttack
-                                selectedComponent={selectedComponent}
-                                selectedPointOfAttack={selectedPointOfAttack}
-                                assetSearchValue={assetSearchValue}
-                                handleAssetSearchChanged={handleAssetSearchChanged}
-                                items={items}
-                                handleOnAssetChanged={handleOnAssetChanged}
-                            />
-                        )}
-                </Box>
+                {selectedConnectionId !== undefined && selectedConnectionId != null && (
+                    <EditorSidebarSelectedConnection
+                        selectedConnection={selectedConnection}
+                        handleDeleteConnection={handleDeleteConnection}
+                        handleOnConnectionNameChange={handleOnConnectionNameChange}
+                        userRole={userRole}
+                    />
+                )}
+
+                {selectedConnectionPoint !== undefined && selectedConnectionPoint != null && (
+                    <EditorSidebarSelectedCommunicationInterface
+                        selectedConnectionPoint={selectedConnectionPoint}
+                        handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
+                        assetSearchValue={assetSearchValue}
+                        handleAssetSearchChanged={handleAssetSearchChanged}
+                        handleOnAssetChanged={handleOnAssetChanged}
+                        items={items}
+                        selectedPointOfAttack={selectedPointOfAttack}
+                        handleOnConnectionPointDescriptionChange={handleOnConnectionPointDescriptionChange}
+                        handleDeleteCommunicationInterface={handleDeleteCommunicationInterface}
+                        userRole={userRole}
+                        handleAssetNameClick={handleAssetNameClick}
+                        handleInterfaceBreadcrumbClick={handleInterfaceBreadcrumbClick}
+                    />
+                )}
+
+                {selectedComponent &&
+                    !selectedConnectionPoint &&
+                    !selectedConnection &&
+                    selectedPointOfAttack !== undefined &&
+                    selectedPointOfAttack != null && (
+                        <EditorSidebarSelectedPointOfAttack
+                            selectedComponent={selectedComponent}
+                            selectedPointOfAttack={selectedPointOfAttack}
+                            assetSearchValue={assetSearchValue}
+                            handleAssetSearchChanged={handleAssetSearchChanged}
+                            items={items}
+                            handleOnAssetChanged={handleOnAssetChanged}
+                            handleAssetNameClick={handleAssetNameClick}
+                            handleComponentBreadcrumbClick={handleComponentBreadcrumbClick}
+                        />
+                    )}
             </Box>
-        </>
+        </Box>
     );
 };

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.test.tsx
@@ -26,19 +26,19 @@ describe("PointOfAttackSwitch", () => {
     it("renders a switch", () => {
         setup();
 
-        expect(screen.getByRole("checkbox")).toBeInTheDocument();
+        expect(screen.getByRole("switch")).toBeInTheDocument();
     });
 
     it("switch is unchecked by default", () => {
         setup({ checked: false });
 
-        expect(screen.getByRole("checkbox")).not.toBeChecked();
+        expect(screen.getByRole("switch")).not.toBeChecked();
     });
 
     it("switch reflects checked state", () => {
         setup({ checked: true });
 
-        expect(screen.getByRole("checkbox")).toBeChecked();
+        expect(screen.getByRole("switch")).toBeChecked();
     });
 
     it("toggling the switch calls onChange", async () => {
@@ -46,7 +46,7 @@ describe("PointOfAttackSwitch", () => {
 
         expect(props.onChange).not.toHaveBeenCalled();
 
-        await user.click(screen.getByRole("checkbox"));
+        await user.click(screen.getByRole("switch"));
 
         expect(props.onChange).toHaveBeenCalledOnce();
     });

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PointOfAttackSwitch, type PointOfAttackSwitchProps } from "./point-of-attack-switch.component";
+
+const setup = (propsOverride: Partial<PointOfAttackSwitchProps> = {}) => {
+    const props = {
+        color: "#ff0000",
+        label: "Test Label",
+        onLabelClick: vi.fn(),
+        checked: false,
+        onChange: vi.fn(),
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    render(<PointOfAttackSwitch {...props} />);
+    return { props, user };
+};
+
+describe("PointOfAttackSwitch", () => {
+    it("renders the label text", () => {
+        setup();
+
+        expect(screen.getByText("Test Label")).toBeInTheDocument();
+    });
+
+    it("renders a switch", () => {
+        setup();
+
+        expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    });
+
+    it("switch is unchecked by default", () => {
+        setup({ checked: false });
+
+        expect(screen.getByRole("checkbox")).not.toBeChecked();
+    });
+
+    it("switch reflects checked state", () => {
+        setup({ checked: true });
+
+        expect(screen.getByRole("checkbox")).toBeChecked();
+    });
+
+    it("toggling the switch calls onChange", async () => {
+        const { props, user } = setup();
+
+        expect(props.onChange).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole("checkbox"));
+
+        expect(props.onChange).toHaveBeenCalledOnce();
+    });
+
+    it("clicking the label calls onLabelClick", async () => {
+        const { props, user } = setup();
+
+        expect(props.onLabelClick).not.toHaveBeenCalled();
+
+        await user.click(screen.getByText("Test Label"));
+
+        expect(props.onLabelClick).toHaveBeenCalledOnce();
+    });
+
+    it("clicking the label does not toggle the switch", async () => {
+        const { props, user } = setup();
+
+        await user.click(screen.getByText("Test Label"));
+
+        expect(props.onChange).not.toHaveBeenCalled();
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
@@ -1,19 +1,20 @@
 import { Box, FormControlLabel, Switch, Typography, type SwitchProps } from "@mui/material";
-import type { ReactNode } from "react";
+import type { ReactNode, MouseEvent } from "react";
 
-interface PointOfAttackSwitchProps extends Omit<SwitchProps, "color"> {
+export interface PointOfAttackSwitchProps extends Omit<SwitchProps, "color"> {
     color: string;
     label: ReactNode;
+    onLabelClick: (event: MouseEvent<HTMLElement>) => void;
 }
 
-export const PointOfAttackSwitch = ({ color, label, ...props }: PointOfAttackSwitchProps) => {
+export const PointOfAttackSwitch = ({ color, label, onLabelClick, ...props }: PointOfAttackSwitchProps) => {
     return (
         <Box
             sx={{
                 display: "flex",
                 flexDirection: "row",
                 alignItems: "center",
-                justifyContent: "space-between",
+                justifyContent: "flex-start",
                 marginBottom: 1,
                 color: "text.primary",
                 fontSize: "0.75rem",
@@ -40,9 +41,19 @@ export const PointOfAttackSwitch = ({ color, label, ...props }: PointOfAttackSwi
                 }
                 label={
                     <Typography
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onLabelClick(e);
+                        }}
                         sx={{
                             fontSize: "0.75rem",
                             marginLeft: 1,
+                            cursor: "default",
+                            ...(props.checked && {
+                                cursor: "pointer",
+                                "&:hover": { textDecoration: "underline" },
+                            }),
                         }}
                     >
                         {label}
@@ -52,16 +63,3 @@ export const PointOfAttackSwitch = ({ color, label, ...props }: PointOfAttackSwi
         </Box>
     );
 };
-
-/**
- *
- *
-<Box
-    sx={{
-        backgroundColor: color,
-        width: "16px",
-        height: "16px",
-        marginLeft: 1,
-        borderRadius: 50,
-    }}
-></Box> */

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { POA_COLORS } from "../../colors/pointsOfAttack.colors";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { createSystemComponent, createConnectionAnchor } from "#test-utils/builders.ts";
+import { SystemComponentConnection } from "./system-component-connection.component";
+
+vi.mock("react-konva", () => ({
+    Group: ({ children }: { children?: React.ReactNode }) => <div data-testid="konva-group">{children}</div>,
+    Line: (props: Record<string, unknown>) => (
+        <div
+            data-testid="konva-line"
+            data-stroke={props["stroke"]}
+            data-stroke-width={props["strokeWidth"]}
+            data-listening={String(props["listening"])}
+            data-points={JSON.stringify(props["points"])}
+        />
+    ),
+}));
+
+const defaultProps = {
+    id: "connection-1",
+    name: "Connection 1",
+    connectionPoints: [],
+    connectionPointsMeta: [],
+    projectId: 1,
+    recalculate: false,
+    waypoints: [100, 100, 300, 300],
+    components: [],
+    onClick: vi.fn(),
+    onPointOfAttackClicked: vi.fn(),
+    selected: false,
+    onRecalculated: vi.fn(),
+    stageRef: { current: null },
+    pointsOfAttack: [],
+    communicationInterface: null,
+};
+
+describe("SystemComponentConnection", () => {
+    describe("connection color based on component type", () => {
+        it("uses USER_BEHAVIOUR colors when from.type is USERS", () => {
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    to={createConnectionAnchor({ id: "comp-2" })}
+                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    toComponent={createSystemComponent({ id: "comp-2" })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            expect(visibleLine).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal);
+        });
+
+        it("uses USER_BEHAVIOUR colors when to.type is USERS", () => {
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    from={createConnectionAnchor()}
+                    to={createConnectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
+                    fromComponent={createSystemComponent()}
+                    toComponent={createSystemComponent({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            expect(visibleLine).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal);
+        });
+
+        it("uses COMMUNICATION_INFRASTRUCTURE colors when neither endpoint is USERS", () => {
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                    to={createConnectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
+                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                    toComponent={createSystemComponent({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            expect(visibleLine).toHaveAttribute(
+                "data-stroke",
+                POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE].normal
+            );
+        });
+
+        it("passes waypoints through to the Line when recalculate is false", () => {
+            const waypoints = [50, 50, 200, 100, 350, 350];
+
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    waypoints={waypoints}
+                    from={createConnectionAnchor()}
+                    to={createConnectionAnchor({ id: "comp-2" })}
+                    fromComponent={createSystemComponent()}
+                    toComponent={createSystemComponent({ id: "comp-2" })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            const renderedPoints = JSON.parse(visibleLine!.dataset["points"]!);
+            expect(renderedPoints).toEqual(waypoints);
+        });
+
+        it("applies hover color when selected", () => {
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    selected={true}
+                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    to={createConnectionAnchor({ id: "comp-2" })}
+                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    toComponent={createSystemComponent({ id: "comp-2" })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            expect(visibleLine).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].hover);
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
@@ -5,6 +5,7 @@ import { POINTS_OF_ATTACK } from "../../../api/types/points-of-attack.types";
 import type { KonvaEventObject } from "konva/lib/Node";
 import type { Stage as KonvaStage } from "konva/lib/Stage";
 import { AnchorOrientation, type AugmentedSystemComponent, type ConnectionPointMeta } from "#api/types/system.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
 import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
 
 const TURN_PENALTY = 200;
@@ -17,6 +18,7 @@ interface LineForPathProps {
     onPointOfAttackClicked: (event: KonvaEventObject<MouseEvent>) => void;
     selected: boolean;
     hover: boolean;
+    colors: { normal: string; selected: string; hover: string };
 }
 
 interface SystemComponentConnectionProps extends AugmentedSystemConnection {
@@ -56,8 +58,8 @@ function LineForPath({
     onPointOfAttackClicked,
     selected,
     hover,
+    colors,
 }: LineForPathProps) {
-    const COLORS = POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE];
     return (
         <Group
             onMouseOver={onMouseEnter}
@@ -85,7 +87,7 @@ function LineForPath({
             {/* Visible connection line */}
             <Line
                 points={waypoints}
-                stroke={selected || hover ? COLORS.hover : COLORS.normal}
+                stroke={selected || hover ? colors.hover : colors.normal}
                 strokeWidth={selected || hover ? 5 : 3}
                 lineCap={"round"}
                 lineJoin={"round"}
@@ -126,6 +128,11 @@ const SystemComponentConnectionInner = ({
     let fromAnchor = from;
     let toAnchor = to;
 
+    const isUserConnection = from.type === STANDARD_COMPONENT_TYPES.USERS || to.type === STANDARD_COMPONENT_TYPES.USERS;
+    const connectionColors = isUserConnection
+        ? POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR]
+        : POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE];
+
     if (!fromComponent || !toComponent) {
         return null;
     }
@@ -165,6 +172,7 @@ const SystemComponentConnectionInner = ({
                     onPointOfAttackClicked={handleLinePointOfAttackClicked}
                     selected={selected}
                     hover={hover}
+                    colors={connectionColors}
                 />
             </Group>
         );
@@ -279,6 +287,7 @@ const SystemComponentConnectionInner = ({
                         onPointOfAttackClicked={handleLinePointOfAttackClicked}
                         selected={selected}
                         hover={hover}
+                        colors={connectionColors}
                     />
                 </Group>
             );

--- a/apps/frontend/src/view/components/icon-selector.component.tsx
+++ b/apps/frontend/src/view/components/icon-selector.component.tsx
@@ -103,7 +103,7 @@ export const IconSelector = ({ value, onChange, label, error, helperText }: Icon
                 <MenuItem>
                     <Grid container spacing={1} sx={{ width: 250, height: 250 }}>
                         {visibleIcons.map((iconName) => (
-                            <Grid item xs={2.4} key={iconName}>
+                            <Grid size={2.4} key={iconName}>
                                 <IconButton
                                     size="small"
                                     onClick={(e) => {

--- a/apps/frontend/src/view/components/matrix.component.tsx
+++ b/apps/frontend/src/view/components/matrix.component.tsx
@@ -61,8 +61,8 @@ export const Matrix = ({ matrix, size = 120, onSelectCell }: MatrixProps): JSX.E
                     fontWeight: "bold",
                     marginTop: 0.5,
                     letterSpacing: "1px",
+                    fontSize: size / 5,
                 }}
-                fontSize={size / 5}
             >
                 {t("probabilityAxis")}
             </Typography>
@@ -120,8 +120,8 @@ const DamageAxis = ({ size, title }: DamageAxisProps): JSX.Element => {
                 ))}
             </Box>
             <Typography
-                fontSize={size / 5}
                 sx={{
+                    fontSize: size / 5,
                     letterSpacing: "1px",
                     fontWeight: "bold",
                     alignSelf: "flex-end",
@@ -150,8 +150,8 @@ const AxisCell = ({ children, variant, size, fontSize }: AxisCellProps): JSX.Ele
             }}
         >
             <Box
-                fontSize={fontSize ? fontSize : size / 3}
                 sx={{
+                    fontSize: fontSize ? fontSize : size / 3,
                     color: "matrix.axisCells.color",
                     fontWeight: "bold",
                 }}

--- a/apps/frontend/src/view/components/name-textfield.component.tsx
+++ b/apps/frontend/src/view/components/name-textfield.component.tsx
@@ -41,6 +41,7 @@ const BaseNameTextField = <TFieldValues extends FieldValues>({
     ownId,
     type,
     projectId,
+    catalogId: _catalogId,
     ...props
 }: BaseNameTextFieldProps<TFieldValues>) => {
     const { t } = useTranslation();

--- a/apps/frontend/src/view/components/project-card.component.tsx
+++ b/apps/frontend/src/view/components/project-card.component.tsx
@@ -144,12 +144,14 @@ export const ProjectCard = ({ project, onClickEditProject, onClickDeleteProject,
                             anchorEl={anchorEl}
                             open={open}
                             onClose={handleClose}
-                            MenuListProps={{
-                                sx: { bgcolor: "background.mainIntransparent" },
-                            }}
-                            PaperProps={{
-                                sx: {
-                                    borderRadius: 5,
+                            slotProps={{
+                                list: {
+                                    sx: { bgcolor: "background.mainIntransparent" },
+                                },
+                                paper: {
+                                    sx: {
+                                        borderRadius: 5,
+                                    },
                                 },
                             }}
                         >

--- a/apps/frontend/src/view/components/projects-grid.component.tsx
+++ b/apps/frontend/src/view/components/projects-grid.component.tsx
@@ -36,8 +36,7 @@ export const ProjectsGridComponent = ({
                 return (
                     <Grid
                         key={columnIndex}
-                        item
-                        xs={Math.floor(12 / columnCount)}
+                        size={Math.floor(12 / columnCount)}
                         sx={{
                             paddingTop: "0 !important",
                             overflow: "visible",

--- a/apps/frontend/src/view/components/projects-grid.component.tsx
+++ b/apps/frontend/src/view/components/projects-grid.component.tsx
@@ -15,7 +15,7 @@ export const ProjectsGridComponent = ({
     onClickDeleteProject,
     onClickEditProject,
 }: ProjectsGridComponentProps) => {
-    const columns = new Array(columnCount).fill(0);
+    const columns = Array.from({ length: columnCount }).fill(0);
     return (
         <Grid
             container

--- a/apps/frontend/src/view/components/user-panel.component.tsx
+++ b/apps/frontend/src/view/components/user-panel.component.tsx
@@ -90,29 +90,31 @@ const UserPanel = () => {
                 open={open}
                 onClose={handleClose}
                 onClick={handleClose}
-                PaperProps={{
-                    elevation: 0,
-                    sx: {
-                        overflow: "visible",
-                        filter: "drop-shadow(0px 2px 8px rgba(0,0,0,0.32))",
-                        mt: 1.5,
-                        "& .MuiAvatar-root": {
-                            width: 32,
-                            height: 32,
-                            ml: 0,
-                            mr: 0,
-                        },
-                        "&:before": {
-                            content: '""',
-                            display: "block",
-                            position: "absolute",
-                            top: 0,
-                            right: 22,
-                            width: 10,
-                            height: 10,
-                            bgcolor: "background.paper",
-                            transform: "translateY(-50%) rotate(45deg)",
-                            zIndex: 0,
+                slotProps={{
+                    paper: {
+                        elevation: 0,
+                        sx: {
+                            overflow: "visible",
+                            filter: "drop-shadow(0px 2px 8px rgba(0,0,0,0.32))",
+                            mt: 1.5,
+                            "& .MuiAvatar-root": {
+                                width: 32,
+                                height: 32,
+                                ml: 0,
+                                mr: 0,
+                            },
+                            "&:before": {
+                                content: '""',
+                                display: "block",
+                                position: "absolute",
+                                top: 0,
+                                right: 22,
+                                width: 10,
+                                height: 10,
+                                bgcolor: "background.paper",
+                                transform: "translateY(-50%) rotate(45deg)",
+                                zIndex: 0,
+                            },
                         },
                     },
                 }}

--- a/apps/frontend/src/view/components/with-menu.component.tsx
+++ b/apps/frontend/src/view/components/with-menu.component.tsx
@@ -1,5 +1,5 @@
-import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutlined";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
 import SyncIcon from "@mui/icons-material/Sync";
 import { IconButton, Typography } from "@mui/material";
 import Box from "@mui/material/Box";

--- a/apps/frontend/src/view/dialogs/add-asset.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/add-asset.dialog.test.tsx
@@ -1,0 +1,82 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddAssetDialog, { type AddAssetDialogProps } from "./add-asset.dialog";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset } from "#test-utils/builders.ts";
+import { mockUseDialog } from "#test-utils/mock-hooks.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+mockUseDialog();
+
+const navigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react-router")>();
+    return { ...actual, useNavigate: () => navigate };
+});
+
+const validAsset = createAsset({ id: 1, name: "Existing Asset" });
+
+const setup = (propsOverride: Partial<AddAssetDialogProps> = {}) => {
+    const props = {
+        projectId: 1,
+        userRole: USER_ROLES.EDITOR,
+        asset: validAsset,
+        open: true,
+        ...propsOverride,
+    };
+    const user = userEvent.setup();
+    renderWithProviders(<AddAssetDialog {...props} />);
+    return { props, user };
+};
+
+describe("AddAssetDialog — onDialogClose prop", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("calls onDialogClose instead of navigate(-1) when cancel is clicked", async () => {
+        const onDialogClose = vi.fn();
+        const { user } = setup({ onDialogClose });
+
+        expect(onDialogClose).not.toHaveBeenCalled();
+
+        await user.click(screen.getByTestId("cancel-button"));
+
+        expect(onDialogClose).toHaveBeenCalledOnce();
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("falls back to navigate(-1) when onDialogClose is not provided", async () => {
+        const { user } = setup();
+
+        expect(navigate).not.toHaveBeenCalled();
+
+        await user.click(screen.getByTestId("cancel-button"));
+
+        expect(navigate).toHaveBeenCalledOnce();
+        expect(navigate).toHaveBeenCalledWith(-1);
+    });
+
+    it("calls onDialogClose after form submission", async () => {
+        const onDialogClose = vi.fn();
+        const { user } = setup({ onDialogClose });
+
+        await user.click(screen.getByTestId("save-button"));
+
+        await waitFor(() => {
+            expect(onDialogClose).toHaveBeenCalledOnce();
+        });
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("calls navigate(-1) after form submission when onDialogClose is not provided", async () => {
+        const { user } = setup();
+
+        await user.click(screen.getByTestId("save-button"));
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledOnce();
+        });
+        expect(navigate).toHaveBeenCalledWith(-1);
+    });
+});

--- a/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
@@ -144,7 +144,17 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="sm" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="sm"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,
@@ -227,46 +237,48 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             error={!!errors?.confidentiality}
                             helperText={errors?.confidentiality?.message}
                             data-testid="asset-creation-modal_confidentiality-input"
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <Tooltip
-                                            title={
-                                                <>
-                                                    1 - {t("damages.1.name")}
-                                                    <br />
-                                                    {t("damages.1.description")}
-                                                    <br />
-                                                    <br />2 - {t("damages.2.name")}
-                                                    <br />
-                                                    {t("damages.2.description")}
-                                                    <br />
-                                                    <br />3 - {t("damages.3.name")}
-                                                    <br />
-                                                    {t("damages.3.description")}
-                                                    <br />
-                                                    <br />4 - {t("damages.4.name")}
-                                                    <br />
-                                                    {t("damages.4.description")}
-                                                    <br />
-                                                    <br />5 - {t("damages.5.name")}
-                                                    <br />
-                                                    {t("damages.5.description")}
-                                                    <br />
-                                                </>
-                                            }
-                                        >
-                                            <InfoOutlined
-                                                className="info-adornment"
-                                                sx={{
-                                                    "&:hover": {
-                                                        color: "#fcac0c !important",
-                                                    },
-                                                }}
-                                            />
-                                        </Tooltip>
-                                    </InputAdornment>
-                                ),
+                            slotProps={{
+                                input: {
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <Tooltip
+                                                title={
+                                                    <>
+                                                        1 - {t("damages.1.name")}
+                                                        <br />
+                                                        {t("damages.1.description")}
+                                                        <br />
+                                                        <br />2 - {t("damages.2.name")}
+                                                        <br />
+                                                        {t("damages.2.description")}
+                                                        <br />
+                                                        <br />3 - {t("damages.3.name")}
+                                                        <br />
+                                                        {t("damages.3.description")}
+                                                        <br />
+                                                        <br />4 - {t("damages.4.name")}
+                                                        <br />
+                                                        {t("damages.4.description")}
+                                                        <br />
+                                                        <br />5 - {t("damages.5.name")}
+                                                        <br />
+                                                        {t("damages.5.description")}
+                                                        <br />
+                                                    </>
+                                                }
+                                            >
+                                                <InfoOutlined
+                                                    className="info-adornment"
+                                                    sx={{
+                                                        "&:hover": {
+                                                            color: "#fcac0c !important",
+                                                        },
+                                                    }}
+                                                />
+                                            </Tooltip>
+                                        </InputAdornment>
+                                    ),
+                                },
                             }}
                         />
                         <Box
@@ -323,46 +335,48 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             error={!!errors?.integrity}
                             helperText={errors?.integrity?.message}
                             data-testid="asset-creation-modal_integrity-input"
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <Tooltip
-                                            title={
-                                                <>
-                                                    1 - {t("damages.1.name")}
-                                                    <br />
-                                                    {t("damages.1.description")}
-                                                    <br />
-                                                    <br />2 - {t("damages.2.name")}
-                                                    <br />
-                                                    {t("damages.2.description")}
-                                                    <br />
-                                                    <br />3 - {t("damages.3.name")}
-                                                    <br />
-                                                    {t("damages.3.description")}
-                                                    <br />
-                                                    <br />4 - {t("damages.4.name")}
-                                                    <br />
-                                                    {t("damages.4.description")}
-                                                    <br />
-                                                    <br />5 - {t("damages.5.name")}
-                                                    <br />
-                                                    {t("damages.5.description")}
-                                                    <br />
-                                                </>
-                                            }
-                                        >
-                                            <InfoOutlined
-                                                className="info-adornment"
-                                                sx={{
-                                                    "&:hover": {
-                                                        color: "#fcac0c !important",
-                                                    },
-                                                }}
-                                            />
-                                        </Tooltip>
-                                    </InputAdornment>
-                                ),
+                            slotProps={{
+                                input: {
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <Tooltip
+                                                title={
+                                                    <>
+                                                        1 - {t("damages.1.name")}
+                                                        <br />
+                                                        {t("damages.1.description")}
+                                                        <br />
+                                                        <br />2 - {t("damages.2.name")}
+                                                        <br />
+                                                        {t("damages.2.description")}
+                                                        <br />
+                                                        <br />3 - {t("damages.3.name")}
+                                                        <br />
+                                                        {t("damages.3.description")}
+                                                        <br />
+                                                        <br />4 - {t("damages.4.name")}
+                                                        <br />
+                                                        {t("damages.4.description")}
+                                                        <br />
+                                                        <br />5 - {t("damages.5.name")}
+                                                        <br />
+                                                        {t("damages.5.description")}
+                                                        <br />
+                                                    </>
+                                                }
+                                            >
+                                                <InfoOutlined
+                                                    className="info-adornment"
+                                                    sx={{
+                                                        "&:hover": {
+                                                            color: "#fcac0c !important",
+                                                        },
+                                                    }}
+                                                />
+                                            </Tooltip>
+                                        </InputAdornment>
+                                    ),
+                                },
                             }}
                         />
                         <Box
@@ -415,46 +429,48 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             error={!!errors?.availability}
                             helperText={errors?.availability?.message}
                             data-testid="asset-creation-modal_availability-input"
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <Tooltip
-                                            title={
-                                                <>
-                                                    1 - {t("damages.1.name")}
-                                                    <br />
-                                                    {t("damages.1.description")}
-                                                    <br />
-                                                    <br />2 - {t("damages.2.name")}
-                                                    <br />
-                                                    {t("damages.2.description")}
-                                                    <br />
-                                                    <br />3 - {t("damages.3.name")}
-                                                    <br />
-                                                    {t("damages.3.description")}
-                                                    <br />
-                                                    <br />4 - {t("damages.4.name")}
-                                                    <br />
-                                                    {t("damages.4.description")}
-                                                    <br />
-                                                    <br />5 - {t("damages.5.name")}
-                                                    <br />
-                                                    {t("damages.5.description")}
-                                                    <br />
-                                                </>
-                                            }
-                                        >
-                                            <InfoOutlined
-                                                className="info-adornment"
-                                                sx={{
-                                                    "&:hover": {
-                                                        color: "#fcac0c !important",
-                                                    },
-                                                }}
-                                            />
-                                        </Tooltip>
-                                    </InputAdornment>
-                                ),
+                            slotProps={{
+                                input: {
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <Tooltip
+                                                title={
+                                                    <>
+                                                        1 - {t("damages.1.name")}
+                                                        <br />
+                                                        {t("damages.1.description")}
+                                                        <br />
+                                                        <br />2 - {t("damages.2.name")}
+                                                        <br />
+                                                        {t("damages.2.description")}
+                                                        <br />
+                                                        <br />3 - {t("damages.3.name")}
+                                                        <br />
+                                                        {t("damages.3.description")}
+                                                        <br />
+                                                        <br />4 - {t("damages.4.name")}
+                                                        <br />
+                                                        {t("damages.4.description")}
+                                                        <br />
+                                                        <br />5 - {t("damages.5.name")}
+                                                        <br />
+                                                        {t("damages.5.description")}
+                                                        <br />
+                                                    </>
+                                                }
+                                            >
+                                                <InfoOutlined
+                                                    className="info-adornment"
+                                                    sx={{
+                                                        "&:hover": {
+                                                            color: "#fcac0c !important",
+                                                        },
+                                                    }}
+                                                />
+                                            </Tooltip>
+                                        </InputAdornment>
+                                    ),
+                                },
                             }}
                         />
                         <Box

--- a/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
@@ -49,10 +49,11 @@ interface FormValues {
 
 interface AssetDialogFormValues extends FormValues, Omit<Partial<Asset>, keyof FormValues>, DialogValue {}
 
-interface AddAssetDialogProps extends DialogProps {
+export interface AddAssetDialogProps extends DialogProps {
     projectId: number | undefined;
     asset?: Partial<Asset>;
     userRole: USER_ROLES | undefined;
+    onDialogClose?: () => void;
 }
 
 /**
@@ -64,7 +65,7 @@ interface AddAssetDialogProps extends DialogProps {
  * @param {object} props - Dialog properties.
  * @returns React component for adding an asset.
  */
-const AddAssetDialog = ({ projectId, asset, userRole, ...props }: AddAssetDialogProps) => {
+const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }: AddAssetDialogProps) => {
     const { cancelDialog, confirmDialog } = useDialog<AssetDialogFormValues | null>("assets");
     const navigate = useNavigate();
     const { t } = useTranslation("assetDialogPage");
@@ -97,7 +98,11 @@ const AddAssetDialog = ({ projectId, asset, userRole, ...props }: AddAssetDialog
      * Closes the dialog.
      */
     const closeDialog = () => {
-        navigate(-1);
+        if (onDialogClose) {
+            onDialogClose();
+        } else {
+            navigate(-1);
+        }
     };
 
     /**

--- a/apps/frontend/src/view/dialogs/add-catalog.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-catalog.dialog.tsx
@@ -110,7 +110,17 @@ const AddCatalogDialog = ({ catalog, ...props }: AddCatalogDialogProps) => {
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="xs" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="xs"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,

--- a/apps/frontend/src/view/dialogs/add-measure.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-measure.dialog.tsx
@@ -94,7 +94,17 @@ const AddMeasureDialog = ({ project, measure, ...props }: AddMeasureDialogProps)
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="sm" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="sm"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,

--- a/apps/frontend/src/view/dialogs/add-member.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-member.dialog.tsx
@@ -129,7 +129,17 @@ const AddMemberDialog = ({
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="xs" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="xs"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,
@@ -232,12 +242,14 @@ const AddMemberDialog = ({
                                     label={t("role")}
                                     {...field}
                                     MenuProps={{
-                                        PaperProps: {
-                                            sx: {
-                                                bgcolor: "background.mainIntransparent",
-                                                borderRadius: 5,
-                                                "*": {
-                                                    fontSize: "0.875rem !important",
+                                        slotProps: {
+                                            paper: {
+                                                sx: {
+                                                    bgcolor: "background.mainIntransparent",
+                                                    borderRadius: 5,
+                                                    "*": {
+                                                        fontSize: "0.875rem !important",
+                                                    },
                                                 },
                                             },
                                         },

--- a/apps/frontend/src/view/dialogs/add-project.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-project.dialog.tsx
@@ -103,7 +103,17 @@ const AddProjectDialog = ({ project, ...props }: AddProjectDialogProps) => {
     useEffect(loadCatalogs, [loadCatalogs]);
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="xs" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="xs"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,
@@ -166,16 +176,18 @@ const AddProjectDialog = ({ project, ...props }: AddProjectDialogProps) => {
                                 label={t("catalog")}
                                 {...field}
                                 MenuProps={{
-                                    PaperProps: {
-                                        sx: {
-                                            bgcolor: "background.mainIntransparent",
-                                            borderRadius: 5,
-                                            "*": {
-                                                fontSize: "0.875rem !important",
-                                            },
-                                            sub: {
-                                                fontSize: "0.75em !important",
-                                                verticalAlign: "sub",
+                                    slotProps: {
+                                        paper: {
+                                            sx: {
+                                                bgcolor: "background.mainIntransparent",
+                                                borderRadius: 5,
+                                                "*": {
+                                                    fontSize: "0.875rem !important",
+                                                },
+                                                sub: {
+                                                    fontSize: "0.75em !important",
+                                                    verticalAlign: "sub",
+                                                },
                                             },
                                         },
                                     },
@@ -259,12 +271,14 @@ const AddProjectDialog = ({ project, ...props }: AddProjectDialogProps) => {
                                 label={t("confidentiality")}
                                 {...field}
                                 MenuProps={{
-                                    PaperProps: {
-                                        sx: {
-                                            bgcolor: "background.mainIntransparent",
-                                            borderRadius: 5,
-                                            "*": {
-                                                fontSize: "0.875rem !important",
+                                    slotProps: {
+                                        paper: {
+                                            sx: {
+                                                bgcolor: "background.mainIntransparent",
+                                                borderRadius: 5,
+                                                "*": {
+                                                    fontSize: "0.875rem !important",
+                                                },
                                             },
                                         },
                                     },

--- a/apps/frontend/src/view/dialogs/add-threat.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat.dialog.tsx
@@ -223,7 +223,11 @@ const AddThreatDialog = ({ threat, project, userRole, ...props }: AddThreatDialo
 
     return (
         <Dialog
-            onBackdropClick={handleCancelDialog}
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
             maxWidth="md"
             fullWidth
             {...props}
@@ -353,36 +357,38 @@ const AddThreatDialog = ({ threat, project, userRole, ...props }: AddThreatDialo
                         error={!!errors?.probability}
                         helperText={errors?.probability?.message}
                         data-testid="EditThreatProbability"
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <Tooltip
-                                        title={
-                                            <>
-                                                1 - {t("probabilities.1.name")} <br />{" "}
-                                                {t("probabilities.1.description")} <br />
-                                                <br />2 - {t("probabilities.2.name")} <br />{" "}
-                                                {t("probabilities.2.description")} <br />
-                                                <br />3 - {t("probabilities.3.name")} <br />{" "}
-                                                {t("probabilities.3.description")} <br />
-                                                <br />4 - {t("probabilities.4.name")} <br />{" "}
-                                                {t("probabilities.4.description")} <br />
-                                                <br />5 - {t("probabilities.5.name")} <br />{" "}
-                                                {t("probabilities.5.description")} <br />
-                                            </>
-                                        }
-                                    >
-                                        <InfoOutlined
-                                            className="info-adornment"
-                                            sx={{
-                                                "&:hover": {
-                                                    color: "#fcac0c !important",
-                                                },
-                                            }}
-                                        />
-                                    </Tooltip>
-                                </InputAdornment>
-                            ),
+                        slotProps={{
+                            input: {
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <Tooltip
+                                            title={
+                                                <>
+                                                    1 - {t("probabilities.1.name")} <br />{" "}
+                                                    {t("probabilities.1.description")} <br />
+                                                    <br />2 - {t("probabilities.2.name")} <br />{" "}
+                                                    {t("probabilities.2.description")} <br />
+                                                    <br />3 - {t("probabilities.3.name")} <br />{" "}
+                                                    {t("probabilities.3.description")} <br />
+                                                    <br />4 - {t("probabilities.4.name")} <br />{" "}
+                                                    {t("probabilities.4.description")} <br />
+                                                    <br />5 - {t("probabilities.5.name")} <br />{" "}
+                                                    {t("probabilities.5.description")} <br />
+                                                </>
+                                            }
+                                        >
+                                            <InfoOutlined
+                                                className="info-adornment"
+                                                sx={{
+                                                    "&:hover": {
+                                                        color: "#fcac0c !important",
+                                                    },
+                                                }}
+                                            />
+                                        </Tooltip>
+                                    </InputAdornment>
+                                ),
+                            },
                         }}
                     />
 
@@ -586,11 +592,13 @@ const AddThreatDialog = ({ threat, project, userRole, ...props }: AddThreatDialo
                         }}
                     >
                         <Box
-                            display="flex"
-                            alignItems="center"
-                            justifyContent="space-between"
-                            paddingTop={1}
-                            paddingBottom={2}
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "space-between",
+                                paddingTop: 1,
+                                paddingBottom: 2,
+                            }}
                         >
                             <Box sx={{ display: "flex", alignItems: "center" }}>
                                 <SearchField onChange={onChangeSearchValue} data-testid="SearchAsset" />

--- a/apps/frontend/src/view/dialogs/catalog-measure.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/catalog-measure.dialog.tsx
@@ -140,7 +140,17 @@ const CatalogMeasureDialog = ({ catalogMeasure, isNew, catalogId, ...props }: Ca
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="sm" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="sm"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,
@@ -203,12 +213,14 @@ const CatalogMeasureDialog = ({ catalogMeasure, isNew, catalogId, ...props }: Ca
                                         validate: (value) => !!value && value.length > 0,
                                     })}
                                     MenuProps={{
-                                        PaperProps: {
-                                            sx: {
-                                                bgcolor: "background.mainIntransparent",
-                                                borderRadius: 5,
-                                                "*": {
-                                                    fontSize: "0.875rem !important",
+                                        slotProps: {
+                                            paper: {
+                                                sx: {
+                                                    bgcolor: "background.mainIntransparent",
+                                                    borderRadius: 5,
+                                                    "*": {
+                                                        fontSize: "0.875rem !important",
+                                                    },
                                                 },
                                             },
                                         },
@@ -296,12 +308,14 @@ const CatalogMeasureDialog = ({ catalogMeasure, isNew, catalogId, ...props }: Ca
                                         validate: (value) => !!value && value.length > 0,
                                     })}
                                     MenuProps={{
-                                        PaperProps: {
-                                            sx: {
-                                                bgcolor: "background.mainIntransparent",
-                                                borderRadius: 5,
-                                                "*": {
-                                                    fontSize: "0.875rem !important",
+                                        slotProps: {
+                                            paper: {
+                                                sx: {
+                                                    bgcolor: "background.mainIntransparent",
+                                                    borderRadius: 5,
+                                                    "*": {
+                                                        fontSize: "0.875rem !important",
+                                                    },
                                                 },
                                             },
                                         },

--- a/apps/frontend/src/view/dialogs/catalog-threat.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/catalog-threat.dialog.tsx
@@ -136,7 +136,17 @@ const CatalogThreatDialog = ({ catalogThreat, isNew, ...props }: CatalogThreatDi
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="sm" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="sm"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,
@@ -195,12 +205,14 @@ const CatalogThreatDialog = ({ catalogThreat, isNew, ...props }: CatalogThreatDi
                                         validate: (value) => !!value && value.length > 0,
                                     })}
                                     MenuProps={{
-                                        PaperProps: {
-                                            sx: {
-                                                bgcolor: "background.mainIntransparent",
-                                                borderRadius: 5,
-                                                "*": {
-                                                    fontSize: "0.875rem !important",
+                                        slotProps: {
+                                            paper: {
+                                                sx: {
+                                                    bgcolor: "background.mainIntransparent",
+                                                    borderRadius: 5,
+                                                    "*": {
+                                                        fontSize: "0.875rem !important",
+                                                    },
                                                 },
                                             },
                                         },
@@ -288,12 +300,14 @@ const CatalogThreatDialog = ({ catalogThreat, isNew, ...props }: CatalogThreatDi
                                         validate: (value) => !!value && value.length > 0,
                                     })}
                                     MenuProps={{
-                                        PaperProps: {
-                                            sx: {
-                                                bgcolor: "background.mainIntransparent",
-                                                borderRadius: 5,
-                                                "*": {
-                                                    fontSize: "0.875rem !important",
+                                        slotProps: {
+                                            paper: {
+                                                sx: {
+                                                    bgcolor: "background.mainIntransparent",
+                                                    borderRadius: 5,
+                                                    "*": {
+                                                        fontSize: "0.875rem !important",
+                                                    },
                                                 },
                                             },
                                         },

--- a/apps/frontend/src/view/dialogs/component.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/component.dialog.tsx
@@ -174,7 +174,16 @@ const ComponentDialog = ({ component, ...props }: ComponentDialogProps) => {
     const symbol = getValues("symbol") ?? "";
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} fullWidth={false} {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            fullWidth={false}
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,

--- a/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
@@ -195,7 +195,17 @@ const MeasureDetailsDialog = ({ project, measure, ...props }: MeasureDetailsDial
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="md" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="md"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,

--- a/apps/frontend/src/view/dialogs/measureImpactByMeasure.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measureImpactByMeasure.dialog.tsx
@@ -185,7 +185,17 @@ const MeasureImpactByMeasureDialog = ({
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="sm" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="sm"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,
@@ -246,12 +256,14 @@ const MeasureImpactByMeasureDialog = ({
                                     })}
                                     onChange={onChange}
                                     MenuProps={{
-                                        PaperProps: {
-                                            sx: {
-                                                bgcolor: "background.mainIntransparent",
-                                                borderRadius: 5,
-                                                "*": {
-                                                    fontSize: "0.875rem !important",
+                                        slotProps: {
+                                            paper: {
+                                                sx: {
+                                                    bgcolor: "background.mainIntransparent",
+                                                    borderRadius: 5,
+                                                    "*": {
+                                                        fontSize: "0.875rem !important",
+                                                    },
                                                 },
                                             },
                                         },
@@ -432,36 +444,38 @@ const MeasureImpactByMeasureDialog = ({
                         })}
                         error={!!errors?.probability}
                         helperText={errors?.probability?.message}
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <Tooltip
-                                        title={
-                                            <>
-                                                1 - {t("probabilities.1.name")} <br />{" "}
-                                                {t("probabilities.1.description")} <br />
-                                                <br />2 - {t("probabilities.2.name")} <br />{" "}
-                                                {t("probabilities.2.description")} <br />
-                                                <br />3 - {t("probabilities.3.name")} <br />{" "}
-                                                {t("probabilities.3.description")} <br />
-                                                <br />4 - {t("probabilities.4.name")} <br />{" "}
-                                                {t("probabilities.4.description")} <br />
-                                                <br />5 - {t("probabilities.5.name")} <br />{" "}
-                                                {t("probabilities.5.description")} <br />
-                                            </>
-                                        }
-                                    >
-                                        <InfoOutlined
-                                            className="info-adornment"
-                                            sx={{
-                                                "&:hover": {
-                                                    color: "#fcac0c !important",
-                                                },
-                                            }}
-                                        />
-                                    </Tooltip>
-                                </InputAdornment>
-                            ),
+                        slotProps={{
+                            input: {
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <Tooltip
+                                            title={
+                                                <>
+                                                    1 - {t("probabilities.1.name")} <br />{" "}
+                                                    {t("probabilities.1.description")} <br />
+                                                    <br />2 - {t("probabilities.2.name")} <br />{" "}
+                                                    {t("probabilities.2.description")} <br />
+                                                    <br />3 - {t("probabilities.3.name")} <br />{" "}
+                                                    {t("probabilities.3.description")} <br />
+                                                    <br />4 - {t("probabilities.4.name")} <br />{" "}
+                                                    {t("probabilities.4.description")} <br />
+                                                    <br />5 - {t("probabilities.5.name")} <br />{" "}
+                                                    {t("probabilities.5.description")} <br />
+                                                </>
+                                            }
+                                        >
+                                            <InfoOutlined
+                                                className="info-adornment"
+                                                sx={{
+                                                    "&:hover": {
+                                                        color: "#fcac0c !important",
+                                                    },
+                                                }}
+                                            />
+                                        </Tooltip>
+                                    </InputAdornment>
+                                ),
+                            },
                         }}
                     />
                 </Box>
@@ -528,46 +542,48 @@ const MeasureImpactByMeasureDialog = ({
                         })}
                         error={!!errors?.damage}
                         helperText={errors?.damage?.message}
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <Tooltip
-                                        title={
-                                            <>
-                                                1 - {t("damages.1.name")}
-                                                <br />
-                                                {t("damages.1.description")}
-                                                <br />
-                                                <br />2 - {t("damages.2.name")}
-                                                <br />
-                                                {t("damages.2.description")}
-                                                <br />
-                                                <br />3 - {t("damages.3.name")}
-                                                <br />
-                                                {t("damages.3.description")}
-                                                <br />
-                                                <br />4 - {t("damages.4.name")}
-                                                <br />
-                                                {t("damages.4.description")}
-                                                <br />
-                                                <br />5 - {t("damages.5.name")}
-                                                <br />
-                                                {t("damages.5.description")}
-                                                <br />
-                                            </>
-                                        }
-                                    >
-                                        <InfoOutlined
-                                            className="info-adornment"
-                                            sx={{
-                                                "&:hover": {
-                                                    color: "#fcac0c !important",
-                                                },
-                                            }}
-                                        />
-                                    </Tooltip>
-                                </InputAdornment>
-                            ),
+                        slotProps={{
+                            input: {
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <Tooltip
+                                            title={
+                                                <>
+                                                    1 - {t("damages.1.name")}
+                                                    <br />
+                                                    {t("damages.1.description")}
+                                                    <br />
+                                                    <br />2 - {t("damages.2.name")}
+                                                    <br />
+                                                    {t("damages.2.description")}
+                                                    <br />
+                                                    <br />3 - {t("damages.3.name")}
+                                                    <br />
+                                                    {t("damages.3.description")}
+                                                    <br />
+                                                    <br />4 - {t("damages.4.name")}
+                                                    <br />
+                                                    {t("damages.4.description")}
+                                                    <br />
+                                                    <br />5 - {t("damages.5.name")}
+                                                    <br />
+                                                    {t("damages.5.description")}
+                                                    <br />
+                                                </>
+                                            }
+                                        >
+                                            <InfoOutlined
+                                                className="info-adornment"
+                                                sx={{
+                                                    "&:hover": {
+                                                        color: "#fcac0c !important",
+                                                    },
+                                                }}
+                                            />
+                                        </Tooltip>
+                                    </InputAdornment>
+                                ),
+                            },
                         }}
                     />
                 </Box>

--- a/apps/frontend/src/view/dialogs/measureImpactByThreat.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measureImpactByThreat.dialog.tsx
@@ -151,7 +151,17 @@ const MeasureImpactByThreatDialog = ({
     };
 
     return (
-        <Dialog onBackdropClick={handleCancelDialog} maxWidth="sm" fullWidth {...props} open={true}>
+        <Dialog
+            onClose={(_event, reason) => {
+                if (reason === "backdropClick") {
+                    handleCancelDialog?.();
+                }
+            }}
+            maxWidth="sm"
+            fullWidth
+            {...props}
+            open={true}
+        >
             <DialogTitle
                 sx={{
                     padding: 0,
@@ -205,12 +215,14 @@ const MeasureImpactByThreatDialog = ({
                                         fieldOnChange(selectedValue);
                                     }}
                                     MenuProps={{
-                                        PaperProps: {
-                                            sx: {
-                                                bgcolor: "background.mainIntransparent",
-                                                borderRadius: 5,
-                                                "*": {
-                                                    fontSize: "0.875rem !important",
+                                        slotProps: {
+                                            paper: {
+                                                sx: {
+                                                    bgcolor: "background.mainIntransparent",
+                                                    borderRadius: 5,
+                                                    "*": {
+                                                        fontSize: "0.875rem !important",
+                                                    },
                                                 },
                                             },
                                         },
@@ -392,36 +404,38 @@ const MeasureImpactByThreatDialog = ({
                         })}
                         error={!!errors?.probability}
                         helperText={errors?.probability?.message}
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <Tooltip
-                                        title={
-                                            <>
-                                                1 - {t("probabilities.1.name")} <br />{" "}
-                                                {t("probabilities.1.description")} <br />
-                                                <br />2 - {t("probabilities.2.name")} <br />{" "}
-                                                {t("probabilities.2.description")} <br />
-                                                <br />3 - {t("probabilities.3.name")} <br />{" "}
-                                                {t("probabilities.3.description")} <br />
-                                                <br />4 - {t("probabilities.4.name")} <br />{" "}
-                                                {t("probabilities.4.description")} <br />
-                                                <br />5 - {t("probabilities.5.name")} <br />{" "}
-                                                {t("probabilities.5.description")} <br />
-                                            </>
-                                        }
-                                    >
-                                        <InfoOutlined
-                                            className="info-adornment"
-                                            sx={{
-                                                "&:hover": {
-                                                    color: "#fcac0c !important",
-                                                },
-                                            }}
-                                        />
-                                    </Tooltip>
-                                </InputAdornment>
-                            ),
+                        slotProps={{
+                            input: {
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <Tooltip
+                                            title={
+                                                <>
+                                                    1 - {t("probabilities.1.name")} <br />{" "}
+                                                    {t("probabilities.1.description")} <br />
+                                                    <br />2 - {t("probabilities.2.name")} <br />{" "}
+                                                    {t("probabilities.2.description")} <br />
+                                                    <br />3 - {t("probabilities.3.name")} <br />{" "}
+                                                    {t("probabilities.3.description")} <br />
+                                                    <br />4 - {t("probabilities.4.name")} <br />{" "}
+                                                    {t("probabilities.4.description")} <br />
+                                                    <br />5 - {t("probabilities.5.name")} <br />{" "}
+                                                    {t("probabilities.5.description")} <br />
+                                                </>
+                                            }
+                                        >
+                                            <InfoOutlined
+                                                className="info-adornment"
+                                                sx={{
+                                                    "&:hover": {
+                                                        color: "#fcac0c !important",
+                                                    },
+                                                }}
+                                            />
+                                        </Tooltip>
+                                    </InputAdornment>
+                                ),
+                            },
                         }}
                     />
                 </Box>
@@ -488,46 +502,48 @@ const MeasureImpactByThreatDialog = ({
                         })}
                         error={!!errors?.damage}
                         helperText={errors?.damage?.message}
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <Tooltip
-                                        title={
-                                            <>
-                                                1 - {t("damages.1.name")}
-                                                <br />
-                                                {t("damages.1.description")}
-                                                <br />
-                                                <br />2 - {t("damages.2.name")}
-                                                <br />
-                                                {t("damages.2.description")}
-                                                <br />
-                                                <br />3 - {t("damages.3.name")}
-                                                <br />
-                                                {t("damages.3.description")}
-                                                <br />
-                                                <br />4 - {t("damages.4.name")}
-                                                <br />
-                                                {t("damages.4.description")}
-                                                <br />
-                                                <br />5 - {t("damages.5.name")}
-                                                <br />
-                                                {t("damages.5.description")}
-                                                <br />
-                                            </>
-                                        }
-                                    >
-                                        <InfoOutlined
-                                            className="info-adornment"
-                                            sx={{
-                                                "&:hover": {
-                                                    color: "#fcac0c !important",
-                                                },
-                                            }}
-                                        />
-                                    </Tooltip>
-                                </InputAdornment>
-                            ),
+                        slotProps={{
+                            input: {
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <Tooltip
+                                            title={
+                                                <>
+                                                    1 - {t("damages.1.name")}
+                                                    <br />
+                                                    {t("damages.1.description")}
+                                                    <br />
+                                                    <br />2 - {t("damages.2.name")}
+                                                    <br />
+                                                    {t("damages.2.description")}
+                                                    <br />
+                                                    <br />3 - {t("damages.3.name")}
+                                                    <br />
+                                                    {t("damages.3.description")}
+                                                    <br />
+                                                    <br />4 - {t("damages.4.name")}
+                                                    <br />
+                                                    {t("damages.4.description")}
+                                                    <br />
+                                                    <br />5 - {t("damages.5.name")}
+                                                    <br />
+                                                    {t("damages.5.description")}
+                                                    <br />
+                                                </>
+                                            }
+                                        >
+                                            <InfoOutlined
+                                                className="info-adornment"
+                                                sx={{
+                                                    "&:hover": {
+                                                        color: "#fcac0c !important",
+                                                    },
+                                                }}
+                                            />
+                                        </Tooltip>
+                                    </InputAdornment>
+                                ),
+                            },
                         }}
                     />
                 </Box>

--- a/apps/frontend/src/view/pages/asset-dialog.page.test.tsx
+++ b/apps/frontend/src/view/pages/asset-dialog.page.test.tsx
@@ -1,0 +1,96 @@
+import { screen } from "@testing-library/react";
+import { Route, Routes, type InitialEntry } from "react-router-dom";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createProject } from "#test-utils/builders.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import type { RootState } from "#application/store.ts";
+import AssetDialogPage from "./asset-dialog.page";
+import type { AddAssetDialogProps } from "../dialogs/add-asset.dialog";
+
+vi.mock("../dialogs/add-asset.dialog", () => ({
+    default: (props: AddAssetDialogProps) => (
+        <div
+            data-testid="add-asset-dialog"
+            data-project-id={props.projectId}
+            data-user-role={props.userRole}
+            data-has-asset={props.asset !== undefined ? "true" : "false"}
+            data-has-on-dialog-close={props.onDialogClose !== undefined ? "true" : "false"}
+        />
+    ),
+}));
+
+const REDIRECT_MARKER = "redirected-to-assets";
+
+function renderPage({ url, preloadedState }: { url: InitialEntry; preloadedState: Partial<RootState> }) {
+    return renderWithProviders(
+        <Routes>
+            <Route path="/projects/:projectId/assets/:assetId/edit" element={<AssetDialogPage />} />
+            <Route path="/projects/:projectId/assets/edit" element={<AssetDialogPage />} />
+            <Route path="/projects/:projectId/assets" element={<div>{REDIRECT_MARKER}</div>} />
+        </Routes>,
+        { preloadedState, initialEntries: [url] }
+    );
+}
+
+describe("AssetDialogPage", () => {
+    it("renders nothing while assets are still loading", () => {
+        renderPage({
+            url: "/projects/1/assets/5/edit",
+            preloadedState: {
+                assets: { ids: [], entities: {}, isPending: true },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+            },
+        });
+
+        expect(screen.queryByTestId("add-asset-dialog")).not.toBeInTheDocument();
+        expect(screen.queryByText(REDIRECT_MARKER)).not.toBeInTheDocument();
+    });
+
+    it("redirects to assets list when asset not found and no location state", () => {
+        const otherAsset = createAsset({ id: 10, name: "Other" });
+
+        renderPage({
+            url: "/projects/1/assets/999/edit",
+            preloadedState: {
+                assets: { ids: [10], entities: { 10: otherAsset }, isPending: false },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+            },
+        });
+
+        expect(screen.getByText(REDIRECT_MARKER)).toBeInTheDocument();
+        expect(screen.queryByTestId("add-asset-dialog")).not.toBeInTheDocument();
+    });
+
+    it("renders dialog with asset from store, projectId, userRole, and onDialogClose", () => {
+        const asset = createAsset({ id: 5, name: "Server DB" });
+        const project = createProject({ id: 1 });
+
+        renderPage({
+            url: "/projects/1/assets/5/edit",
+            preloadedState: {
+                assets: { ids: [5], entities: { 5: asset }, isPending: false },
+                projects: { ids: [], entities: {}, isPending: false, current: project },
+            },
+        });
+
+        const dialog = screen.getByTestId("add-asset-dialog");
+        expect(dialog).toHaveAttribute("data-project-id", "1");
+        expect(dialog).toHaveAttribute("data-user-role", USER_ROLES.EDITOR);
+        expect(dialog).toHaveAttribute("data-has-asset", "true");
+        expect(dialog).toHaveAttribute("data-has-on-dialog-close", "true");
+    });
+
+    it("renders dialog from location state without onDialogClose when no assetId", () => {
+        renderPage({
+            url: { pathname: "/projects/1/assets/edit", state: { asset: { name: "New Asset" } } },
+            preloadedState: {
+                assets: { ids: [], entities: {}, isPending: false },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+            },
+        });
+
+        const dialog = screen.getByTestId("add-asset-dialog");
+        expect(dialog).toHaveAttribute("data-has-asset", "true");
+        expect(dialog).toHaveAttribute("data-has-on-dialog-close", "false");
+    });
+});

--- a/apps/frontend/src/view/pages/asset-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/asset-dialog.page.tsx
@@ -3,8 +3,10 @@
  *     page for the assets.
  */
 
-import { useLocation, useNavigate, useParams, type Location } from "react-router-dom";
+import { useCallback } from "react";
+import { Navigate, useLocation, useNavigate, useParams, type Location } from "react-router-dom";
 import { useAppSelector } from "#application/hooks/use-app-redux.hook.ts";
+import { assetsSelectors } from "#application/selectors/assets.selectors.ts";
 import type { Asset } from "#api/types/asset.types.ts";
 import AddAssetDialog from "../dialogs/add-asset.dialog";
 
@@ -20,21 +22,38 @@ interface AssetDialogLocationState {
  */
 const AssetDialogPage = () => {
     const navigate = useNavigate();
-    const { projectId = "" } = useParams<{ projectId?: string }>();
+    const { projectId = "", assetId } = useParams<{ projectId?: string; assetId?: string }>();
     const userRole = useAppSelector((state) => state.projects.current?.role);
     const { state } = useLocation() as Location<AssetDialogLocationState | undefined>;
 
-    if (state) {
-        const asset = state.asset;
+    const assetFromStore = useAppSelector((state) =>
+        assetId ? assetsSelectors.selectById(state, Number(assetId)) : undefined
+    );
+    const isAssetsLoaded = useAppSelector((state) => !state.assets.isPending);
 
-        return (
-            <AddAssetDialog open={true} projectId={Number(projectId) || undefined} asset={asset} userRole={userRole} />
-        );
-    } else {
-        navigate(`/projects/${projectId}/assets`, { replace: true });
+    const handleEditorClose = useCallback(() => {
+        navigate(`/projects/${projectId}/system`, { replace: true });
+    }, [navigate, projectId]);
 
+    if (assetId && !assetFromStore && !isAssetsLoaded) {
         return null;
     }
+
+    const asset = assetFromStore ?? state?.asset;
+
+    if (!asset && !state) {
+        return <Navigate to={`/projects/${projectId}/assets`} replace />;
+    }
+
+    return (
+        <AddAssetDialog
+            open={true}
+            projectId={Number(projectId) || undefined}
+            {...(asset && { asset })}
+            userRole={userRole}
+            {...(assetId && { onDialogClose: handleEditorClose })}
+        />
+    );
 };
 
 export default AssetDialogPage;

--- a/apps/frontend/src/view/pages/editor.page.test.tsx
+++ b/apps/frontend/src/view/pages/editor.page.test.tsx
@@ -1,0 +1,265 @@
+import { screen, act } from "@testing-library/react";
+import { Route, Routes } from "react-router-dom";
+import { EditorPage } from "./editor.page";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset } from "#test-utils/builders.ts";
+import { mockUseConfirm, mockUseAlert, mockUseEditor, mockUseAssets } from "#test-utils/mock-hooks.ts";
+import type { useEditor } from "#application/hooks/use-editor.hook.ts";
+import { EditorSidebar } from "../components/editor-components/editor-sidebar.component";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+// --- Hook spies (module-level, persist across tests) ---
+
+const editorSpy = mockUseEditor();
+mockUseAssets();
+mockUseConfirm();
+mockUseAlert();
+
+// --- Child component mocks (isolate page from canvas/sidebar internals) ---
+
+vi.mock("../components/with-menu.component", () => ({
+    CreatePage: (_Header: unknown, Body: unknown) => Body,
+    HeaderNavigation: () => null,
+}));
+
+vi.mock("../components/editor-components/editor-sidebar.component", () => ({
+    EditorSidebar: vi.fn(({ sidebarRef }: { sidebarRef?: React.RefObject<HTMLDivElement | null> }) => (
+        <div data-testid="editor-sidebar" ref={sidebarRef} />
+    )),
+}));
+
+vi.mock("../components/editor-components/editor-stage.component", () => ({
+    EditorStage: ({ children }: { children: React.ReactNode }) => <div data-testid="editor-stage">{children}</div>,
+}));
+
+vi.mock("../components/editor-components/system-component.component", () => ({
+    SystemComponent: () => null,
+}));
+
+vi.mock("../components/editor-components/system-component-connection.component", () => ({
+    SystemComponentConnection: () => null,
+}));
+
+vi.mock("../components/editor-components/connection-preview.component", () => ({
+    ConnectionPreview: () => null,
+}));
+
+vi.mock("../components/editor-components/editor-communication-interface-context-menu.component", () => ({
+    CommunicationContextMenu: () => null,
+}));
+
+vi.mock("../dialogs/add-communication-interface.dialog", () => ({
+    default: () => null,
+}));
+
+vi.mock("./asset-dialog.page", () => ({
+    default: () => <div data-testid="asset-dialog-page" />,
+}));
+
+vi.mock("./component-dialog.page", () => ({
+    default: () => <div data-testid="component-dialog-page" />,
+}));
+
+vi.mock("react-konva", () => ({
+    Group: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Layer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Line: () => null,
+}));
+
+vi.mock("../components/editor-components/contexts/LineDrawingProvider", () => ({
+    LineDrawingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../components/page.component", () => ({
+    Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("#hooks/useDebounce.ts", () => ({
+    useDebounce: (fn: () => void) => fn,
+}));
+
+// --- Helpers ---
+
+/**
+ * Returns the mock object from the last useEditor() call (populated after render).
+ * Since mockImplementation creates fresh vi.fn() per call and clearMocks: true
+ * resets spy results between tests, each test gets independent fn instances.
+ */
+const getEditorMock = () => {
+    const { results } = editorSpy.mock;
+    return results[results.length - 1]!.value as ReturnType<typeof useEditor>;
+};
+
+const getSidebarProps = () => {
+    const calls = vi.mocked(EditorSidebar).mock.calls;
+    return calls[calls.length - 1]![0];
+};
+
+interface RenderEditorPageOptions {
+    initialEntries?: string[];
+    role?: USER_ROLES;
+}
+
+const renderEditorPage = ({
+    initialEntries = ["/projects/1/system"],
+    role = USER_ROLES.EDITOR,
+}: RenderEditorPageOptions = {}) => {
+    return renderWithProviders(
+        <Routes>
+            <Route path="/projects/:projectId/system/*" element={<EditorPage />} />
+        </Routes>,
+        {
+            initialEntries,
+            preloadedState: {
+                projects: { current: { role } } as never,
+                editor: { stageScale: 1, stagePosition: { x: 0, y: 0 } } as never,
+            },
+        }
+    );
+};
+
+// --- Tests ---
+
+describe("EditorPage", () => {
+    describe("sidebar handler orchestration", () => {
+        describe("handlePointOfAttackLabelClick", () => {
+            it("clears search and selects the point of attack", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handlePointOfAttackLabelClick("poa-1", "comp-1");
+                });
+
+                expect(mockEditor.setAssetSearchValue).toHaveBeenCalledWith("");
+                expect(mockEditor.selectPointOfAttack).toHaveBeenCalledWith("poa-1");
+            });
+
+            it("with componentId: selects component, deselects connection/connectionPoint, opens sidebar", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handlePointOfAttackLabelClick("poa-1", "comp-1");
+                });
+
+                expect(mockEditor.deselectConnection).toHaveBeenCalledOnce();
+                expect(mockEditor.deselectConnectionPoint).toHaveBeenCalledOnce();
+                expect(mockEditor.selectComponent).toHaveBeenCalledWith("comp-1");
+                expect(screen.getByTestId("editor-sidebar").style.right).toBe("40px");
+            });
+
+            it("without componentId: does not select a component", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handlePointOfAttackLabelClick("poa-1");
+                });
+
+                expect(mockEditor.selectComponent).not.toHaveBeenCalled();
+                expect(screen.getByTestId("editor-sidebar").style.right).not.toBe("40px");
+            });
+        });
+
+        describe("handleAssetNameClick", () => {
+            it("navigates to the asset edit route", () => {
+                renderEditorPage();
+                const props = getSidebarProps();
+                const asset = createAsset({ id: 5, name: "My Asset" });
+
+                act(() => {
+                    props.handleAssetNameClick(asset);
+                });
+
+                expect(screen.getByTestId("asset-dialog-page")).toBeInTheDocument();
+            });
+        });
+
+        describe("handleComponentBreadcrumbClick", () => {
+            it("deselects the point of attack", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleComponentBreadcrumbClick();
+                });
+
+                expect(mockEditor.deselectPointOfAttack).toHaveBeenCalledOnce();
+            });
+        });
+
+        describe("handleSelectConnectedComponent", () => {
+            it("clears search and deselects connection", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleSelectConnectedComponent("comp-2", "ci-1");
+                });
+
+                expect(mockEditor.setAssetSearchValue).toHaveBeenCalledWith("");
+                expect(mockEditor.deselectConnection).toHaveBeenCalledOnce();
+            });
+
+            it("with communicationInterfaceId: selects connectionPoint and POA, deselects component", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleSelectConnectedComponent("comp-2", "ci-1");
+                });
+
+                expect(mockEditor.selectConnectionPoint).toHaveBeenCalledWith("ci-1");
+                expect(mockEditor.selectPointOfAttack).toHaveBeenCalledWith("ci-1");
+                expect(mockEditor.deselectComponent).toHaveBeenCalledOnce();
+                expect(mockEditor.selectComponent).not.toHaveBeenCalled();
+                expect(screen.getByTestId("editor-sidebar").style.right).toBe("40px");
+            });
+
+            it("without communicationInterfaceId: selects component, deselects POA/connectionPoint", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleSelectConnectedComponent("comp-2");
+                });
+
+                expect(mockEditor.deselectPointOfAttack).toHaveBeenCalledOnce();
+                expect(mockEditor.selectComponent).toHaveBeenCalledWith("comp-2");
+                expect(mockEditor.deselectConnectionPoint).toHaveBeenCalledOnce();
+                expect(mockEditor.selectConnectionPoint).not.toHaveBeenCalled();
+                expect(screen.getByTestId("editor-sidebar").style.right).toBe("40px");
+            });
+
+            it("treats null communicationInterfaceId same as undefined", () => {
+                renderEditorPage();
+                const mockEditor = getEditorMock();
+                const props = getSidebarProps();
+
+                act(() => {
+                    props.handleSelectConnectedComponent("comp-2", null);
+                });
+
+                expect(mockEditor.deselectPointOfAttack).toHaveBeenCalledOnce();
+                expect(mockEditor.selectComponent).toHaveBeenCalledWith("comp-2");
+                expect(mockEditor.deselectConnectionPoint).toHaveBeenCalledOnce();
+            });
+        });
+    });
+
+    describe("routing", () => {
+        it("renders AssetDialogPage at assets/:assetId/edit", () => {
+            renderEditorPage({ initialEntries: ["/projects/1/system/assets/5/edit"] });
+
+            expect(screen.getByTestId("asset-dialog-page")).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -31,6 +31,7 @@ import { Page } from "../components/page.component";
 import { SystemComponentConnection } from "../components/editor-components/system-component-connection.component";
 import { SystemComponent } from "../components/editor-components/system-component.component";
 import { CreatePage, HeaderNavigation } from "../components/with-menu.component";
+import AssetDialogPage from "./asset-dialog.page";
 import ComponentDialogPage from "./component-dialog.page";
 import { CommunicationContextMenu } from "../components/editor-components/editor-communication-interface-context-menu.component";
 import { useAlert } from "../../application/hooks/use-alert.hook";
@@ -223,8 +224,8 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
             stageRef.current.scale({ x: 1, y: 1 });
             setLayerPositionEvent(0, 0);
             setStageScaleEvent(1, { x: 0, y: 0 });
+            navigate(location.pathname, { replace: true, state: {} });
         }
-        navigate(location.pathname, { replace: true, state: {} });
     }, [shouldCenter, navigate, location.pathname]);
 
     useEffect(() => {
@@ -349,7 +350,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         autoSaveBlocked();
     });
 
-    const handlComponentDragStart = (_event: KonvaEventObject<DragEvent>, componentId: string): void => {
+    const handleComponentDragStart = (_event: KonvaEventObject<DragEvent>, componentId: string): void => {
         addInUseComponent(componentId);
         selectComponent(componentId);
         deselectConnection();
@@ -382,7 +383,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         });
     };
 
-    const handlComponentDragEnd = (event: KonvaEventObject<DragEvent>, componentId: string): void => {
+    const handleComponentDragEnd = (event: KonvaEventObject<DragEvent>, componentId: string): void => {
         removeInUseComponent(componentId);
         setShowHelpLines(false);
         updateConnectionsOfComponent();
@@ -735,6 +736,50 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         }
     };
 
+    const handlePointOfAttackLabelClick = (pointOfAttackId: string, componentId?: string): void => {
+        setAssetSearchValue("");
+        selectPointOfAttack(pointOfAttackId);
+        if (componentId) {
+            deselectConnection();
+            deselectConnectionPoint();
+            selectComponent(componentId);
+            showSideBar();
+        }
+    };
+
+    const handleAssetNameClick = (asset: Asset): void => {
+        navigate(`assets/${asset.id}/edit`);
+    };
+
+    const handleComponentBreadcrumbClick = (): void => {
+        deselectPointOfAttack();
+    };
+
+    const handleInterfaceBreadcrumbClick = (): void => {
+        if (selectedConnectionPoint?.componentId) {
+            deselectConnectionPoint();
+            deselectPointOfAttack();
+            selectComponent(selectedConnectionPoint.componentId);
+        }
+    };
+
+    const handleSelectConnectedComponent = (componentId: string, communicationInterfaceId?: string | null): void => {
+        setAssetSearchValue("");
+        deselectConnection();
+
+        if (communicationInterfaceId) {
+            selectConnectionPoint(communicationInterfaceId);
+            selectPointOfAttack(communicationInterfaceId);
+            deselectComponent();
+        } else {
+            deselectPointOfAttack();
+            selectComponent(componentId);
+            deselectConnectionPoint();
+        }
+
+        showSideBar();
+    };
+
     const handleChangePointOfAttack = (
         e: ChangeEvent<HTMLInputElement>,
         type: POINTS_OF_ATTACK,
@@ -987,242 +1032,264 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
     }
 
     return (
-        <>
-            <LineDrawingProvider>
-                <Page
+        <LineDrawingProvider>
+            <Page
+                sx={{
+                    p: 0,
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                }}
+            >
+                <Box
                     sx={{
-                        p: 0,
-                        paddingLeft: 0,
-                        paddingRight: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        bgcolor: "background.paper",
+                        boxShadow: 8,
+                        height: "100%",
+                        position: "realtive",
                     }}
                 >
-                    <Box
-                        sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "space-between",
-                            bgcolor: "background.paper",
-                            boxShadow: 8,
-                            height: "100%",
-                            position: "realtive",
-                        }}
+                    <EditorStage
+                        ref={stageRef}
+                        handleMouseDown={handleMouseDown}
+                        handleMouseMove={handleMouseMove}
+                        handleMouseUp={handleMouseUp}
+                        onContextMenuOpen={handleContextMenuOpen}
+                        onContextMenuAction={handleContextMenuAction}
+                        onMouseLeave={handleMouseOut}
+                        onKeyUp={handleKeyUp}
+                        mousePointers={mousePointers}
+                        onScale={onStageScale}
+                        scale={stageScale}
+                        position={stagePosition}
+                        userRole={userRole}
                     >
-                        <EditorStage
-                            ref={stageRef}
-                            handleMouseDown={handleMouseDown}
-                            handleMouseMove={handleMouseMove}
-                            handleMouseUp={handleMouseUp}
-                            onContextMenuOpen={handleContextMenuOpen}
-                            onContextMenuAction={handleContextMenuAction}
-                            onMouseLeave={handleMouseOut}
-                            onKeyUp={handleKeyUp}
-                            mousePointers={mousePointers}
-                            onScale={onStageScale}
-                            scale={stageScale}
-                            position={stagePosition}
-                            userRole={userRole}
-                        >
-                            <Layer>
-                                {lineArray.map((_item, index) => (
+                        <Layer>
+                            {lineArray.map((_item, index) => (
+                                <Line
+                                    key={index}
+                                    points={[
+                                        layerPosition.x - gridRenderConfig.offsetX - gridRenderConfig.stageOffsetX,
+                                        layerPosition.y -
+                                            gridRenderConfig.offsetY +
+                                            index * GRID_CONFIG.renderedGridSizeY -
+                                            gridRenderConfig.stageOffsetY,
+                                        500000,
+                                        layerPosition.y -
+                                            gridRenderConfig.offsetY +
+                                            index * GRID_CONFIG.renderedGridSizeY -
+                                            gridRenderConfig.stageOffsetY,
+                                    ]}
+                                    stroke={GRID_CONFIG.gridLineColor}
+                                    strokeWidth={0.75}
+                                />
+                            ))}
+
+                            {lineArray.map((_item, index) => {
+                                let stageOffsetX = 0;
+                                let stageOffsetY = 0;
+                                if (stageRef?.current) {
+                                    stageOffsetX = stageRef.current.x() / stageRef.current.scale().x;
+                                    stageOffsetY = stageRef.current.y() / stageRef.current.scale().y;
+                                }
+                                const columnsToTheTop =
+                                    Math.floor(layerPosition.y / GRID_CONFIG.renderedGridSizeY) + 75;
+                                const offsetY = columnsToTheTop * GRID_CONFIG.renderedGridSizeY;
+                                const columnsToTheLeft =
+                                    Math.floor(layerPosition.x / GRID_CONFIG.renderedGridSizeX) + 75;
+                                const offsetX = columnsToTheLeft * GRID_CONFIG.renderedGridSizeX;
+                                return (
                                     <Line
                                         key={index}
                                         points={[
-                                            layerPosition.x - gridRenderConfig.offsetX - gridRenderConfig.stageOffsetX,
-                                            layerPosition.y -
-                                                gridRenderConfig.offsetY +
-                                                index * GRID_CONFIG.renderedGridSizeY -
-                                                gridRenderConfig.stageOffsetY,
+                                            layerPosition.x -
+                                                offsetX +
+                                                index * GRID_CONFIG.renderedGridSizeX -
+                                                stageOffsetX,
+                                            layerPosition.y - offsetY - stageOffsetY,
+                                            layerPosition.x -
+                                                offsetX +
+                                                index * GRID_CONFIG.renderedGridSizeX -
+                                                stageOffsetX,
                                             500000,
-                                            layerPosition.y -
-                                                gridRenderConfig.offsetY +
-                                                index * GRID_CONFIG.renderedGridSizeY -
-                                                gridRenderConfig.stageOffsetY,
                                         ]}
                                         stroke={GRID_CONFIG.gridLineColor}
                                         strokeWidth={0.75}
                                     />
-                                ))}
+                                );
+                            })}
 
-                                {lineArray.map((_item, index) => {
-                                    let stageOffsetX = 0;
-                                    let stageOffsetY = 0;
-                                    if (stageRef?.current) {
-                                        stageOffsetX = stageRef.current.x() / stageRef.current.scale().x;
-                                        stageOffsetY = stageRef.current.y() / stageRef.current.scale().y;
-                                    }
-                                    const columnsToTheTop =
-                                        Math.floor(layerPosition.y / GRID_CONFIG.renderedGridSizeY) + 75;
-                                    const offsetY = columnsToTheTop * GRID_CONFIG.renderedGridSizeY;
-                                    const columnsToTheLeft =
-                                        Math.floor(layerPosition.x / GRID_CONFIG.renderedGridSizeX) + 75;
-                                    const offsetX = columnsToTheLeft * GRID_CONFIG.renderedGridSizeX;
-                                    return (
-                                        <Line
-                                            key={index}
-                                            points={[
-                                                layerPosition.x -
-                                                    offsetX +
-                                                    index * GRID_CONFIG.renderedGridSizeX -
-                                                    stageOffsetX,
-                                                layerPosition.y - offsetY - stageOffsetY,
-                                                layerPosition.x -
-                                                    offsetX +
-                                                    index * GRID_CONFIG.renderedGridSizeX -
-                                                    stageOffsetX,
-                                                500000,
-                                            ]}
-                                            stroke={GRID_CONFIG.gridLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                    );
-                                })}
+                            {showHelpLines && currentHelpLinesRef.current && (
+                                <Group>
+                                    <Line
+                                        points={[
+                                            -1000,
+                                            currentHelpLinesRef.current.y,
+                                            10000,
+                                            currentHelpLinesRef.current.y,
+                                        ]}
+                                        stroke={GRID_CONFIG.helpLineColor}
+                                        strokeWidth={0.75}
+                                    />
+                                    <Line
+                                        points={[
+                                            -1000,
+                                            currentHelpLinesRef.current.y2,
+                                            10000,
+                                            currentHelpLinesRef.current.y2,
+                                        ]}
+                                        stroke={GRID_CONFIG.helpLineColor}
+                                        strokeWidth={0.75}
+                                    />
+                                    <Line
+                                        points={[
+                                            currentHelpLinesRef.current.x,
+                                            -1000,
+                                            currentHelpLinesRef.current.x,
+                                            10000,
+                                        ]}
+                                        stroke={GRID_CONFIG.helpLineColor}
+                                        strokeWidth={0.75}
+                                    />
+                                    <Line
+                                        points={[
+                                            currentHelpLinesRef.current.x2,
+                                            -1000,
+                                            currentHelpLinesRef.current.x2,
+                                            10000,
+                                        ]}
+                                        stroke={GRID_CONFIG.helpLineColor}
+                                        strokeWidth={0.75}
+                                    />
+                                </Group>
+                            )}
+                        </Layer>
 
-                                {showHelpLines && currentHelpLinesRef.current && (
-                                    <Group>
-                                        <Line
-                                            points={[
-                                                -1000,
-                                                currentHelpLinesRef.current.y,
-                                                10000,
-                                                currentHelpLinesRef.current.y,
-                                            ]}
-                                            stroke={GRID_CONFIG.helpLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                        <Line
-                                            points={[
-                                                -1000,
-                                                currentHelpLinesRef.current.y2,
-                                                10000,
-                                                currentHelpLinesRef.current.y2,
-                                            ]}
-                                            stroke={GRID_CONFIG.helpLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                        <Line
-                                            points={[
-                                                currentHelpLinesRef.current.x,
-                                                -1000,
-                                                currentHelpLinesRef.current.x,
-                                                10000,
-                                            ]}
-                                            stroke={GRID_CONFIG.helpLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                        <Line
-                                            points={[
-                                                currentHelpLinesRef.current.x2,
-                                                -1000,
-                                                currentHelpLinesRef.current.x2,
-                                                10000,
-                                            ]}
-                                            stroke={GRID_CONFIG.helpLineColor}
-                                            strokeWidth={0.75}
-                                        />
-                                    </Group>
-                                )}
-                            </Layer>
+                        <Layer x={layerPosition.x} y={layerPosition.y}>
+                            {newConnection && newConnectionPreviewComponent && (
+                                <ConnectionPreview
+                                    key={`new-connection-${newConnection.from.id}-${Date.now()}`}
+                                    component={newConnectionPreviewComponent}
+                                    newConnectionMousePosition={newConnectionMousePosition}
+                                />
+                            )}
 
-                            <Layer x={layerPosition.x} y={layerPosition.y}>
-                                {newConnection && newConnectionPreviewComponent && (
+                            {componentConnectionLines.map((line, index) => {
+                                const key = `connection-preview-${line.otherComponentInfo.id}-${line.draggedComponentInfo.id}-${index}`;
+                                const otherComponent = components.filter(
+                                    (component) => component.id === line.otherComponentInfo.id
+                                )[0];
+                                const draggedComponent = components.filter(
+                                    (component) => component.id === line.draggedComponentInfo.id
+                                )[0];
+                                if (!otherComponent || !draggedComponent) return null;
+
+                                return (
                                     <ConnectionPreview
-                                        key={`new-connection-${newConnection.from.id}-${Date.now()}`}
-                                        component={newConnectionPreviewComponent}
-                                        newConnectionMousePosition={newConnectionMousePosition}
+                                        key={key}
+                                        component={otherComponent}
+                                        draggedComponent={draggedComponent}
                                     />
-                                )}
+                                );
+                            })}
+                        </Layer>
 
-                                {componentConnectionLines.map((line, index) => {
-                                    const key = `connection-preview-${line.otherComponentInfo.id}-${line.draggedComponentInfo.id}-${index}`;
-                                    const otherComponent = components.filter(
-                                        (component) => component.id === line.otherComponentInfo.id
-                                    )[0];
-                                    const draggedComponent = components.filter(
-                                        (component) => component.id === line.draggedComponentInfo.id
-                                    )[0];
-                                    if (!otherComponent || !draggedComponent) return null;
+                        <Layer x={layerPosition.x} y={layerPosition.y} ref={componentLayerRef}>
+                            {connections.map((connection, i) => {
+                                if (connection.visible === false) {
+                                    return <Group key={i}></Group>;
+                                }
 
-                                    return (
-                                        <ConnectionPreview
-                                            key={key}
-                                            component={otherComponent}
-                                            draggedComponent={draggedComponent}
-                                        />
-                                    );
-                                })}
-                            </Layer>
+                                const fromComponent = components.filter(
+                                    (component) => component.id === connection.from.id
+                                )[0];
+                                const toComponent = components.filter(
+                                    (component) => component.id === connection.to.id
+                                )[0];
+                                if (!fromComponent || !toComponent) return null;
 
-                            <Layer x={layerPosition.x} y={layerPosition.y} ref={componentLayerRef}>
-                                {connections.map((connection, i) => {
-                                    if (connection.visible === false) {
-                                        return <Group key={i}></Group>;
-                                    }
-
-                                    const fromComponent = components.filter(
-                                        (component) => component.id === connection.from.id
-                                    )[0];
-                                    const toComponent = components.filter(
-                                        (component) => component.id === connection.to.id
-                                    )[0];
-                                    if (!fromComponent || !toComponent) return null;
-
-                                    return (
-                                        <SystemComponentConnection
-                                            key={i}
-                                            {...connection}
-                                            onClick={handleSelectConnection}
-                                            onPointOfAttackClicked={handleOnPointOfAttackClicked}
-                                            fromComponent={fromComponent}
-                                            toComponent={toComponent}
-                                            components={components}
-                                            selected={selectedConnectionId === connection.id}
-                                            recalculate={connection.recalculate}
-                                            onRecalculated={onRecalculated}
-                                            onConnectionPointClicked={handleOnConnectionPointClicked}
-                                            selectedConnectionPointId={selectedConnectionPointId}
-                                            stageRef={stageRef}
-                                        />
-                                    );
-                                })}
-                                {components.map((component, i) => (
-                                    <SystemComponent
+                                return (
+                                    <SystemComponentConnection
                                         key={i}
-                                        {...component}
-                                        onSelectAnchor={handleSelectAnchor}
-                                        selectedAnchor={
-                                            newConnection
-                                                ? newConnection.from.id === component.id
-                                                    ? newConnection.from.anchor
-                                                    : ""
-                                                : ""
-                                        }
-                                        onDragMove={(e) => handleComponentDragMove(e, component.id)}
-                                        onClick={(e) => handleSelectComponent(e, component.id)}
-                                        onDragEnd={(e) => handlComponentDragEnd(e, component.id)}
-                                        onDragStart={(e) => handlComponentDragStart(e, component.id)}
+                                        {...connection}
+                                        onClick={handleSelectConnection}
                                         onPointOfAttackClicked={handleOnPointOfAttackClicked}
-                                        selectedPointOfAttackId={selectedPointOfAttack ? selectedPointOfAttack.id : ""}
-                                        component={component}
+                                        fromComponent={fromComponent}
+                                        toComponent={toComponent}
+                                        components={components}
+                                        selected={selectedConnectionId === connection.id}
+                                        recalculate={connection.recalculate}
+                                        onRecalculated={onRecalculated}
+                                        onConnectionPointClicked={handleOnConnectionPointClicked}
+                                        selectedConnectionPointId={selectedConnectionPointId}
                                         stageRef={stageRef}
-                                        userRole={userRole}
-                                        toggleCommunicationInterfacesMenu={toggleCommunicationInterfacesMenu}
                                     />
-                                ))}
-                            </Layer>
-                        </EditorStage>
+                                );
+                            })}
+                            {components.map((component, i) => (
+                                <SystemComponent
+                                    key={i}
+                                    {...component}
+                                    onSelectAnchor={handleSelectAnchor}
+                                    selectedAnchor={
+                                        newConnection
+                                            ? newConnection.from.id === component.id
+                                                ? newConnection.from.anchor
+                                                : ""
+                                            : ""
+                                    }
+                                    onDragMove={(e) => handleComponentDragMove(e, component.id)}
+                                    onClick={(e) => handleSelectComponent(e, component.id)}
+                                    onDragEnd={(e) => handleComponentDragEnd(e, component.id)}
+                                    onDragStart={(e) => handleComponentDragStart(e, component.id)}
+                                    onPointOfAttackClicked={handleOnPointOfAttackClicked}
+                                    selectedPointOfAttackId={selectedPointOfAttack ? selectedPointOfAttack.id : ""}
+                                    component={component}
+                                    stageRef={stageRef}
+                                    userRole={userRole}
+                                    toggleCommunicationInterfacesMenu={toggleCommunicationInterfacesMenu}
+                                />
+                            ))}
+                        </Layer>
+                    </EditorStage>
 
-                        <Box
+                    <Box
+                        sx={{
+                            position: "absolute",
+                            top: 8,
+                            left: 8,
+                            width: "38px",
+                            marginLeft: "auto",
+                            marginRight: "auto",
+                        }}
+                    >
+                        <IconButton
+                            onClick={handleCenterEditor}
                             sx={{
-                                position: "absolute",
-                                top: 8,
-                                left: 8,
-                                width: "38px",
-                                marginLeft: "auto",
-                                marginRight: "auto",
+                                backgroundColor: "background.paperIntransparent",
+                                "&:hover": {
+                                    backgroundColor: "rgba(149, 163, 181, 0.7)",
+                                },
                             }}
                         >
+                            <CenterFocusWeak sx={{ fontSize: 30, color: "primary.main" }} />
+                        </IconButton>
+                    </Box>
+                    <Box
+                        sx={{
+                            position: "absolute",
+                            top: 60,
+                            left: 8,
+                            width: "38px",
+                            marginLeft: "auto",
+                            marginRight: "auto",
+                        }}
+                    >
+                        <Tooltip title={t("canvas.exportSystemImage")}>
                             <IconButton
-                                onClick={handleCenterEditor}
+                                onClick={handleDownloadSystemView}
                                 sx={{
                                     backgroundColor: "background.paperIntransparent",
                                     "&:hover": {
@@ -1230,97 +1297,79 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                                     },
                                 }}
                             >
-                                <CenterFocusWeak sx={{ fontSize: 30, color: "primary.main" }} />
-                            </IconButton>
-                        </Box>
-                        <Box
-                            sx={{
-                                position: "absolute",
-                                top: 60,
-                                left: 8,
-                                width: "38px",
-                                marginLeft: "auto",
-                                marginRight: "auto",
-                            }}
-                        >
-                            <Tooltip title={t("canvas.exportSystemImage")}>
-                                <IconButton
-                                    onClick={handleDownloadSystemView}
+                                <Download
                                     sx={{
-                                        backgroundColor: "background.paperIntransparent",
-                                        "&:hover": {
-                                            backgroundColor: "rgba(149, 163, 181, 0.7)",
-                                        },
+                                        fontSize: 30,
+                                        color: "primary.main",
                                     }}
-                                >
-                                    <Download
-                                        sx={{
-                                            fontSize: 30,
-                                            color: "primary.main",
-                                        }}
-                                    />
-                                </IconButton>
-                            </Tooltip>
-                        </Box>
+                                />
+                            </IconButton>
+                        </Tooltip>
                     </Box>
+                </Box>
 
-                    <EditorSidebar
-                        sidebarRef={sidebarRef}
-                        selectedComponent={selectedComponent}
-                        selectedComponentId={selectedComponentId}
-                        selectedPointOfAttack={selectedPointOfAttack}
-                        handleDeleteComponent={handleDeleteComponent}
-                        handleOnNameChange={handleOnNameChange}
-                        handleChangePointOfAttack={handleChangePointOfAttack}
-                        handleAddAssetToAllPointsOfAttack={handleAddAssetToAllPointsOfAttack}
-                        handleRemoveAssetFromAllPointsOfAttack={handleRemoveAssetFromAllPointsOfAttack}
-                        assetSearchValue={assetSearchValue}
-                        handleAssetSearchChanged={handleAssetSearchChanged}
-                        items={items}
-                        pointsOfAttackOfSelectedComponent={pointsOfAttackOfSelectedComponent}
-                        selectedConnectionId={selectedConnectionId}
-                        selectedConnection={selectedConnection}
-                        handleDeleteConnection={handleDeleteConnection}
-                        handleOnConnectionNameChange={handleConnectionNameChange}
-                        handleOnAssetChanged={handleOnAssetChanged}
-                        selectedConnectionPoint={selectedConnectionPoint}
-                        userRole={userRole}
-                        handleOnDescriptionChange={handleOnDescriptionChange}
-                        connectedComponents={getConnectedComponents(selectedComponentId)}
-                        handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
-                        handleOnConnectionPointDescriptionChange={handleOnConnectionPointDescriptionChange}
-                        handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
-                        handleDeleteCommunicationInterface={handleDeleteCommunicationInterfaceDialog}
+                <EditorSidebar
+                    sidebarRef={sidebarRef}
+                    selectedComponent={selectedComponent}
+                    selectedComponentId={selectedComponentId}
+                    selectedPointOfAttack={selectedPointOfAttack}
+                    handleDeleteComponent={handleDeleteComponent}
+                    handleOnNameChange={handleOnNameChange}
+                    handleChangePointOfAttack={handleChangePointOfAttack}
+                    handleAddAssetToAllPointsOfAttack={handleAddAssetToAllPointsOfAttack}
+                    handleRemoveAssetFromAllPointsOfAttack={handleRemoveAssetFromAllPointsOfAttack}
+                    assetSearchValue={assetSearchValue}
+                    handleAssetSearchChanged={handleAssetSearchChanged}
+                    items={items}
+                    pointsOfAttackOfSelectedComponent={pointsOfAttackOfSelectedComponent}
+                    selectedConnectionId={selectedConnectionId}
+                    selectedConnection={selectedConnection}
+                    handleDeleteConnection={handleDeleteConnection}
+                    handleOnConnectionNameChange={handleConnectionNameChange}
+                    handleOnAssetChanged={handleOnAssetChanged}
+                    selectedConnectionPoint={selectedConnectionPoint}
+                    userRole={userRole}
+                    handleOnDescriptionChange={handleOnDescriptionChange}
+                    connectedComponents={getConnectedComponents(selectedComponentId)}
+                    handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
+                    handleOnConnectionPointDescriptionChange={handleOnConnectionPointDescriptionChange}
+                    handleChangeCommunicationInterfaceName={handleChangeCommunicationInterfaceName}
+                    handleDeleteCommunicationInterface={handleDeleteCommunicationInterfaceDialog}
+                    handlePointOfAttackLabelClick={handlePointOfAttackLabelClick}
+                    handleAssetNameClick={handleAssetNameClick}
+                    handleSelectConnectedComponent={handleSelectConnectedComponent}
+                    handleComponentBreadcrumbClick={handleComponentBreadcrumbClick}
+                    handleInterfaceBreadcrumbClick={handleInterfaceBreadcrumbClick}
+                />
+
+                <Routes>
+                    <Route path="components/edit" element={<ComponentDialogPage />} />
+                    <Route path="assets/:assetId/edit" element={<AssetDialogPage />} />
+                </Routes>
+
+                <CommunicationContextMenu
+                    stageRef={stageRef}
+                    open={communicationMenuOpen}
+                    componentName={communicationMenuComponent?.name}
+                    onSelect={handleCommunicationSelect}
+                    onCreateNew={handleOpenCommunicationInterfaceDialog}
+                    onClose={handleCloseCommunicationMenu}
+                    onSelectAnchor={handleSelectAnchor}
+                    componentId={communicationMenuComponent?.id}
+                    componentType={communicationMenuComponent?.type}
+                    components={components}
+                    connections={connections}
+                    handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
+                />
+                {isCommunicationInterfaceDialogOpen && (
+                    <CommunicationInterfaceDialog
+                        open={true}
+                        onClose={handleCloseCommunicationInterfaceDialog}
+                        handleCreateNew={handleCreateNewCommunicationInterface}
                     />
-
-                    <Routes>
-                        <Route path="components/edit" element={<ComponentDialogPage />} />
-                    </Routes>
-
-                    <CommunicationContextMenu
-                        stageRef={stageRef}
-                        open={communicationMenuOpen}
-                        componentName={communicationMenuComponent?.name}
-                        onSelect={handleCommunicationSelect}
-                        onCreateNew={handleOpenCommunicationInterfaceDialog}
-                        onClose={handleCloseCommunicationMenu}
-                        onSelectAnchor={handleSelectAnchor}
-                        componentId={communicationMenuComponent?.id}
-                        componentType={communicationMenuComponent?.type}
-                        components={components}
-                        connections={connections}
-                        handleDeleteConnectionBetweenComponents={handleDeleteConnectionBetweenComponents}
-                    />
-                    {isCommunicationInterfaceDialogOpen && (
-                        <CommunicationInterfaceDialog
-                            open={true}
-                            onClose={handleCloseCommunicationInterfaceDialog}
-                            handleCreateNew={handleCreateNewCommunicationInterface}
-                        />
-                    )}
-                </Page>
-            </LineDrawingProvider>
-        </>
+                )}
+            </Page>
+        </LineDrawingProvider>
     );
 };
 

--- a/apps/frontend/tests/editor.page.spec.ts
+++ b/apps/frontend/tests/editor.page.spec.ts
@@ -4,6 +4,11 @@ import { getProjects, importProject, deleteProject, deleteCatalog } from "./test
 import threatsFixture from "./fixtures/threats.json" with { type: "json" };
 import type { USER_ROLES } from "#api/types/user-roles.types.ts";
 
+// Canvas click positions for fixture components (center of each component body):
+// Users:  (500, 340)  — fixture pos (465, 305), size 80x80
+// Client: (845, 340)  — fixture pos (810, 305), size 80x80
+// Client CI connector: (885, 370) — opens communication interface context menu
+
 async function addCommunication(page: Page) {
     await page
         .locator("canvas")
@@ -259,6 +264,77 @@ test.describe("Editor Page Tests", () => {
             await page.locator('[data-testid="selected-communication-asset-search-field"] input').fill("NonExistent");
             const results = page.getByTestId("asset-search-results");
             await expect(results).toHaveCount(0);
+        });
+    });
+
+    test.describe("Asset Name Click Navigation Tests", () => {
+        test("Clicking asset name in component sidebar opens edit dialog", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("selected-component-asset-search-results").first().click();
+            await expect(page).toHaveURL(/\/system\/assets\/\d+\/edit/);
+            await expect(page.locator('[data-testid="asset-creation-modal_name-input"]')).toBeVisible();
+        });
+
+        test("Closing asset edit dialog returns to editor", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("selected-component-asset-search-results").first().click();
+            await expect(page).toHaveURL(/\/system\/assets\/\d+\/edit/);
+            await page.getByTestId("cancel-button").click();
+            await expect(page).toHaveURL(/\/system$/);
+        });
+
+        test("Clicking asset name in POA sidebar opens edit dialog", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("poa-switch-USER_INTERFACE").click();
+            await expect(page.locator('[data-testid="selected-point-of-attack-asset-search-field"]')).toBeVisible();
+            await page.getByTestId("asset-search-results").first().click();
+            await expect(page).toHaveURL(/\/system\/assets\/\d+\/edit/);
+        });
+    });
+
+    test.describe("POA Navigation Tests", () => {
+        test("Clicking POA label switches sidebar to POA view", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("poa-switch-USER_INTERFACE").click();
+            await expect(page.locator('[data-testid="selected-point-of-attack-asset-search-field"]')).toBeVisible();
+            await expect(page.getByTestId("poa-breadcrumb-component")).toBeVisible();
+            await expect(page.getByTestId("poa-breadcrumb-component")).toContainText("Client");
+        });
+
+        test("Clicking breadcrumb component name returns to component sidebar", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await page.getByTestId("poa-switch-USER_INTERFACE").click();
+            await expect(page.locator('[data-testid="selected-point-of-attack-asset-search-field"]')).toBeVisible();
+            await page.getByTestId("poa-breadcrumb-component").click();
+            await expect(page.locator('[data-testid="selected-component-asset-search-field"]')).toBeVisible();
+            await expect(page.locator('[data-testid="selected-point-of-attack-asset-search-field"]')).not.toBeVisible();
+        });
+    });
+
+    test.describe("Connected Component Navigation Tests", () => {
+        test("Clicking connected component name switches sidebar to that component", async ({ page }) => {
+            await page
+                .locator("canvas")
+                .nth(2)
+                .click({ position: { x: 845, y: 340 } });
+            await expect(page.getByTestId("connected-component-name").first()).toBeVisible();
+            await page.getByTestId("connected-component-name").first().click();
+            await expect(page.getByTestId("connected-component-name").first()).toContainText("Client");
         });
     });
 

--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -6,5 +6,6 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
 }

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -6,6 +6,9 @@
     },
     {
       "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
     }
   ],
   "compilerOptions": {

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "vitest.setup.ts"]
+  "include": ["src", "vitest.setup.ts"],
+  "exclude": []
 }

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 import svgrPlugin from "vite-plugin-svgr";
 
 export default defineConfig({
-    base: "./",
+    base: "/",
     plugins: [react(), svgrPlugin()],
     cacheDir: ".vite",
     publicDir: "public",

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
         globals: true,
         environment: "jsdom",
         clearMocks: true,
+        pool: "threads",
+        isolate: false,
+        maxWorkers: 1,
         coverage: {
             include: ["src/**/*.{ts,tsx}"],
             exclude: ["src/**/*.{test,spec}.{ts,tsx}", "src/test-utils/**", "src/index.tsx", "src/reportWebVitals.ts"],

--- a/apps/frontend/vitest.setup.ts
+++ b/apps/frontend/vitest.setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+    cleanup();
+});

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.33.1"
+  "packageManager": "pnpm@10.33.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,14 +178,14 @@ importers:
         specifier: 11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@mui/icons-material':
-        specifier: 6.5.0
-        version: 6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
+        specifier: 9.0.0
+        version: 9.0.0(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@mui/material':
-        specifier: 6.5.0
-        version: 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 9.0.0
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mui/system':
-        specifier: 6.5.0
-        version: 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
+        specifier: 9.0.0
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@react-pdf/renderer':
         specifier: 4.5.1
         version: 4.5.1(react@19.2.5)
@@ -1020,27 +1020,27 @@ packages:
     resolution: {integrity: sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==}
     engines: {node: '>=v12.0.0'}
 
-  '@mui/core-downloads-tracker@6.5.0':
-    resolution: {integrity: sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==}
+  '@mui/core-downloads-tracker@9.0.0':
+    resolution: {integrity: sha512-uwQNGkhv0lf7ufxw6QXev77BW6pWbW+7uxYjU5+rfp4lBkFtMEgJCsarTM3Tn+i0lGx6+Ol2u88JdGXr0GDskA==}
 
-  '@mui/icons-material@6.5.0':
-    resolution: {integrity: sha512-VPuPqXqbBPlcVSA0BmnoE4knW4/xG6Thazo8vCLWkOKusko6DtwFV6B665MMWJ9j0KFohTIf3yx2zYtYacvG1g==}
+  '@mui/icons-material@9.0.0':
+    resolution: {integrity: sha512-oDwyvI6LgjWRC9MBcSGvLkPud9S9ELgSBQFYxa1rYcZn6Br55dn22SyvsPDMsn0G8OndFk53iMT45W5mNqrogw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@mui/material': ^6.5.0
+      '@mui/material': ^9.0.0
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/material@6.5.0':
-    resolution: {integrity: sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==}
+  '@mui/material@9.0.0':
+    resolution: {integrity: sha512-+VP/oQCDhDR87NQQgXnNBG8dwy6GNuQLnenS1pZvkbn2dKFSxRSRMybTpH9xUxXP+316mlYDy5CSbYtusnCWtw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
-      '@mui/material-pigment-css': ^6.5.0
+      '@mui/material-pigment-css': ^9.0.0
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1054,8 +1054,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/private-theming@6.4.9':
-    resolution: {integrity: sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==}
+  '@mui/private-theming@9.0.0':
+    resolution: {integrity: sha512-JtuZoaiCqwD6vjgYu6Xp3T7DZkrxJlgtDz5yESzhI34fEX5hHMh2VJUbuL9UOg8xrfIFMrq6dcYoH/7Zi4G0RA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1064,8 +1064,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/styled-engine@6.5.0':
-    resolution: {integrity: sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==}
+  '@mui/styled-engine@9.0.0':
+    resolution: {integrity: sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -1077,8 +1077,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/system@6.5.0':
-    resolution: {integrity: sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==}
+  '@mui/system@9.0.0':
+    resolution: {integrity: sha512-YnC5Zg6j04IxiLc/boAKs0464jfZlLFVa7mf5E8lF0XOtZVUvG6R6gJK50lgUYdaaLdyLfxF6xR7LaPuEpeT/g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -1093,16 +1093,16 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/types@7.2.24':
-    resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
+  '@mui/types@9.0.0':
+    resolution: {integrity: sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/utils@6.4.9':
-    resolution: {integrity: sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==}
+  '@mui/utils@9.0.0':
+    resolution: {integrity: sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5763,23 +5763,23 @@ snapshots:
     dependencies:
       lodash: 4.18.1
 
-  '@mui/core-downloads-tracker@6.5.0': {}
+  '@mui/core-downloads-tracker@9.0.0': {}
 
-  '@mui/icons-material@6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)':
+  '@mui/icons-material@9.0.0(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mui/material': 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/core-downloads-tracker': 6.5.0
-      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
-      '@mui/types': 7.2.24(@types/react@19.2.14)
-      '@mui/utils': 6.4.9(@types/react@19.2.14)(react@19.2.5)
+      '@mui/core-downloads-tracker': 9.0.0
+      '@mui/system': 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
+      '@mui/types': 9.0.0(@types/react@19.2.14)
+      '@mui/utils': 9.0.0(@types/react@19.2.14)(react@19.2.5)
       '@popperjs/core': 2.11.8
       '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
       clsx: 2.1.1
@@ -5794,16 +5794,16 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@types/react': 19.2.14
 
-  '@mui/private-theming@6.4.9(@types/react@19.2.14)(react@19.2.5)':
+  '@mui/private-theming@9.0.0(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/utils': 6.4.9(@types/react@19.2.14)(react@19.2.5)
+      '@mui/utils': 9.0.0(@types/react@19.2.14)(react@19.2.5)
       prop-types: 15.8.1
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@mui/styled-engine@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
+  '@mui/styled-engine@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@emotion/cache': 11.14.0
@@ -5816,13 +5816,13 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
 
-  '@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)':
+  '@mui/system@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/private-theming': 6.4.9(@types/react@19.2.14)(react@19.2.5)
-      '@mui/styled-engine': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
-      '@mui/types': 7.2.24(@types/react@19.2.14)
-      '@mui/utils': 6.4.9(@types/react@19.2.14)(react@19.2.5)
+      '@mui/private-theming': 9.0.0(@types/react@19.2.14)(react@19.2.5)
+      '@mui/styled-engine': 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@mui/types': 9.0.0(@types/react@19.2.14)
+      '@mui/utils': 9.0.0(@types/react@19.2.14)(react@19.2.5)
       clsx: 2.1.1
       csstype: 3.2.3
       prop-types: 15.8.1
@@ -5832,14 +5832,16 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@types/react': 19.2.14
 
-  '@mui/types@7.2.24(@types/react@19.2.14)':
+  '@mui/types@9.0.0(@types/react@19.2.14)':
+    dependencies:
+      '@babel/runtime': 7.29.2
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@mui/utils@6.4.9(@types/react@19.2.14)(react@19.2.5)':
+  '@mui/utils@9.0.0(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/types': 7.2.24(@types/react@19.2.14)
+      '@mui/types': 9.0.0(@types/react@19.2.14)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
       prop-types: 15.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/frontend:
     dependencies:
@@ -282,7 +282,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: 4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -302,14 +302,14 @@ importers:
         specifier: 0.21.1
         version: 0.21.1
       vite:
-        specifier: 8.0.9
-        version: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: 8.0.10
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-svgr:
         specifier: 5.2.0
-        version: 5.2.0(typescript@6.0.3)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/typescript-config: {}
 
@@ -467,11 +467,11 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -1185,8 +1185,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oxc-project/types@0.126.0':
-    resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@oxfmt/binding-android-arm-eabi@0.46.0':
     resolution: {integrity: sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==}
@@ -1542,103 +1542,103 @@ packages:
       react-redux:
         optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.16':
-    resolution: {integrity: sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
-    resolution: {integrity: sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
-    resolution: {integrity: sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
-    resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
-    resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
-    resolution: {integrity: sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
-    resolution: {integrity: sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
-    resolution: {integrity: sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.16':
-    resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -4451,8 +4451,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rolldown@1.0.0-rc.16:
-    resolution: {integrity: sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4984,8 +4984,8 @@ packages:
     peerDependencies:
       vite: '>=3.0.0'
 
-  vite@8.0.9:
-    resolution: {integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==}
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -5384,13 +5384,13 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@emnapi/core@1.9.2':
+  '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5848,10 +5848,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -5931,7 +5931,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oxc-project/types@0.126.0': {}
+  '@oxc-project/types@0.127.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.46.0':
     optional: true
@@ -6207,56 +6207,56 @@ snapshots:
       react: 19.2.5
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.16':
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.16':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.16': {}
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -6640,10 +6640,10 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -6657,7 +6657,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -6668,13 +6668,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -9038,26 +9038,26 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rolldown@1.0.0-rc.16:
+  rolldown@1.0.0-rc.17:
     dependencies:
-      '@oxc-project/types': 0.126.0
-      '@rolldown/pluginutils': 1.0.0-rc.16
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.16
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.16
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.16
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.16
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.16
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.16
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.16
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.16
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.16
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   router@2.2.0:
     dependencies:
@@ -9640,23 +9640,23 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  vite-plugin-svgr@5.2.0(typescript@6.0.3)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-svgr@5.2.0(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
-      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.10
-      rolldown: 1.0.0-rc.16
+      rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.12.2
@@ -9665,10 +9665,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -9685,7 +9685,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,8 +202,8 @@ importers:
         specifier: 4.4.0
         version: 4.4.0
       i18next:
-        specifier: 26.0.6
-        version: 26.0.6(typescript@6.0.3)
+        specifier: 26.0.7
+        version: 26.0.7(typescript@6.0.3)
       json-stable-stringify:
         specifier: 1.3.0
         version: 1.3.0
@@ -227,7 +227,7 @@ importers:
         version: 7.73.1(react@19.2.5)
       react-i18next:
         specifier: 17.0.4
-        version: 17.0.4(i18next@26.0.6(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 17.0.4(i18next@26.0.7(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react-konva:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)(konva@10.2.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3163,8 +3163,8 @@ packages:
   hyphen@1.14.1:
     resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
 
-  i18next@26.0.6:
-    resolution: {integrity: sha512-A4U6eCXodIbrhf8EarRurB9/4ebyaurH4+fu4gig9bqxmpSt+fCAFm/GpRQDcN1Xzu/LdFCx4nYHsnM1edIIbg==}
+  i18next@26.0.7:
+    resolution: {integrity: sha512-f7tL/iw0VQsx4nC5oNxBM2RjM8alNys5KzyiQTU6A9TI5TI89py4/Ez1cKFvHiLWsvzOXvuGUES+Kk/A2WiANQ==}
     peerDependencies:
       typescript: ^5 || ^6
     peerDependenciesMeta:
@@ -7904,9 +7904,7 @@ snapshots:
 
   hyphen@1.14.1: {}
 
-  i18next@26.0.6(typescript@6.0.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
+  i18next@26.0.7(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 
@@ -8863,11 +8861,11 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-i18next@17.0.4(i18next@26.0.6(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
+  react-i18next@17.0.4(i18next@26.0.7(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
-      i18next: 26.0.6(typescript@6.0.3)
+      i18next: 26.0.7(typescript@6.0.3)
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: 5.2.1
         version: 5.2.1
       express-rate-limit:
-        specifier: 8.3.2
-        version: 8.3.2(express@5.2.1)
+        specifier: 8.4.0
+        version: 8.4.0(express@5.2.1)
       express-session:
         specifier: 1.19.0
         version: 1.19.0
@@ -2860,8 +2860,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.3.2:
-    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+  express-rate-limit@8.4.0:
+    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -7540,7 +7540,7 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.3.2(express@5.2.1):
+  express-rate-limit@8.4.0(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0


### PR DESCRIPTION
## Summary                                                                                                                                                   
                                         
  Resolves #550                                                                                                                
  
  - Connections involving a `USERS` component now render in pink (USER_BEHAVIOUR color) instead of the default blue                                             
  - Applies to both live connections and the dashed preview line while dragging                                                                             
                                                                                                                                                              
  ### Changes                                                                                                                                                   
                                                                                                                                                              
  - `connection-preview.component.tsx` — Added isUserConnection check; stroke color switches between pink (#ff68bd) and blue (#5786ff) based on whether either endpoint is a USERS component          
  - `system-component-connection.component.tsx` — Same isUserConnection logic; extracted hardcoded color into a colors prop on LineForPath so it receives the correct color set                                                                                                                                           
  - `test-utils/builders.ts `— Added createConnectionAnchor builder for connection endpoint test data
                                                                                                                                                              
  ### Tests                                                                                                                                                     
                                                                                                                                                              
  - `connection-preview.component.test.tsx `(5 tests) — stroke color by component type, padded points calculation, raw mouse-position points                    
  - `system-component-connection.component.test.tsx` (5 tests) — color selection for USERS/non-USERS endpoints, waypoint passthrough, hover/selected color
                                                                                                                                                              
###   Screenshots
<img width="805" height="523" alt="connection line between USERS and another component (pink)" src="https://github.com/user-attachments/assets/9c12da39-cd97-4d99-9400-d0774cf4b8e9" />
<img width="863" height="529" alt="drag preview line" src="https://github.com/user-attachments/assets/a2e83c3d-2639-415a-afa5-e8cf32a20fe4" />
