### PR TITLE
feat(editor): distinguish user-component connections with pink color

### DIFF
--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -3,6 +3,7 @@ import type { ExtendedProject } from "#api/types/project.types.ts";
 import {
     AnchorOrientation,
     type AugmentedSystemComponent,
+    type ConnectionAnchor,
     type SystemConnection,
     type SystemPointOfAttack,
 } from "#api/types/system.types.ts";
@@ -81,6 +82,14 @@ export const createProject = (overrides: Partial<ExtendedProject> = {}): Extende
     updatedAt: new Date("2025-01-01"),
     role: USER_ROLES.EDITOR,
     image: null,
+    ...overrides,
+});
+
+export const createConnectionAnchor = (overrides: Partial<ConnectionAnchor> = {}) => ({
+    id: "comp-1",
+    anchor: AnchorOrientation.right,
+    type: STANDARD_COMPONENT_TYPES.CLIENT,
+    component: undefined,
     ...overrides,
 });
 

--- a/apps/frontend/src/view/components/editor-components/connection-preview.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/connection-preview.component.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { POA_COLORS } from "../../colors/pointsOfAttack.colors";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { createSystemComponent } from "#test-utils/builders.ts";
+import { ConnectionPreview } from "./connection-preview.component";
+
+vi.mock("react-konva", () => ({
+    Line: (props: Record<string, unknown>) => (
+        <div data-testid="konva-line" data-stroke={props["stroke"]} data-points={JSON.stringify(props["points"])} />
+    ),
+}));
+
+describe("ConnectionPreview", () => {
+    it("renders with blue stroke when component is not USERS type", () => {
+        render(
+            <ConnectionPreview
+                component={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                newConnectionMousePosition={{ x: 300, y: 300 }}
+            />
+        );
+
+        const line = screen.getByTestId("konva-line");
+        expect(line).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE].normal);
+    });
+
+    it("renders with pink stroke when component type is USERS", () => {
+        render(
+            <ConnectionPreview
+                component={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                newConnectionMousePosition={{ x: 300, y: 300 }}
+            />
+        );
+
+        const line = screen.getByTestId("konva-line");
+        expect(line).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal);
+    });
+
+    it("renders with pink stroke when draggedComponent type is USERS", () => {
+        render(
+            <ConnectionPreview
+                component={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                draggedComponent={createSystemComponent({
+                    id: "comp-2",
+                    type: STANDARD_COMPONENT_TYPES.USERS,
+                    x: 300,
+                    y: 300,
+                })}
+            />
+        );
+
+        const line = screen.getByTestId("konva-line");
+        expect(line).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal);
+    });
+
+    it("calculates padded points when draggedComponent is provided", () => {
+        const component = createSystemComponent({ x: 0, y: 0, width: 100, height: 100 });
+        const draggedComponent = createSystemComponent({ id: "comp-2", x: 200, y: 0, width: 100, height: 100 });
+
+        render(<ConnectionPreview component={component} draggedComponent={draggedComponent} />);
+
+        const line = screen.getByTestId("konva-line");
+        const points: number[] = JSON.parse(line.dataset["points"]!);
+
+        // Both components have center at (50,50) and (250,50) respectively.
+        // The line between them is horizontal (200px apart), padded inward by 45px on each end.
+        expect(points).toHaveLength(4);
+        expect(points[0]).toBeGreaterThan(50);
+        expect(points[2]).toBeLessThan(250);
+        // Y coordinates stay at 50 (centers aligned horizontally)
+        expect(points[1]).toBe(50);
+        expect(points[3]).toBe(50);
+    });
+
+    it("uses raw center-to-mouse points when newConnectionMousePosition is provided", () => {
+        const component = createSystemComponent({ x: 0, y: 0, width: 100, height: 100 });
+        const mousePosition = { x: 400, y: 300 };
+
+        render(<ConnectionPreview component={component} newConnectionMousePosition={mousePosition} />);
+
+        const line = screen.getByTestId("konva-line");
+        const points: number[] = JSON.parse(line.dataset["points"]!);
+
+        expect(points).toEqual([50, 50, 400, 300]);
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/connection-preview.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/connection-preview.component.tsx
@@ -2,6 +2,9 @@ import { useRef } from "react";
 import { Line } from "react-konva";
 import type { Line as KonvaLine } from "konva/lib/shapes/Line";
 import type { Coordinate, SystemComponent } from "#api/types/system.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { POA_COLORS } from "../../colors/pointsOfAttack.colors";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 
 interface ConnectionPreviewProps {
     component: SystemComponent;
@@ -50,5 +53,11 @@ export const ConnectionPreview = ({
         points = [componentCenter.x, componentCenter.y, newConnectionMousePosition.x, newConnectionMousePosition.y];
     }
 
-    return <Line points={points} stroke={"#3889ff"} strokeWidth={2} ref={lineRef} dash={[20, 5]} dashEnabled />;
+    const isUserConnection =
+        component.type === STANDARD_COMPONENT_TYPES.USERS || draggedComponent?.type === STANDARD_COMPONENT_TYPES.USERS;
+    const strokeColor = isUserConnection
+        ? POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal
+        : POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE].normal;
+
+    return <Line points={points} stroke={strokeColor} strokeWidth={2} ref={lineRef} dash={[20, 5]} dashEnabled />;
 };

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { POA_COLORS } from "../../colors/pointsOfAttack.colors";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { createSystemComponent, createConnectionAnchor } from "#test-utils/builders.ts";
+import { SystemComponentConnection } from "./system-component-connection.component";
+
+vi.mock("react-konva", () => ({
+    Group: ({ children }: { children?: React.ReactNode }) => <div data-testid="konva-group">{children}</div>,
+    Line: (props: Record<string, unknown>) => (
+        <div
+            data-testid="konva-line"
+            data-stroke={props["stroke"]}
+            data-stroke-width={props["strokeWidth"]}
+            data-listening={String(props["listening"])}
+            data-points={JSON.stringify(props["points"])}
+        />
+    ),
+}));
+
+const defaultProps = {
+    id: "connection-1",
+    name: "Connection 1",
+    connectionPoints: [],
+    connectionPointsMeta: [],
+    projectId: 1,
+    recalculate: false,
+    waypoints: [100, 100, 300, 300],
+    components: [],
+    onClick: vi.fn(),
+    onPointOfAttackClicked: vi.fn(),
+    selected: false,
+    onRecalculated: vi.fn(),
+    stageRef: { current: null },
+    pointsOfAttack: [],
+    communicationInterface: null,
+};
+
+describe("SystemComponentConnection", () => {
+    describe("connection color based on component type", () => {
+        it("uses USER_BEHAVIOUR colors when from.type is USERS", () => {
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    to={createConnectionAnchor({ id: "comp-2" })}
+                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    toComponent={createSystemComponent({ id: "comp-2" })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            expect(visibleLine).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal);
+        });
+
+        it("uses USER_BEHAVIOUR colors when to.type is USERS", () => {
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    from={createConnectionAnchor()}
+                    to={createConnectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
+                    fromComponent={createSystemComponent()}
+                    toComponent={createSystemComponent({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            expect(visibleLine).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].normal);
+        });
+
+        it("uses COMMUNICATION_INFRASTRUCTURE colors when neither endpoint is USERS", () => {
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                    to={createConnectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
+                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                    toComponent={createSystemComponent({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            expect(visibleLine).toHaveAttribute(
+                "data-stroke",
+                POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE].normal
+            );
+        });
+
+        it("passes waypoints through to the Line when recalculate is false", () => {
+            const waypoints = [50, 50, 200, 100, 350, 350];
+
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    waypoints={waypoints}
+                    from={createConnectionAnchor()}
+                    to={createConnectionAnchor({ id: "comp-2" })}
+                    fromComponent={createSystemComponent()}
+                    toComponent={createSystemComponent({ id: "comp-2" })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            const renderedPoints = JSON.parse(visibleLine!.dataset["points"]!);
+            expect(renderedPoints).toEqual(waypoints);
+        });
+
+        it("applies hover color when selected", () => {
+            render(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    selected={true}
+                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    to={createConnectionAnchor({ id: "comp-2" })}
+                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    toComponent={createSystemComponent({ id: "comp-2" })}
+                />
+            );
+
+            const visibleLine = screen.getAllByTestId("konva-line").find((el) => el.dataset["listening"] === "false");
+            expect(visibleLine).toHaveAttribute("data-stroke", POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR].hover);
+        });
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
@@ -5,6 +5,7 @@ import { POINTS_OF_ATTACK } from "../../../api/types/points-of-attack.types";
 import type { KonvaEventObject } from "konva/lib/Node";
 import type { Stage as KonvaStage } from "konva/lib/Stage";
 import { AnchorOrientation, type AugmentedSystemComponent, type ConnectionPointMeta } from "#api/types/system.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
 import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
 
 const TURN_PENALTY = 200;
@@ -17,6 +18,7 @@ interface LineForPathProps {
     onPointOfAttackClicked: (event: KonvaEventObject<MouseEvent>) => void;
     selected: boolean;
     hover: boolean;
+    colors: { normal: string; selected: string; hover: string };
 }
 
 interface SystemComponentConnectionProps extends AugmentedSystemConnection {
@@ -56,8 +58,8 @@ function LineForPath({
     onPointOfAttackClicked,
     selected,
     hover,
+    colors,
 }: LineForPathProps) {
-    const COLORS = POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE];
     return (
         <Group
             onMouseOver={onMouseEnter}
@@ -85,7 +87,7 @@ function LineForPath({
             {/* Visible connection line */}
             <Line
                 points={waypoints}
-                stroke={selected || hover ? COLORS.hover : COLORS.normal}
+                stroke={selected || hover ? colors.hover : colors.normal}
                 strokeWidth={selected || hover ? 5 : 3}
                 lineCap={"round"}
                 lineJoin={"round"}
@@ -126,6 +128,11 @@ const SystemComponentConnectionInner = ({
     let fromAnchor = from;
     let toAnchor = to;
 
+    const isUserConnection = from.type === STANDARD_COMPONENT_TYPES.USERS || to.type === STANDARD_COMPONENT_TYPES.USERS;
+    const connectionColors = isUserConnection
+        ? POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR]
+        : POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE];
+
     if (!fromComponent || !toComponent) {
         return null;
     }
@@ -165,6 +172,7 @@ const SystemComponentConnectionInner = ({
                     onPointOfAttackClicked={handleLinePointOfAttackClicked}
                     selected={selected}
                     hover={hover}
+                    colors={connectionColors}
                 />
             </Group>
         );
@@ -279,6 +287,7 @@ const SystemComponentConnectionInner = ({
                         onPointOfAttackClicked={handleLinePointOfAttackClicked}
                         selected={selected}
                         hover={hover}
+                        colors={connectionColors}
                     />
                 </Group>
             );


### PR DESCRIPTION
## Summary                                                                                                                                                   
                                         
  Resolves #550                                                                                                                  
  
  - Connections involving a USERS component now render in pink (USER_BEHAVIOUR color) instead of the default blue                                             
  - Applies to both live connections and the dashed preview line while dragging                                                                             
                                                                                                                                                              
  ### Changes                                                                                                                                                   
                                                                                                                                                              
  - `connection-preview.component.tsx `— Added isUserConnection check; stroke color switches between pink (#ff68bd) and blue (#5786ff) based on whether either  
  endpoint is a USERS component          
  - s`ystem-component-connection.component.tsx` — Same isUserConnection logic; extracted hardcoded color into a colors prop on LineForPath so it receives the   
  correct color set                                                                                                                                           
  - `test-utils/builders.ts `— Added createConnectionAnchor builder for connection endpoint test data
                                                                                                                                                              
  ### Tests                                                                                                                                                     
                                                                                                                                                              
  - `connection-preview.component.test.tsx `(5 tests) — stroke color by component type, padded points calculation, raw mouse-position points                    
  - `system-component-connection.component.test.tsx `(5 tests) — color selection for USERS/non-USERS endpoints, waypoint passthrough, hover/selected color
                                                                                                                                                              
  ### Screenshots   
  <img width="805" height="523" alt="connection line between USERS and another component (pink)" src="https://github.com/user-attachments/assets/0c1344a7-ee25-41da-853e-f0c9769fedf5" />
<img width="863" height="529" alt="drag preview line" src="https://github.com/user-attachments/assets/5d7e2f8e-b3f8-4d85-baec-570b826f9115" />