### PR TITLE
  fix: address release 1.2.0 sigterm shutdown and editor pan state issues          

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -38,6 +38,8 @@ server.listen(PORT, async () => {
 });
 
 process.on("SIGTERM", () => {
-    // graceful shutdown logic
-    server.close(() => process.exit(0));
+    // graceful shutdown logic — io.close() disconnects all Socket.IO clients,
+    // closes engine.io, and closes the underlying HTTP server in one call.
+    io.close(() => process.exit(0));
+    setTimeout(() => process.exit(1), 10_000).unref();
 });

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -502,6 +502,15 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
     };
 
     const handleMouseOut = () => {
+        // If the user released the button outside the stage, handleMouseUp
+        // never fires — mirror its reset so re-entry doesn't resume panning.
+        if (moveLayerRef.current) {
+            moveLayerRef.current = false;
+            if (stageRef.current?.content) {
+                stageRef.current.content.style.cursor = "default";
+            }
+        }
+
         setMousePointers({
             x: -20000,
             y: -20000,


### PR DESCRIPTION
- Active Socket.IO disconnect on SIGTERM so K8s graceful shutdown actually exits 
  within the grace period instead of being SIGKILL'd.                              
- Editor canvas no longer "stuck panning" after a click-drag where the user      
  releases the mouse button outside the canvas and re-enters. 