### PR TITLE
fix(editor): clean up POA and asset sidebar switch rows

### DIFF
--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
@@ -23,7 +23,13 @@ export const EditorSidebarAssetList = ({
         {items.map((asset, index) => (
             <Box
                 key={index}
-                sx={{ display: "flex", flexDirection: "row", alignItems: "center", color: "text.primary" }}
+                sx={{
+                    display: "flex",
+                    flexDirection: "row",
+                    alignItems: "center",
+                    color: "text.primary",
+                    marginLeft: "-11px",
+                }}
             >
                 <Switch
                     checked={checkedAssets.includes(asset.id)}

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-asset-list.component.tsx
@@ -1,4 +1,4 @@
-import { FormControlLabel, FormGroup, Switch, Typography } from "@mui/material";
+import { Box, FormGroup, Switch, Typography } from "@mui/material";
 import type { ChangeEvent, MouseEvent } from "react";
 import type { Asset } from "#api/types/asset.types.ts";
 
@@ -18,54 +18,43 @@ export const EditorSidebarAssetList = ({
     onAssetNameClick,
     onAssetHover,
     onAssetLeave,
-}: EditorSidebarAssetListProps) => {
-    return (
-        <FormGroup sx={{ color: "text.primary", paddingLeft: 0.5 }}>
-            {items.map((asset, index) => {
-                return (
-                    <FormControlLabel
-                        key={index}
-                        control={
-                            <Switch
-                                checked={checkedAssets.includes(asset.id)}
-                                onChange={(e) => onChangeHandler(e, asset)}
-                                size="small"
-                                sx={{
-                                    "& .MuiSwitch-switchBase": {
-                                        "&.Mui-checked": {
-                                            "& + .MuiSwitch-track": {
-                                                backgroundColor: "#546481",
-                                                opacity: 0.8,
-                                            },
-                                        },
-                                    },
-                                }}
-                            />
-                        }
-                        label={
-                            <Typography
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    onAssetNameClick(asset);
-                                }}
-                                onMouseEnter={(e) => onAssetHover(e, asset)}
-                                onMouseLeave={onAssetLeave}
-                                sx={{
-                                    fontSize: "0.75rem",
-                                    fontWeight: "bold",
-                                    marginLeft: 1,
-                                    cursor: "pointer",
-                                    "&:hover": { textDecoration: "underline" },
-                                }}
-                                data-testid="asset-search-results"
-                            >
-                                {asset.name}
-                            </Typography>
-                        }
-                    />
-                );
-            })}
-        </FormGroup>
-    );
-};
+}: EditorSidebarAssetListProps) => (
+    <FormGroup sx={{ color: "text.primary", paddingLeft: 0.5 }}>
+        {items.map((asset, index) => (
+            <Box
+                key={index}
+                sx={{ display: "flex", flexDirection: "row", alignItems: "center", color: "text.primary" }}
+            >
+                <Switch
+                    checked={checkedAssets.includes(asset.id)}
+                    onChange={(e) => onChangeHandler(e, asset)}
+                    size="small"
+                    slotProps={{ input: { role: "switch", "aria-label": asset.name } }}
+                    sx={{
+                        "& .MuiSwitch-switchBase": {
+                            "&.Mui-checked": {
+                                "& + .MuiSwitch-track": { backgroundColor: "#546481", opacity: 0.8 },
+                            },
+                        },
+                    }}
+                />
+                <Typography
+                    component="span"
+                    onClick={() => onAssetNameClick(asset)}
+                    onMouseEnter={(e) => onAssetHover(e, asset)}
+                    onMouseLeave={onAssetLeave}
+                    data-testid="asset-search-results"
+                    sx={{
+                        fontSize: "0.75rem",
+                        fontWeight: "bold",
+                        marginLeft: 1,
+                        cursor: "pointer",
+                        "&:hover": { textDecoration: "underline" },
+                    }}
+                >
+                    {asset.name}
+                </Typography>
+            </Box>
+        ))}
+    </FormGroup>
+);

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
@@ -336,6 +336,7 @@ export const EditorSidebarSelectedComponent = ({
                         return (
                             <PointOfAttackSwitch
                                 key={i}
+                                ariaLabel={t(`pointsOfAttackList.${type}`)}
                                 label={
                                     <Typography
                                         component="span"

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.test.tsx
@@ -6,6 +6,7 @@ const setup = (propsOverride: Partial<PointOfAttackSwitchProps> = {}) => {
     const props = {
         color: "#ff0000",
         label: "Test Label",
+        ariaLabel: "Test Label",
         onLabelClick: vi.fn(),
         checked: false,
         onChange: vi.fn(),

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
@@ -17,6 +17,7 @@ export const PointOfAttackSwitch = ({ color, label, ariaLabel, onLabelClick, ...
             color: "text.primary",
             marginBottom: 1,
             fontSize: "0.75rem",
+            marginLeft: "-11px",
         }}
     >
         <Switch

--- a/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/point-of-attack-switch.component.tsx
@@ -1,65 +1,51 @@
-import { Box, FormControlLabel, Switch, Typography, type SwitchProps } from "@mui/material";
-import type { ReactNode, MouseEvent } from "react";
+import { Box, Switch, Typography, type SwitchProps } from "@mui/material";
+import type { MouseEvent, ReactNode } from "react";
 
 export interface PointOfAttackSwitchProps extends Omit<SwitchProps, "color"> {
     color: string;
     label: ReactNode;
+    ariaLabel: string;
     onLabelClick: (event: MouseEvent<HTMLElement>) => void;
 }
 
-export const PointOfAttackSwitch = ({ color, label, onLabelClick, ...props }: PointOfAttackSwitchProps) => {
-    return (
-        <Box
+export const PointOfAttackSwitch = ({ color, label, ariaLabel, onLabelClick, ...props }: PointOfAttackSwitchProps) => (
+    <Box
+        sx={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            color: "text.primary",
+            marginBottom: 1,
+            fontSize: "0.75rem",
+        }}
+    >
+        <Switch
+            size="small"
+            slotProps={{ input: { role: "switch", "aria-label": ariaLabel } }}
             sx={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                justifyContent: "flex-start",
-                marginBottom: 1,
-                color: "text.primary",
+                "& .MuiSwitch-switchBase": {
+                    "&.Mui-checked": {
+                        "& + .MuiSwitch-track": { backgroundColor: color },
+                    },
+                },
+                "& .MuiSwitch-thumb": { backgroundColor: color },
+            }}
+            {...props}
+        />
+        <Typography
+            component="span"
+            onClick={onLabelClick}
+            sx={{
                 fontSize: "0.75rem",
+                marginLeft: 1,
+                cursor: "default",
+                ...(props.checked && {
+                    cursor: "pointer",
+                    "&:hover": { textDecoration: "underline" },
+                }),
             }}
         >
-            <FormControlLabel
-                control={
-                    <Switch
-                        size="small"
-                        sx={{
-                            "& .MuiSwitch-switchBase": {
-                                "&.Mui-checked": {
-                                    "& + .MuiSwitch-track": {
-                                        backgroundColor: color,
-                                    },
-                                },
-                            },
-                            "& .MuiSwitch-thumb": {
-                                backgroundColor: color,
-                            },
-                        }}
-                        {...props}
-                    />
-                }
-                label={
-                    <Typography
-                        onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            onLabelClick(e);
-                        }}
-                        sx={{
-                            fontSize: "0.75rem",
-                            marginLeft: 1,
-                            cursor: "default",
-                            ...(props.checked && {
-                                cursor: "pointer",
-                                "&:hover": { textDecoration: "underline" },
-                            }),
-                        }}
-                    >
-                        {label}
-                    </Typography>
-                }
-            />
-        </Box>
-    );
-};
+            {label}
+        </Typography>
+    </Box>
+);


### PR DESCRIPTION
- Remove the switch-toggle halo so clicking the gap between switch and label no longer flips the toggle (POA and asset sidebar lists).         
- Align the switch rows flush with the sidebar's left edge via `marginLeft: -11px` to compensate for MUI Switch's internal padding.