### PR TITLE
fix(backend): unblock pdf report generation under CSP 

### DIFF
--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -67,6 +67,8 @@ export const helmetConfig: HelmetOptions = {
             "script-src": ["'self'", "'wasm-unsafe-eval'"],
             "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com/"],
             "font-src": ["'self'", "https://fonts.gstatic.com/"],
+            "worker-src": ["'self'", "blob:"],
+            "connect-src": ["'self'", "data:"],
         },
     },
     strictTransportSecurity: {


### PR DESCRIPTION
@react-pdf/renderer v4 spawns a Web Worker from a blob: URL to decode PNG alpha channels and fetches inlined WASM (used by font subsetting) from a data: URL. Without explicit worker-src and connect-src directives, both fall back to the existing script-src / default-src, which forbid blob: and data: respectively. The browser blocks the worker creation and the WASM fetch, BlobProvider never resolves, and the "Report gets created..." dialog hangs indefinitely in deployed environments.

Add narrow allowances:
- worker-src 'self' blob:  → only this page's own blob workers
- connect-src 'self' data: → fetch the WASM bytes inlined in the bundle

Both are scoped to their directives and don't loosen script-src.