### PR TITLE
chore(backend): isolate vitest on threatsea_test database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       postgres:
         image: postgres:18.3-alpine
         env:
-          POSTGRES_DB: threatsea
+          POSTGRES_DB: threatsea_test
           POSTGRES_USER: user
           POSTGRES_PASSWORD: user
         options: >-
@@ -103,7 +103,7 @@ jobs:
       ORIGIN_BACKEND: http://localhost:8000
       DATABASE_USER: user
       DATABASE_PASSWORD: user
-      DATABASE_NAME: threatsea
+      DATABASE_NAME: threatsea_test
       DATABASE_HOST: localhost
       DATABASE_TLS: disabled
       COOKIES_SECURE_OPTION: disabled

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -2,6 +2,8 @@ import "dotenv/config";
 import { defineConfig } from "vitest/config";
 import path from "path";
 
+process.env["DATABASE_NAME"] = "threatsea_test";
+
 export default defineConfig({
     test: {
         include: ["./tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],

--- a/apps/backend/vitest.setup.global.ts
+++ b/apps/backend/vitest.setup.global.ts
@@ -1,10 +1,31 @@
+import { databaseConfig } from "#config/config.js";
 import { db, runMigrations } from "#db/index.js";
 import { CreateCatalog, users } from "#db/schema.js";
 import { createDefaultCatalog } from "#services/catalogs.service.js";
 import { LANGUAGES } from "#types/languages.type.ts";
 import * as fs from "node:fs/promises";
+import { Client } from "pg";
+
+async function ensureTestDatabaseExists() {
+    const targetDb = databaseConfig.database;
+    if (!targetDb) {
+        return;
+    }
+
+    const client = new Client({ ...databaseConfig, database: "postgres" });
+    await client.connect();
+    try {
+        const exists = await client.query("SELECT 1 FROM pg_database WHERE datname = $1", [targetDb]);
+        if (exists.rowCount === 0) {
+            await client.query(`CREATE DATABASE "${targetDb}"`);
+        }
+    } finally {
+        await client.end();
+    }
+}
 
 export async function setup() {
+    await ensureTestDatabaseExists();
     await runMigrations();
 
     const testUser = (


### PR DESCRIPTION
- Backend vitest now runs against a dedicated `threatsea_test` database, isolating test runs
  from the dev/runtime DB
- Global vitest setup auto-creates the test DB on first run, so contributors don't need a
  manual setup step
- CI postgres service and env vars updated to match the new name