### PR TITLE
chore(lint): enforce curly rule with "all" option

### DIFF
--- a/apps/backend/.oxlintrc.json
+++ b/apps/backend/.oxlintrc.json
@@ -24,6 +24,7 @@
   },
   "rules": {
     "constructor-super": "error",
+    "curly": ["error", "all"],
     "for-direction": "error",
     "getter-return": "error",
     "no-async-promise-executor": "error",

--- a/apps/backend/src/services/points-of-attack.service.ts
+++ b/apps/backend/src/services/points-of-attack.service.ts
@@ -28,7 +28,9 @@ export interface PointOfAttack {
  * @returns An array of objects with the asset data.
  */
 async function getAssets(assetIds: number[]): Promise<Asset[]> {
-    if (assetIds.length === 0) return [];
+    if (assetIds.length === 0) {
+        return [];
+    }
 
     return await getMultipleAssets(assetIds);
 }
@@ -43,9 +45,13 @@ async function getAssets(assetIds: number[]): Promise<Asset[]> {
 export async function getPointsOfAttack(projectId: number): Promise<PointOfAttack[]> {
     // Fetch system.
     const system = await findSystem(projectId);
-    if (!system) return [];
+    if (!system) {
+        return [];
+    }
     const { data } = system;
-    if (!data) return [];
+    if (!data) {
+        return [];
+    }
 
     // Destructure data.
     const { pointsOfAttack, components = [], connections = [], connectionPoints = [] } = data;

--- a/apps/frontend/.oxlintrc.json
+++ b/apps/frontend/.oxlintrc.json
@@ -18,6 +18,7 @@
   },
   "rules": {
     "constructor-super": "error",
+    "curly": ["error", "all"],
     "for-direction": "error",
     "getter-return": "error",
     "no-async-promise-executor": "error",

--- a/apps/frontend/src/application/hooks/use-addedMember-list.hook.ts
+++ b/apps/frontend/src/application/hooks/use-addedMember-list.hook.ts
@@ -39,11 +39,17 @@ export const useMembersList = (projectCatalogId: number, memberPath: string, mem
 
         return filteredItems.sort((a, b) => {
             if (sortDirection === "asc") {
-                if (sortField === "role") return a[sortField] < b[sortField] ? -1 : 1;
-                else return a[sortField].toLowerCase() < b[sortField].toLowerCase() ? -1 : 1;
+                if (sortField === "role") {
+                    return a[sortField] < b[sortField] ? -1 : 1;
+                } else {
+                    return a[sortField].toLowerCase() < b[sortField].toLowerCase() ? -1 : 1;
+                }
             } else {
-                if (sortField === "role") return a[sortField] > b[sortField] ? -1 : 1;
-                else return a[sortField].toLowerCase() > b[sortField].toLowerCase() ? -1 : 1;
+                if (sortField === "role") {
+                    return a[sortField] > b[sortField] ? -1 : 1;
+                } else {
+                    return a[sortField].toLowerCase() > b[sortField].toLowerCase() ? -1 : 1;
+                }
             }
         });
     }, [filteredItems, sortBy, sortDirection]);

--- a/apps/frontend/src/application/hooks/use-report.hook.ts
+++ b/apps/frontend/src/application/hooks/use-report.hook.ts
@@ -33,8 +33,12 @@ const calcNetRiskMatrix = (
     matrix: RiskMatrix | null,
     scheduledAt: Date
 ): RiskMatrix | null => {
-    if (!threats) return null;
-    if (!matrix) return null;
+    if (!threats) {
+        return null;
+    }
+    if (!matrix) {
+        return null;
+    }
     return threats.reduce(
         (arr, threat) => {
             const probability = threat.measures.reduce((min, measure) => {
@@ -83,7 +87,9 @@ const calcNetRiskMatrix = (
 };
 
 const calcRiskBarGraph = (matrix: RiskMatrix | null): RiskBarGraph | null => {
-    if (!matrix) return null;
+    if (!matrix) {
+        return null;
+    }
     return matrix.reduce(
         (summary, row) => {
             row.forEach((cell) => {
@@ -145,8 +151,12 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, []);
 
     const matrixDesign: RiskMatrix | null = useMemo(() => {
-        if (typeof data?.project?.lineOfToleranceGreen !== "number") return null;
-        if (typeof data?.project?.lineOfToleranceRed !== "number") return null;
+        if (typeof data?.project?.lineOfToleranceGreen !== "number") {
+            return null;
+        }
+        if (typeof data?.project?.lineOfToleranceRed !== "number") {
+            return null;
+        }
         const lineOfToleranceGreen = data?.project?.lineOfToleranceGreen;
         const lineOfToleranceRed = data?.project?.lineOfToleranceRed;
         const matrix: RiskMatrix = [];
@@ -164,8 +174,12 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, [data?.project?.lineOfToleranceGreen, data?.project?.lineOfToleranceRed]);
 
     const filteredThreats: ReportThreat[] | null = useMemo(() => {
-        if (!threats) return null;
-        if (!fromScheduledAt && !tillScheduledAt) return threats;
+        if (!threats) {
+            return null;
+        }
+        if (!fromScheduledAt && !tillScheduledAt) {
+            return threats;
+        }
         const from = fromScheduledAt ? new Date(fromScheduledAt) : null;
         const till = tillScheduledAt ? new Date(tillScheduledAt) : null;
         return threats.map((threat) => {
@@ -188,9 +202,15 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, [threats, fromScheduledAt, tillScheduledAt]);
 
     const transformedThreats: (ReportThreat & { bruttoColor: string; nettoColor: string })[] | null = useMemo(() => {
-        if (!filteredThreats) return null;
-        if (typeof data?.project?.lineOfToleranceGreen !== "number") return null;
-        if (typeof data?.project?.lineOfToleranceRed !== "number") return null;
+        if (!filteredThreats) {
+            return null;
+        }
+        if (typeof data?.project?.lineOfToleranceGreen !== "number") {
+            return null;
+        }
+        if (typeof data?.project?.lineOfToleranceRed !== "number") {
+            return null;
+        }
         const lineOfToleranceGreen = data?.project?.lineOfToleranceGreen;
         const lineOfToleranceRed = data?.project?.lineOfToleranceRed;
         return filteredThreats.map((threat) => {
@@ -213,8 +233,12 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, [filteredThreats, data?.project?.lineOfToleranceGreen, data?.project?.lineOfToleranceRed]);
 
     const filteredMeasures: ReportMeasure[] | null = useMemo(() => {
-        if (!measures) return null;
-        if (!fromScheduledAt && !tillScheduledAt) return measures;
+        if (!measures) {
+            return null;
+        }
+        if (!fromScheduledAt && !tillScheduledAt) {
+            return measures;
+        }
         const from = fromScheduledAt ? new Date(fromScheduledAt.substring(0, 10)) : null;
         const till = tillScheduledAt ? new Date(tillScheduledAt.substring(0, 10)) : null;
         return measures.filter((measure) => {
@@ -233,8 +257,12 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, [measures, fromScheduledAt, tillScheduledAt]);
 
     const bruttoMatrix: RiskMatrix | null = useMemo(() => {
-        if (!transformedThreats) return null;
-        if (!matrixDesign) return null;
+        if (!transformedThreats) {
+            return null;
+        }
+        if (!matrixDesign) {
+            return null;
+        }
         return transformedThreats.reduce(
             (arr, threat) => {
                 const y = 5 - threat.probability;
@@ -253,8 +281,12 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, [transformedThreats, matrixDesign]);
 
     const nettoMatrix: RiskMatrix | null = useMemo(() => {
-        if (!transformedThreats) return null;
-        if (!matrixDesign) return null;
+        if (!transformedThreats) {
+            return null;
+        }
+        if (!matrixDesign) {
+            return null;
+        }
         return transformedThreats.reduce(
             (arr, threat) => {
                 const { netProbability, netDamage } = threat;
@@ -274,9 +306,15 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, [transformedThreats, matrixDesign]);
 
     const milestones: Milestone[] | null = useMemo(() => {
-        if (!filteredMeasures) return null;
-        if (!filteredThreats) return null;
-        if (!matrixDesign) return null;
+        if (!filteredMeasures) {
+            return null;
+        }
+        if (!filteredThreats) {
+            return null;
+        }
+        if (!matrixDesign) {
+            return null;
+        }
         const map: Record<number, Milestone> = filteredMeasures.reduce(
             (obj, item) => {
                 if (!item.scheduledAt) {
@@ -307,7 +345,9 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, [filteredMeasures, filteredThreats, matrixDesign]);
 
     const transformedMilestones: Milestone[] | null = useMemo(() => {
-        if (!milestones) return null;
+        if (!milestones) {
+            return null;
+        }
         return milestones.map((milestone) => {
             const { scheduledAt } = milestone;
             const id = scheduledAt.toISOString().substring(0, 10);
@@ -319,7 +359,9 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     }, [milestones, riskMatrixMeasures]);
 
     const sortedThreats: typeof transformedThreats = useMemo(() => {
-        if (!transformedThreats) return null;
+        if (!transformedThreats) {
+            return null;
+        }
 
         const threatsSortedBy = sortBy as keyof (typeof transformedThreats)[number];
         const threatsCopy: typeof transformedThreats = JSON.parse(JSON.stringify(transformedThreats));

--- a/apps/frontend/src/application/reducers/catalogs.reducer.ts
+++ b/apps/frontend/src/application/reducers/catalogs.reducer.ts
@@ -72,9 +72,13 @@ const catalogsReducer = createReducer(defaultState, (builder) => {
         const role = action.payload;
         const id = state.current?.id;
 
-        if (id && state.entities[id]) state.entities[id].role = role;
+        if (id && state.entities[id]) {
+            state.entities[id].role = role;
+        }
 
-        if (state.current) state.current.role = role;
+        if (state.current) {
+            state.current.role = role;
+        }
     });
 });
 

--- a/apps/frontend/src/application/reducers/projects.reducer.ts
+++ b/apps/frontend/src/application/reducers/projects.reducer.ts
@@ -76,9 +76,13 @@ const projectsReducer = createReducer(defaultState, (builder) => {
         const role = action.payload;
         const id = state.current?.id;
 
-        if (id && state.entities[id]) state.entities[id]!.role = role;
+        if (id && state.entities[id]) {
+            state.entities[id]!.role = role;
+        }
 
-        if (state.current) state.current.role = role;
+        if (state.current) {
+            state.current.role = role;
+        }
     });
 });
 

--- a/apps/frontend/src/view/components/alert.component.tsx
+++ b/apps/frontend/src/view/components/alert.component.tsx
@@ -21,7 +21,9 @@ export const Alert = (): JSX.Element | null => {
             console.log(error.type + " " + error.message);
             if (error.type === ERR_TYPE_API) {
                 dispatch(UserActions.setUserLoggedOut());
-                if (location.pathname !== "/login") navigate("/login", { replace: true });
+                if (location.pathname !== "/login") {
+                    navigate("/login", { replace: true });
+                }
             } else if (error.type === ERR_TYPE_PROJECT_CATALOG_EXISTANCE) {
                 navigate("/projects", { replace: true });
             }

--- a/apps/frontend/src/view/components/catalog-measures-list-box.component.tsx
+++ b/apps/frontend/src/view/components/catalog-measures-list-box.component.tsx
@@ -163,7 +163,9 @@ export const CatalogMeasuresListBox = ({
         try {
             const file = e.currentTarget.files?.[0];
             e.currentTarget.value = "";
-            if (!file) throw new Error("file not found");
+            if (!file) {
+                throw new Error("file not found");
+            }
             const result = await importCsvFile(
                 file,
                 (row) => ({
@@ -178,14 +180,18 @@ export const CatalogMeasuresListBox = ({
                 }),
                 (data) => {
                     const { name, probability, attacker, pointOfAttack } = data as Partial<CatalogMeasure>;
-                    if (!name || name === "") throw new Error("name required");
+                    if (!name || name === "") {
+                        throw new Error("name required");
+                    }
                     if (!probability || probability < 1) {
                         throw new Error("probability must be greater equals 1");
                     }
                     if (!probability || probability > 5) {
                         throw new Error("probability must be smaller equals 5");
                     }
-                    if (!attacker || !ATTACKERS[attacker]) throw new Error("attacker type is unknown");
+                    if (!attacker || !ATTACKERS[attacker]) {
+                        throw new Error("attacker type is unknown");
+                    }
                     if (!pointOfAttack || !POINTS_OF_ATTACK[pointOfAttack]) {
                         throw new Error("point of attack type is unknown");
                     }

--- a/apps/frontend/src/view/components/catalog-threats-list-box.component.tsx
+++ b/apps/frontend/src/view/components/catalog-threats-list-box.component.tsx
@@ -140,7 +140,9 @@ export const CatalogThreatsListBox = ({ catalogId, attacker, pointOfAttack, user
         try {
             const file = event.currentTarget.files?.[0];
             event.currentTarget.value = "";
-            if (!file) throw new Error("file not found");
+            if (!file) {
+                throw new Error("file not found");
+            }
             const result = await importCsvFile(
                 file,
                 (row) => ({
@@ -155,14 +157,18 @@ export const CatalogThreatsListBox = ({ catalogId, attacker, pointOfAttack, user
                 }),
                 (data) => {
                     const { name, probability, attacker, pointOfAttack } = data as Partial<CatalogThreat>;
-                    if (!name || name === "") throw new Error("name required");
+                    if (!name || name === "") {
+                        throw new Error("name required");
+                    }
                     if (!probability || probability < 1) {
                         throw new Error("probability must be greater equals 1");
                     }
                     if (!probability || probability > 5) {
                         throw new Error("probability must be smaller equals 5");
                     }
-                    if (!attacker || !ATTACKERS[attacker]) throw new Error("attacker type is unknown");
+                    if (!attacker || !ATTACKERS[attacker]) {
+                        throw new Error("attacker type is unknown");
+                    }
                     if (!pointOfAttack || !POINTS_OF_ATTACK[pointOfAttack]) {
                         throw new Error("point of attack type is unknown");
                     }

--- a/apps/frontend/src/view/components/editor-components/editor-context-menu.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-context-menu.component.tsx
@@ -100,7 +100,9 @@ export const EditorContextMenu = ({ onSelect, stageRef, ref }: EditorContextMenu
     };
 
     const handleOnContextMenuLoad = () => {
-        if (contextMenuRef.current == null) return;
+        if (contextMenuRef.current == null) {
+            return;
+        }
         new ResizeObserver(() => {
             const stage = stageRef.current;
             const contextMenu = contextMenuRef.current;

--- a/apps/frontend/src/view/components/editor-components/editor-stage.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-stage.component.tsx
@@ -56,10 +56,14 @@ export const EditorStage = ({
         (event: KonvaEventObject<WheelEvent>) => {
             event.evt.preventDefault();
             const stage = stageRef.current;
-            if (!stage) return;
+            if (!stage) {
+                return;
+            }
 
             const pointer = stage.getPointerPosition();
-            if (!pointer) return;
+            if (!pointer) {
+                return;
+            }
 
             const oldScale = stage.scaleX();
 
@@ -88,10 +92,14 @@ export const EditorStage = ({
             event.evt.preventDefault();
             const stage = stageRef.current;
             const contextMenu = contextMenuRef.current;
-            if (!stage || !contextMenu) return;
+            if (!stage || !contextMenu) {
+                return;
+            }
 
             const pointer = stage.getPointerPosition();
-            if (!pointer) return;
+            if (!pointer) {
+                return;
+            }
 
             let { x, y } = pointer;
 
@@ -134,7 +142,9 @@ export const EditorStage = ({
     useEffect(() => {
         const box = boxRef.current;
         const stage = stageRef.current;
-        if (!box || !stage) return;
+        if (!box || !stage) {
+            return;
+        }
 
         const resizeObserver = new ResizeObserver(() => {
             stage.width(box.clientWidth);

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
@@ -476,7 +476,9 @@ const createGridForAStar = (
         // Apply walk costs in bulk
         for (let y = bounds.minY; y < bounds.maxY; y++) {
             const row = grid[y];
-            if (!row) continue;
+            if (!row) {
+                continue;
+            }
 
             const relativeY = y - componentGridY;
 
@@ -492,7 +494,9 @@ const createGridForAStar = (
                 }
 
                 const cell = row[x];
-                if (!cell) continue;
+                if (!cell) {
+                    continue;
+                }
 
                 // Set walk cost
                 cell.walkCost = relativeY >= 5 && relativeY <= 22 && relativeX >= 5 && relativeY <= 17 ? 500 : 300;
@@ -502,15 +506,21 @@ const createGridForAStar = (
         // Set unwalkable areas more efficiently
         for (let y = 3; y < 9; y++) {
             const gridY = componentGridY + y;
-            if (gridY < 0 || gridY >= grid.length) continue;
+            if (gridY < 0 || gridY >= grid.length) {
+                continue;
+            }
 
             const row = grid[gridY];
             for (let x = 3; x < 9; x++) {
                 const gridX = componentGridX + x;
-                if (gridX < 0 || gridX >= (row?.length ?? 0)) continue;
+                if (gridX < 0 || gridX >= (row?.length ?? 0)) {
+                    continue;
+                }
 
                 const cell = row?.[gridX];
-                if (!cell) continue;
+                if (!cell) {
+                    continue;
+                }
 
                 cell.walkable = false;
                 cell.walkCost = 400000;
@@ -563,7 +573,9 @@ const findPathOptimized = (grid: GridNode[][], startNode: GridNode, targetNode: 
     const openList = new FastPriorityQueue<GridNode>((a, b) => {
         const aF = a.gCost + a.hCost;
         const bF = b.gCost + b.hCost;
-        if (aF === bF) return a.hCost < b.hCost;
+        if (aF === bF) {
+            return a.hCost < b.hCost;
+        }
         return aF < bF;
     });
 
@@ -582,7 +594,9 @@ const findPathOptimized = (grid: GridNode[][], startNode: GridNode, targetNode: 
         }
         const nodeKey = `${currentNode.gridX},${currentNode.gridY}`;
 
-        if (visited.has(nodeKey)) continue;
+        if (visited.has(nodeKey)) {
+            continue;
+        }
         visited.add(nodeKey);
 
         if (currentNode === targetNode) {
@@ -641,7 +655,9 @@ const findPathOptimized = (grid: GridNode[][], startNode: GridNode, targetNode: 
 
         for (const neighbor of neighbors) {
             const neighborKey = `${neighbor.gridX},${neighbor.gridY}`;
-            if (!neighbor.walkable || visited.has(neighborKey)) continue;
+            if (!neighbor.walkable || visited.has(neighborKey)) {
+                continue;
+            }
 
             const pathLength = Math.abs(targetNode.x - startNode.x) + Math.abs(targetNode.y - startNode.y);
             const turnPenaltyMultiplier = Math.max(1, 1000 / pathLength);
@@ -720,7 +736,9 @@ class FastPriorityQueue<T> {
     }
 
     poll(): T | undefined {
-        if (this.isEmpty()) return undefined;
+        if (this.isEmpty()) {
+            return undefined;
+        }
         const value = this.heap[0];
         const last = this.heap.pop();
         if (this.heap.length > 0 && last !== undefined) {

--- a/apps/frontend/src/view/components/editor-components/system-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component.component.tsx
@@ -109,7 +109,9 @@ interface ConnectorProps {
 }
 
 const remapImagePath = (path: string | null | undefined): string | null | undefined => {
-    if (!path) return path;
+    if (!path) {
+        return path;
+    }
 
     const match = path.match(/\/([^/]+?)(?:\.[a-f0-9]+)?\.(?:png|webp|jpg|jpeg|svg)$/i);
     if (match) {

--- a/apps/frontend/src/view/components/with-menu.component.tsx
+++ b/apps/frontend/src/view/components/with-menu.component.tsx
@@ -487,7 +487,9 @@ export const HeaderNavigation = () => {
 
     let finalButtons: ToggleButtonConfig[] = [];
     let finalOnChangePath = (_event: SyntheticEvent, path: string) => {
-        if (path != null) navigate(path);
+        if (path != null) {
+            navigate(path);
+        }
     };
 
     // login page => language picker = A

--- a/apps/frontend/src/view/pages/assets.page.tsx
+++ b/apps/frontend/src/view/pages/assets.page.tsx
@@ -161,7 +161,9 @@ const AssetsPageBody = ({ project }: AssetsPageBodyProps) => {
     };
 
     const handleAssetsCount = (): string => {
-        if (assets.length > 1) return t("assetsFound");
+        if (assets.length > 1) {
+            return t("assetsFound");
+        }
         return t("assetFound");
     };
 

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -196,7 +196,9 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
     const currentHelpLinesRef = useRef<HelpLines | null>(null);
 
     const newConnectionPreviewComponent = useMemo(() => {
-        if (!newConnection) return undefined;
+        if (!newConnection) {
+            return undefined;
+        }
         return components.filter((component) => component.id === newConnection.from.id)[0];
     }, [components, newConnection]);
 
@@ -689,21 +691,29 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
     };
 
     const handleOnNameChange = (evt: ChangeEvent<HTMLInputElement>): void => {
-        if (checkUserRole(userRole, USER_ROLES.EDITOR)) setSelectedComponentName(evt.target.value);
+        if (checkUserRole(userRole, USER_ROLES.EDITOR)) {
+            setSelectedComponentName(evt.target.value);
+        }
     };
 
     const handleOnDescriptionChange = (evt: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
-        if (checkUserRole(userRole, USER_ROLES.EDITOR)) setSelectedComponentDescription(evt.target.value);
+        if (checkUserRole(userRole, USER_ROLES.EDITOR)) {
+            setSelectedComponentDescription(evt.target.value);
+        }
     };
 
     const handleOnConnectionPointDescriptionChange = (
         evt: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
     ): void => {
-        if (checkUserRole(userRole, USER_ROLES.EDITOR)) setSelectedConnectionPointDescription(evt.target.value);
+        if (checkUserRole(userRole, USER_ROLES.EDITOR)) {
+            setSelectedConnectionPointDescription(evt.target.value);
+        }
     };
 
     const handleConnectionNameChange = (evt: ChangeEvent<HTMLInputElement>): void => {
-        if (checkUserRole(userRole, USER_ROLES.EDITOR)) setSelectedConnectionName(evt.target.value);
+        if (checkUserRole(userRole, USER_ROLES.EDITOR)) {
+            setSelectedConnectionName(evt.target.value);
+        }
     };
 
     const handleOnConnectionPointClicked = ({ evt }: KonvaEventObject<MouseEvent>, connectionPointId: string): void => {
@@ -983,7 +993,9 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
     };
 
     const handleCreateNewCommunicationInterface = ({ name, icon }: { name: string; icon: string }): void => {
-        if (!communicationMenuComponent) return;
+        if (!communicationMenuComponent) {
+            return;
+        }
         addCommunicationInterface(communicationMenuComponent.id, name, icon);
         setIsCommunicationInterfaceDialogOpen(false);
     };
@@ -1184,7 +1196,9 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                                 const draggedComponent = components.filter(
                                     (component) => component.id === line.draggedComponentInfo.id
                                 )[0];
-                                if (!otherComponent || !draggedComponent) return null;
+                                if (!otherComponent || !draggedComponent) {
+                                    return null;
+                                }
 
                                 return (
                                     <ConnectionPreview
@@ -1208,7 +1222,9 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                                 const toComponent = components.filter(
                                     (component) => component.id === connection.to.id
                                 )[0];
-                                if (!fromComponent || !toComponent) return null;
+                                if (!fromComponent || !toComponent) {
+                                    return null;
+                                }
 
                                 return (
                                     <SystemComponentConnection

--- a/apps/frontend/src/view/pages/measures.page.tsx
+++ b/apps/frontend/src/view/pages/measures.page.tsx
@@ -152,7 +152,9 @@ const MeasuresPageBody = ({ project }: MeasuresPageBodyProps) => {
     };
 
     const handleMeasureCount = (): string => {
-        if (measures.length > 1) return t("measuresFound");
+        if (measures.length > 1) {
+            return t("measuresFound");
+        }
         return t("measureFound");
     };
 

--- a/apps/frontend/src/view/pages/member.page.tsx
+++ b/apps/frontend/src/view/pages/member.page.tsx
@@ -89,8 +89,11 @@ const MemberPageBody = () => {
 
     useLayoutEffect(() => {
         if (isSelfRemoved) {
-            if (projectId) navigate("/projects");
-            else navigate("/catalogs");
+            if (projectId) {
+                navigate("/projects");
+            } else {
+                navigate("/catalogs");
+            }
 
             dispatch(MemberActions.resetIsSelfRemoved());
         }
@@ -245,7 +248,9 @@ const MemberPageBody = () => {
     };
 
     const handleParticipantCount = (): string => {
-        if (members.length > 1) return t("participants");
+        if (members.length > 1) {
+            return t("participants");
+        }
         return t("participant");
     };
 

--- a/apps/frontend/src/view/pages/projects.page.tsx
+++ b/apps/frontend/src/view/pages/projects.page.tsx
@@ -105,7 +105,9 @@ export const ProjectsPage = CreatePage(HeaderNavigation, () => {
 
             event.currentTarget.value = "";
 
-            if (!file) throw new Error("file not found");
+            if (!file) {
+                throw new Error("file not found");
+            }
 
             const fileReader = new FileReader();
             fileReader.readAsText(file, "UTF-8");


### PR DESCRIPTION
Adds the eslint `curly` rule at error level in both apps/frontend and apps/backend oxlint configs to require braces for all control statement bodies. Auto-fixed existing violations via `oxlint --fix`.