### PR TITLE
feat: add markdown report

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -18,6 +18,7 @@
     ".turbo",
     ".vite",
     "build",
-    "dist"
+    "dist",
+    "**/testData/**"
   ]
 }

--- a/apps/frontend/src/translations/de/report-page.de.json
+++ b/apps/frontend/src/translations/de/report-page.de.json
@@ -14,7 +14,7 @@
   "systemImageOnSeperatePage": "Systembild auf eigene Seite",
   "createBtn": "PDF-Report erstellen",
   "openInBrowserBtn": "Im Browser öffnen",
-  "downloadBtn": "PDF herunterladen",
+  "downloadPdfBtn": "PDF herunterladen",
   "downloadMarkdownBtn": "Markdown herunterladen",
   "reportLoads": "Report wird erstellt...",
   "pageSettings": "Seiten Einstellungen",

--- a/apps/frontend/src/translations/de/report-page.de.json
+++ b/apps/frontend/src/translations/de/report-page.de.json
@@ -13,7 +13,7 @@
   "tillScheduledAt": "Bis",
   "systemImageOnSeperatePage": "Systembild auf eigene Seite",
   "createBtn": "PDF-Report erstellen",
-  "openInBrowserBtn": "Im Browser öffnen",
+  "openInBrowserBtn": "PDF im Browser öffnen",
   "downloadPdfBtn": "PDF herunterladen",
   "downloadMarkdownBtn": "Markdown herunterladen",
   "reportLoads": "Report wird erstellt...",

--- a/apps/frontend/src/translations/de/report-page.de.json
+++ b/apps/frontend/src/translations/de/report-page.de.json
@@ -15,6 +15,7 @@
   "createBtn": "Report erstellen",
   "openInBrowserBtn": "Im Browser öffnen",
   "downloadBtn": "Download",
+  "downloadMarkdownBtn": "Markdown herunterladen",
   "reportLoads": "Report wird erstellt...",
   "pageSettings": "Seiten Einstellungen",
   "riskMatrixSettings": "Risikomatrix Einstellungen",

--- a/apps/frontend/src/translations/de/report-page.de.json
+++ b/apps/frontend/src/translations/de/report-page.de.json
@@ -12,7 +12,7 @@
   "fromScheduledAt": "Von",
   "tillScheduledAt": "Bis",
   "systemImageOnSeperatePage": "Systembild auf eigene Seite",
-  "createBtn": "Report erstellen",
+  "createBtn": "PDF-Report erstellen",
   "openInBrowserBtn": "Im Browser öffnen",
   "downloadBtn": "Download",
   "downloadMarkdownBtn": "Markdown herunterladen",

--- a/apps/frontend/src/translations/de/report-page.de.json
+++ b/apps/frontend/src/translations/de/report-page.de.json
@@ -14,7 +14,7 @@
   "systemImageOnSeperatePage": "Systembild auf eigene Seite",
   "createBtn": "PDF-Report erstellen",
   "openInBrowserBtn": "Im Browser öffnen",
-  "downloadBtn": "Download",
+  "downloadBtn": "PDF herunterladen",
   "downloadMarkdownBtn": "Markdown herunterladen",
   "reportLoads": "Report wird erstellt...",
   "pageSettings": "Seiten Einstellungen",

--- a/apps/frontend/src/translations/de/report.de.json
+++ b/apps/frontend/src/translations/de/report.de.json
@@ -16,6 +16,8 @@
   "method": "Die 4x6 Methodik",
   "gross": "brutto",
   "net": "netto",
+  "matrixLegend": "G = grün (geringes Risiko), Y = gelb (mittleres Risiko), R = rot (hohes Risiko). Anzahl wird angezeigt, wenn Bedrohungen vorhanden sind.",
+  "matrixAxisLegend": "P = Wahrscheinlichkeit (1 = niedrig, 5 = hoch), D = Schaden (1 = niedrig, 5 = hoch)",
 
   "explanationIdea": "Die 4x6 Methodik basiert auf einer Matrix, die für jedes IT-System, das auf sechs Klassen von Angriffspunkten abstrahiert wird, für die vier Klassen von Angreifern jede erdenkliche Bedrohung wiedergibt.",
   "explanationApplication": "Die Matrix ist zunächst unabhängig von konkreten Angriffstechniken oder Angriffszielen. Im Laufe einer Bedrohungsanalyse wird diese abstrahierte Matrix auf eine konkrete Systemarchitektur, die gemäß der obigen Vorgabe abstrahiert wurde, angewendet. Daraus werden unmittelbar konkrete Angriffsszenarien in einer überschaubaren, aber dennoch vollständigen Sicht entwickelt.",

--- a/apps/frontend/src/translations/de/report.de.json
+++ b/apps/frontend/src/translations/de/report.de.json
@@ -58,7 +58,7 @@
     },
     "COMMUNICATION_INFRASTRUCTURE": {
       "name": "Kommunikationsinfrastruktur",
-      "description": "Orte der Programmausführung - im Prinzip alles, was einen Prozessor und keine absolut unveränderliche Programmierung hat, z.B. auch Datenbankserver, wo die Abfragen verarbeitet werden"
+      "description": "Physische Übertragung von Daten über Kabel oder Funk"
     },
     "COMMUNICATION_INTERFACES": {
       "name": "Kommunikationsschnittstelle",

--- a/apps/frontend/src/translations/en/report-page.en.json
+++ b/apps/frontend/src/translations/en/report-page.en.json
@@ -14,7 +14,7 @@
   "systemImageOnSeperatePage": "System Image on separate page",
   "createBtn": "Create PDF Document",
   "openInBrowserBtn": "Open in Browser",
-  "downloadBtn": "Download",
+  "downloadBtn": "Download PDF",
   "downloadMarkdownBtn": "Download Markdown",
   "reportLoads": "Report gets created...",
   "pageSettings": "Page Settings",

--- a/apps/frontend/src/translations/en/report-page.en.json
+++ b/apps/frontend/src/translations/en/report-page.en.json
@@ -13,7 +13,7 @@
   "tillScheduledAt": "Until",
   "systemImageOnSeperatePage": "System Image on separate page",
   "createBtn": "Create PDF Document",
-  "openInBrowserBtn": "Open in Browser",
+  "openInBrowserBtn": "Open PDF in Browser",
   "downloadPdfBtn": "Download PDF",
   "downloadMarkdownBtn": "Download Markdown",
   "reportLoads": "Report gets created...",

--- a/apps/frontend/src/translations/en/report-page.en.json
+++ b/apps/frontend/src/translations/en/report-page.en.json
@@ -15,6 +15,7 @@
   "createBtn": "Create PDF Document",
   "openInBrowserBtn": "Open in Browser",
   "downloadBtn": "Download",
+  "downloadMarkdownBtn": "Download Markdown",
   "reportLoads": "Report gets created...",
   "pageSettings": "Page Settings",
   "riskMatrixSettings": "Risk Matrix for Milestones",

--- a/apps/frontend/src/translations/en/report-page.en.json
+++ b/apps/frontend/src/translations/en/report-page.en.json
@@ -14,7 +14,7 @@
   "systemImageOnSeperatePage": "System Image on separate page",
   "createBtn": "Create PDF Document",
   "openInBrowserBtn": "Open in Browser",
-  "downloadBtn": "Download PDF",
+  "downloadPdfBtn": "Download PDF",
   "downloadMarkdownBtn": "Download Markdown",
   "reportLoads": "Report gets created...",
   "pageSettings": "Page Settings",

--- a/apps/frontend/src/translations/en/report.en.json
+++ b/apps/frontend/src/translations/en/report.en.json
@@ -15,6 +15,8 @@
   "after": "After",
   "gross": "gross",
   "net": "net",
+  "matrixLegend": "G = green (low risk), Y = yellow (medium risk), R = red (high risk). Count shown when threats present.",
+  "matrixAxisLegend": "P = Probability (1 = low, 5 = high), D = Damage (1 = low, 5 = high)",
 
   "explanationIdea": "The 4x6 methodology is based on a matrix that specifies every conceivable threat from the four classes of attackers for any IT system abstracted to six classes of attack points.",
   "explanationApplication": "The matrix is initially independent of specific attack techniques or attack targets. In the course of a threat analysis, this abstracted matrix is applied to a specific system architecture that was abstracted according to the above specification. From this, concrete attack scenarios are immediately developed in a manageable but nevertheless complete view.",

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -19,7 +19,7 @@ import { ToggleButtons } from "../components/toggle-buttons.component";
 import { CreatePage } from "../components/create-page.component";
 import { HeaderUtilityControls } from "../components/header-utility-controls.component";
 import { Report } from "../report/report";
-import { generateMarkdownReport } from "../report/report-md";
+import { downloadMarkdownReport } from "../report/download-markdown-report";
 import { ExportIconButton } from "../components/export-icon-button.component";
 import { withProject } from "../components/with-project.hoc";
 
@@ -55,6 +55,7 @@ interface PdfDocumentToolbarProps {
     data: ReportToolbarData;
     bruttoMatrix: ReportHookReturn["bruttoMatrix"];
     nettoMatrix: ReportHookReturn["nettoMatrix"];
+    onDownloadMarkdown: () => void;
 }
 
 const ReportPageBody = ({ project }: ReportPageBodyProps) => {
@@ -231,11 +232,12 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
     };
 
     const handleDownloadMarkdown = () => {
-        if (!data) {
-            return;
-        }
-        const markdown = generateMarkdownReport({
-            data: { ...data, milestones, threats: threats ?? [], measures: measures ?? [] },
+        downloadMarkdownReport({
+            data,
+            filename,
+            milestones,
+            threats,
+            measures,
             bruttoMatrix,
             nettoMatrix,
             tillScheduledAt,
@@ -251,13 +253,6 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
             systemImageOnSeperatePage,
             language: reportLanguage,
         });
-        const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `${filename}.md`;
-        a.click();
-        URL.revokeObjectURL(url);
     };
 
     useEffect(() => {
@@ -733,6 +728,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                                     }}
                                     bruttoMatrix={bruttoMatrix}
                                     nettoMatrix={nettoMatrix}
+                                    onDownloadMarkdown={handleDownloadMarkdown}
                                 />
                             )}
                         </Box>
@@ -743,7 +739,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
     );
 };
 
-const PdfDocumentToolbar = ({ filename, ...props }: PdfDocumentToolbarProps) => {
+const PdfDocumentToolbar = ({ filename, onDownloadMarkdown, ...props }: PdfDocumentToolbarProps) => {
     const { t } = useTranslation("reportPage");
 
     return (
@@ -802,6 +798,7 @@ const PdfDocumentToolbar = ({ filename, ...props }: PdfDocumentToolbarProps) => 
                                 </Button>
                             </>
                         )}
+                        <Button onClick={onDownloadMarkdown}>{t("downloadMarkdownBtn")}</Button>
                     </Box>
                 );
             }}

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -230,6 +230,36 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
         fullExportAsExcel(project, data);
     };
 
+    const handleDownloadMarkdown = () => {
+        if (!data) {
+            return;
+        }
+        const markdown = generateMarkdownReport({
+            data: { ...data, milestones, threats: threats ?? [], measures: measures ?? [] },
+            bruttoMatrix,
+            nettoMatrix,
+            tillScheduledAt,
+            showCoverPage,
+            showTableOfContentsPage,
+            showMethodExplanation,
+            showScaleExplanation,
+            showMatrixPage,
+            showAssetsPage,
+            showMeasuresPage,
+            showThreatListPage,
+            showThreatsPage,
+            systemImageOnSeperatePage,
+            language: reportLanguage,
+        });
+        const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${filename}.md`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
     useEffect(() => {
         setIsChanged(true);
     }, [setIsChanged, language]);
@@ -670,9 +700,12 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                             }}
                         >
                             {isChanged ? (
-                                <Box sx={{ marginTop: 2 }}>
-                                    <Button sx={{ marginRight: 0 }} onClick={onClickRefresh}>
+                                <Box sx={{ marginTop: 2, display: "flex", alignItems: "center" }}>
+                                    <Button sx={{ marginRight: 1 }} onClick={onClickRefresh}>
                                         {t("createBtn")}
+                                    </Button>
+                                    <Button sx={{ marginRight: 0 }} onClick={handleDownloadMarkdown}>
+                                        {t("downloadMarkdownBtn")}
                                     </Button>
                                 </Box>
                             ) : (
@@ -712,33 +745,6 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
 
 const PdfDocumentToolbar = ({ filename, ...props }: PdfDocumentToolbarProps) => {
     const { t } = useTranslation("reportPage");
-
-    const handleDownloadMarkdown = () => {
-        const markdown = generateMarkdownReport({
-            data: props.data,
-            bruttoMatrix: props.bruttoMatrix,
-            nettoMatrix: props.nettoMatrix,
-            tillScheduledAt: props.tillScheduledAt,
-            showCoverPage: props.showCoverPage,
-            showTableOfContentsPage: props.showTableOfContentsPage,
-            showMethodExplanation: props.showMethodExplanation,
-            showScaleExplanation: props.showScaleExplanation,
-            showMatrixPage: props.showMatrixPage,
-            showAssetsPage: props.showAssetsPage,
-            showMeasuresPage: props.showMeasuresPage,
-            showThreatListPage: props.showThreatListPage,
-            showThreatsPage: props.showThreatsPage,
-            systemImageOnSeperatePage: props.systemImageOnSeperatePage,
-            language: props.language,
-        });
-        const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `${filename}.md`;
-        a.click();
-        URL.revokeObjectURL(url);
-    };
 
     return (
         <BlobProvider document={<Report {...props} />}>
@@ -789,18 +795,10 @@ const PdfDocumentToolbar = ({ filename, ...props }: PdfDocumentToolbarProps) => 
                                     {...{ download: `${filename}.pdf` }}
                                     disabled={disabled}
                                     sx={{
-                                        marginRight: 1,
-                                    }}
-                                >
-                                    {t("downloadBtn")}
-                                </Button>
-                                <Button
-                                    onClick={handleDownloadMarkdown}
-                                    sx={{
                                         marginRight: 0,
                                     }}
                                 >
-                                    {t("downloadMarkdownBtn")}
+                                    {t("downloadBtn")}
                                 </Button>
                             </>
                         )}

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -794,7 +794,7 @@ const PdfDocumentToolbar = ({ filename, onDownloadMarkdown, ...props }: PdfDocum
                                         marginRight: 1,
                                     }}
                                 >
-                                    {t("downloadBtn")}
+                                    {t("downloadPdfBtn")}
                                 </Button>
                             </>
                         )}

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -729,6 +729,7 @@ const PdfDocumentToolbar = ({ filename, ...props }: PdfDocumentToolbarProps) => 
             showThreatListPage: props.showThreatListPage,
             showThreatsPage: props.showThreatsPage,
             systemImageOnSeperatePage: props.systemImageOnSeperatePage,
+            language: props.language,
         });
         const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
         const url = URL.createObjectURL(blob);

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -19,6 +19,7 @@ import { ToggleButtons } from "../components/toggle-buttons.component";
 import { CreatePage } from "../components/create-page.component";
 import { HeaderUtilityControls } from "../components/header-utility-controls.component";
 import { Report } from "../report/report";
+import { generateMarkdownReport } from "../report/report-md";
 import { ExportIconButton } from "../components/export-icon-button.component";
 import { withProject } from "../components/with-project.hoc";
 
@@ -711,6 +712,33 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
 
 const PdfDocumentToolbar = ({ filename, ...props }: PdfDocumentToolbarProps) => {
     const { t } = useTranslation("reportPage");
+
+    const handleDownloadMarkdown = () => {
+        const markdown = generateMarkdownReport({
+            data: props.data,
+            bruttoMatrix: props.bruttoMatrix,
+            nettoMatrix: props.nettoMatrix,
+            tillScheduledAt: props.tillScheduledAt,
+            showCoverPage: props.showCoverPage,
+            showTableOfContentsPage: props.showTableOfContentsPage,
+            showMethodExplanation: props.showMethodExplanation,
+            showScaleExplanation: props.showScaleExplanation,
+            showMatrixPage: props.showMatrixPage,
+            showAssetsPage: props.showAssetsPage,
+            showMeasuresPage: props.showMeasuresPage,
+            showThreatListPage: props.showThreatListPage,
+            showThreatsPage: props.showThreatsPage,
+            systemImageOnSeperatePage: props.systemImageOnSeperatePage,
+        });
+        const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${filename}.md`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
     return (
         <BlobProvider document={<Report {...props} />}>
             {({ url, loading, error }) => {
@@ -760,10 +788,18 @@ const PdfDocumentToolbar = ({ filename, ...props }: PdfDocumentToolbarProps) => 
                                     {...{ download: `${filename}.pdf` }}
                                     disabled={disabled}
                                     sx={{
-                                        marginRight: 0,
+                                        marginRight: 1,
                                     }}
                                 >
                                     {t("downloadBtn")}
+                                </Button>
+                                <Button
+                                    onClick={handleDownloadMarkdown}
+                                    sx={{
+                                        marginRight: 0,
+                                    }}
+                                >
+                                    {t("downloadMarkdownBtn")}
                                 </Button>
                             </>
                         )}

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -795,7 +795,7 @@ const PdfDocumentToolbar = ({ filename, ...props }: PdfDocumentToolbarProps) => 
                                     {...{ download: `${filename}.pdf` }}
                                     disabled={disabled}
                                     sx={{
-                                        marginRight: 0,
+                                        marginRight: 1,
                                     }}
                                 >
                                     {t("downloadBtn")}

--- a/apps/frontend/src/view/report/download-markdown-report.ts
+++ b/apps/frontend/src/view/report/download-markdown-report.ts
@@ -1,0 +1,84 @@
+import type { ProjectReport } from "#api/types/project.types.ts";
+import type { RiskMatrix, Milestone } from "#application/hooks/use-report.hook.ts";
+import { generateMarkdownReport } from "./report-md";
+
+/**
+ * Subset of the useReport hook return values required to generate and download
+ * a markdown report. Matches the shape of the state in ReportPageBody so the
+ * call site needs no transformation.
+ */
+interface MarkdownDownloadState {
+    data: ProjectReport | null | undefined;
+    filename: string;
+    milestones: Milestone[] | null | undefined;
+    threats: ProjectReport["threats"] | null | undefined;
+    measures: ProjectReport["measures"] | null | undefined;
+    bruttoMatrix: RiskMatrix | null | undefined;
+    nettoMatrix: RiskMatrix | null | undefined;
+    tillScheduledAt: string | null | undefined;
+    showCoverPage?: boolean;
+    showTableOfContentsPage?: boolean;
+    showMethodExplanation?: boolean;
+    showScaleExplanation?: boolean;
+    showMatrixPage?: boolean;
+    showAssetsPage?: boolean;
+    showMeasuresPage?: boolean;
+    showThreatListPage?: boolean;
+    showThreatsPage?: boolean;
+    systemImageOnSeperatePage?: boolean;
+    language?: string;
+}
+
+/**
+ * Assembles a markdown report from raw hook state and triggers a browser
+ * file download. Returns early if data is not yet loaded.
+ */
+export function downloadMarkdownReport({
+    data,
+    filename,
+    milestones,
+    threats,
+    measures,
+    bruttoMatrix,
+    nettoMatrix,
+    tillScheduledAt,
+    showCoverPage,
+    showTableOfContentsPage,
+    showMethodExplanation,
+    showScaleExplanation,
+    showMatrixPage,
+    showAssetsPage,
+    showMeasuresPage,
+    showThreatListPage,
+    showThreatsPage,
+    systemImageOnSeperatePage,
+    language,
+}: MarkdownDownloadState): void {
+    if (!data) {
+        return;
+    }
+    const markdown = generateMarkdownReport({
+        data: { ...data, milestones, threats: threats ?? [], measures: measures ?? [] },
+        bruttoMatrix,
+        nettoMatrix,
+        tillScheduledAt,
+        showCoverPage,
+        showTableOfContentsPage,
+        showMethodExplanation,
+        showScaleExplanation,
+        showMatrixPage,
+        showAssetsPage,
+        showMeasuresPage,
+        showThreatListPage,
+        showThreatsPage,
+        systemImageOnSeperatePage,
+        language,
+    });
+    const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${filename}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+}

--- a/apps/frontend/src/view/report/download-markdown-report.ts
+++ b/apps/frontend/src/view/report/download-markdown-report.ts
@@ -79,6 +79,8 @@ export function downloadMarkdownReport({
     const a = document.createElement("a");
     a.href = url;
     a.download = `${filename}.md`;
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/apps/frontend/src/view/report/report-md.test.ts
+++ b/apps/frontend/src/view/report/report-md.test.ts
@@ -106,6 +106,18 @@ describe("generateMarkdownReport – injection prevention", () => {
         const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", data: { ...report, threats: [threat] } });
         expect(md).toContain("Threat \\] Injection");
     });
+
+    it("escapes backslashes in threat names (link text context)", () => {
+        const threat = { ...report.threats[0]!, name: "Threat \\ Backslash" };
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", data: { ...report, threats: [threat] } });
+        expect(md).toContain("Threat \\\\ Backslash");
+    });
+
+    it("escapes backslashes in threat component names (table cell context)", () => {
+        const threat = { ...report.threats[0]!, componentName: "Server \\ Database" };
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", data: { ...report, threats: [threat] } });
+        expect(md).toContain("Server \\\\ Database");
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/frontend/src/view/report/report-md.test.ts
+++ b/apps/frontend/src/view/report/report-md.test.ts
@@ -1,0 +1,132 @@
+import "#utils/translations.ts"; // initialises i18next with all namespaces as a side effect
+import { generateMarkdownReport, type MarkdownReportOptions } from "#view/report/report-md.ts";
+import type { ProjectReport } from "#api/types/project.types.ts";
+import fixtureData from "./testData/project-report.fixture.json";
+
+const report = fixtureData as unknown as ProjectReport & { milestones: null };
+
+const BASE_OPTIONS: MarkdownReportOptions = {
+    data: report,
+    date: "2025-01-15",
+};
+
+// ---------------------------------------------------------------------------
+// Snapshot tests
+// ---------------------------------------------------------------------------
+
+describe("generateMarkdownReport – snapshot", () => {
+    it("produces the expected english report", async () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en" });
+        await expect(md).toMatchFileSnapshot("./testData/expected-report.en.md");
+    });
+
+    it("produces the expected german report", async () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "de" });
+        await expect(md).toMatchFileSnapshot("./testData/expected-report.de.md");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Section toggling
+// ---------------------------------------------------------------------------
+
+describe("generateMarkdownReport – section toggling", () => {
+    it("omits the cover page heading when showCoverPage is false", () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", showCoverPage: false });
+        expect(md).not.toContain(`# ${report.project.name}`);
+    });
+
+    it("omits assets section when showAssetsPage is false", () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", showAssetsPage: false });
+        expect(md).not.toContain("chapter-assetsDetails");
+    });
+
+    it("omits measures section when showMeasuresPage is false", () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", showMeasuresPage: false });
+        expect(md).not.toContain("chapter-measuresDetails");
+    });
+
+    it("omits threat sections when showThreatsPage and showThreatListPage are false", () => {
+        const md = generateMarkdownReport({
+            ...BASE_OPTIONS,
+            language: "en",
+            showThreatsPage: false,
+            showThreatListPage: false,
+        });
+        expect(md).not.toContain("chapter-riskDetails");
+        expect(md).not.toContain("chapter-riskList");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Injection prevention – block context (descriptions)
+// ---------------------------------------------------------------------------
+
+describe("generateMarkdownReport – injection prevention", () => {
+    const withProjectDescription = (description: string): MarkdownReportOptions => ({
+        ...BASE_OPTIONS,
+        language: "en",
+        data: { ...report, project: { ...report.project, description } },
+    });
+
+    it("escapes ATX headings in project description", () => {
+        const md = generateMarkdownReport(withProjectDescription("### Injected heading"));
+        expect(md).toContain("\\### Injected heading");
+    });
+
+    it("escapes bare ATX headings without trailing space", () => {
+        const md = generateMarkdownReport(withProjectDescription("###"));
+        expect(md).toContain("\\###");
+    });
+
+    it("escapes thematic breaks / setext underlines in project description", () => {
+        const md = generateMarkdownReport(withProjectDescription("---"));
+        expect(md).toContain("\\---");
+    });
+
+    it("escapes fenced code block delimiters in project description", () => {
+        const md = generateMarkdownReport(withProjectDescription("```js\nalert(1)\n```"));
+        expect(md).toContain("\\```js");
+    });
+
+    it("escapes HTML block openers in project description", () => {
+        const md = generateMarkdownReport(withProjectDescription("<script>alert(1)</script>"));
+        expect(md).toContain("\\<script>");
+    });
+
+    it("escapes pipe characters in threat component names (table cell context)", () => {
+        const threat = { ...report.threats[0]!, componentName: "Server | Database" };
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", data: { ...report, threats: [threat] } });
+        expect(md).toContain("Server \\| Database");
+    });
+
+    it("escapes closing square brackets in threat names (link text context)", () => {
+        const threat = { ...report.threats[0]!, name: "Threat ] Injection" };
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", data: { ...report, threats: [threat] } });
+        expect(md).toContain("Threat \\] Injection");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Line break preservation – block context (descriptions)
+// ---------------------------------------------------------------------------
+
+describe("generateMarkdownReport – line break preservation", () => {
+    it("converts single newlines to Markdown hard line breaks", () => {
+        const md = generateMarkdownReport({
+            ...BASE_OPTIONS,
+            language: "en",
+            data: { ...report, project: { ...report.project, description: "First line\nSecond line" } },
+        });
+        expect(md).toContain("First line  \nSecond line");
+    });
+
+    it("preserves paragraph breaks (double newlines) in descriptions", () => {
+        const md = generateMarkdownReport({
+            ...BASE_OPTIONS,
+            language: "en",
+            data: { ...report, project: { ...report.project, description: "Para one\n\nPara two" } },
+        });
+        expect(md).toContain("Para one\n\nPara two");
+    });
+});

--- a/apps/frontend/src/view/report/report-md.test.ts
+++ b/apps/frontend/src/view/report/report-md.test.ts
@@ -1,6 +1,7 @@
 import "#utils/translations.ts"; // initialises i18next with all namespaces as a side effect
 import { generateMarkdownReport, type MarkdownReportOptions } from "#view/report/report-md.ts";
 import type { ProjectReport } from "#api/types/project.types.ts";
+import type { RiskMatrix } from "#application/hooks/use-report.hook.ts";
 import fixtureData from "./testData/project-report.fixture.json";
 
 const report = fixtureData as unknown as ProjectReport & { milestones: null };
@@ -128,5 +129,104 @@ describe("generateMarkdownReport – line break preservation", () => {
             data: { ...report, project: { ...report.project, description: "Para one\n\nPara two" } },
         });
         expect(md).toContain("Para one\n\nPara two");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Matrix rendering
+// ---------------------------------------------------------------------------
+
+// 5×5 matrix: outer index 0 = P5 (highest), inner index 0 = D1 (lowest)
+const TEST_MATRIX: RiskMatrix = [
+    // P5
+    [{ color: "red", amount: 2 }, { color: "red" }, { color: "red" }, { color: "red" }, { color: "red" }],
+    // P4
+    [{ color: "yellow", amount: 1 }, { color: "red" }, { color: "red" }, { color: "red" }, { color: "red" }],
+    // P3
+    [{ color: "green" }, { color: "yellow" }, { color: "yellow" }, { color: "red" }, { color: "red" }],
+    // P2
+    [{ color: "green" }, { color: "green" }, { color: "yellow" }, { color: "yellow" }, { color: "red" }],
+    // P1
+    [{ color: "green" }, { color: "green" }, { color: "green" }, { color: "yellow" }, { color: "yellow" }],
+];
+
+describe("generateMarkdownReport – matrix rendering", () => {
+    const matrixOptions: MarkdownReportOptions = {
+        ...BASE_OPTIONS,
+        language: "en",
+        bruttoMatrix: TEST_MATRIX,
+    };
+
+    it("renders the matrix table header row", () => {
+        const md = generateMarkdownReport(matrixOptions);
+        expect(md).toContain("| P \\ D | D1 | D2 | D3 | D4 | D5 |");
+    });
+
+    it("renders probability row labels P5 through P1", () => {
+        const md = generateMarkdownReport(matrixOptions);
+        for (const label of ["P5", "P4", "P3", "P2", "P1"]) {
+            expect(md).toContain(`| ${label} |`);
+        }
+    });
+
+    it("renders cell colors as G/Y/R abbreviations", () => {
+        const md = generateMarkdownReport(matrixOptions);
+        // P5 D1: red with count 2
+        expect(md).toContain("R:2");
+        // P4 D1: yellow with count 1
+        expect(md).toContain("Y:1");
+        // P1 starts with three green cells without counts
+        expect(md).toContain("| P1 | G | G | G |");
+    });
+
+    it("renders the axis legend explaining P and D", () => {
+        const md = generateMarkdownReport(matrixOptions);
+        expect(md).toContain("P = Probability");
+        expect(md).toContain("D = Damage");
+    });
+
+    it("renders the color legend explaining G/Y/R", () => {
+        const md = generateMarkdownReport(matrixOptions);
+        expect(md).toContain("G = green (low risk)");
+        expect(md).toContain("Y = yellow (medium risk)");
+        expect(md).toContain("R = red (high risk)");
+    });
+
+    it("renders axis and color legends in German", () => {
+        const md = generateMarkdownReport({ ...matrixOptions, language: "de" });
+        expect(md).toContain("P = Wahrscheinlichkeit");
+        expect(md).toContain("D = Schaden");
+        expect(md).toContain("G = grün (geringes Risiko)");
+    });
+
+    it("renders the brutto matrix with 'Before' title", () => {
+        const md = generateMarkdownReport(matrixOptions);
+        expect(md).toContain("**Before**");
+    });
+
+    it("renders the netto matrix with 'After' title", () => {
+        const md = generateMarkdownReport({ ...matrixOptions, bruttoMatrix: undefined, nettoMatrix: TEST_MATRIX });
+        expect(md).toContain("**After**");
+        expect(md).toContain("| P \\ D | D1 | D2 | D3 | D4 | D5 |");
+    });
+
+    it("omits the matrix section when showMatrixPage is false", () => {
+        const md = generateMarkdownReport({ ...matrixOptions, showMatrixPage: false });
+        expect(md).not.toContain("chapter-matrix");
+        expect(md).not.toContain("| P \\ D |");
+    });
+
+    it("renders a milestone matrix with the milestone date as title", () => {
+        const milestone = {
+            scheduledAt: new Date("2025-06-01"),
+            matrix: TEST_MATRIX,
+            barGraph: null,
+            active: true,
+        };
+        const md = generateMarkdownReport({
+            ...matrixOptions,
+            data: { ...report, milestones: [milestone] },
+        });
+        expect(md).toContain("**2025-06-01**");
     });
 });

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -1,5 +1,6 @@
 import type { ProjectReport } from "#api/types/project.types.ts";
 import type { RiskMatrix, Milestone } from "#application/hooks/use-report.hook.ts";
+import i18next from "i18next";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,156 +29,131 @@ export interface MarkdownReportOptions {
     showThreatListPage?: boolean;
     showThreatsPage?: boolean;
     systemImageOnSeperatePage?: boolean;
+    language?: string;
 }
 
 // ---------------------------------------------------------------------------
-// Static translations (English)
-// The report i18n namespace is partially incomplete; we embed strings here
-// so the markdown generator has no runtime i18n dependency.
+// Translations
 // ---------------------------------------------------------------------------
 
-const T = {
-    coverPage: "Cover Page",
-    tableOfContents: "Table of Contents",
-    chapter: "Chapter",
-    pagenumber: "Page",
-    method: "The 4x6 Methodology",
-    explanationIdea:
-        "The 4x6 methodology is based on a matrix that specifies every conceivable threat from the four classes of attackers for any IT system abstracted to six classes of attack points.",
-    explanationApplication:
-        "The matrix is initially independent of specific attack techniques or attack targets. In the course of a threat analysis, this abstracted matrix is applied to a specific system architecture that was abstracted according to the above specification. From this, concrete attack scenarios are immediately developed in a manageable but nevertheless complete view.",
-    attackersHeader: "Attackers",
-    pointsOfAttackHeader: "Points Of Attack",
-    explanationScale: "Explanation of Probability and Damage Scale",
-    probability: "Probability",
-    damage: "Damage",
-    risk: "Risk",
-    riskMatrices: "Risk Matrices",
-    before: "Before",
-    after: "After",
-    gross: "gross",
-    net: "net",
-    systemImage: "System Image",
-    assets: "Assets",
-    measures: "Measures",
-    riskList: "List of Threats",
-    threats: "Threats",
-    name: "Name",
-    component: "Component",
-    description: "Description",
-    confidentiality: "Confidentiality",
-    integrity: "Integrity",
-    availability: "Availability",
-    confidentialityJustification: "Confidentiality Justification",
-    integrityJustification: "Integrity Justification",
-    availabilityJustification: "Availability Justification",
-    attacker: "Attacker",
-    pointOfAttack: "Point of Attack",
+interface Translations {
+    coverPage: string;
+    tableOfContents: string;
+    chapter: string;
+    pagenumber: string;
+    method: string;
+    explanationIdea: string;
+    explanationApplication: string;
+    attackersHeader: string;
+    pointsOfAttackHeader: string;
+    explanationScale: string;
+    probability: string;
+    damage: string;
+    risk: string;
+    riskMatrices: string;
+    before: string;
+    after: string;
+    gross: string;
+    net: string;
+    systemImage: string;
+    assets: string;
+    measures: string;
+    riskList: string;
+    threats: string;
+    name: string;
+    component: string;
+    description: string;
+    confidentiality: string;
+    integrity: string;
+    availability: string;
+    confidentialityJustification: string;
+    integrityJustification: string;
+    availabilityJustification: string;
+    attacker: string;
+    pointOfAttack: string;
+    confidentialityLevels: Record<string, string>;
+    attackers: Record<string, { name: string; description: string }>;
+    pointsOfAttacks: Record<string, { name: string; description: string }>;
+    probabilities: { name: string; description: string }[];
+    cellNames: Record<string, Record<string, string>>;
+    damages: { name: string; description: string }[];
+}
 
-    confidentialityLevels: {
-        PUBLIC: "Public",
-        INTERNAL: "Internal",
-        CONFIDENTIAL: "Confidential",
-        SECRET: "Secret",
-    } as Record<string, string>,
+function buildTranslations(language: string): Translations {
+    const t = i18next.getFixedT(language, "report");
 
-    attackers: {
-        UNAUTHORISED_PARTIES: {
-            name: "Unauthorised Parties",
-            description: "Entities with no tie to and especially no authorisation on the system under consideration",
-        },
-        SYSTEM_USERS: {
-            name: "System Users",
-            description:
-                "Users being authorised to share use of resources with the application under consideration but not having authorisation on the application itself",
-        },
-        APPLICATION_USERS: {
-            name: "Application Users",
-            description: "Users being authorised to work with the application under consideration",
-        },
-        ADMINISTRATORS: {
-            name: "(Technical) Administrators",
-            description: "Users with elevated privileges who manage the infrastructure used by the application",
-        },
-    } as Record<string, { name: string; description: string }>,
+    const poaKeys = [
+        "DATA_STORAGE_INFRASTRUCTURE",
+        "PROCESSING_INFRASTRUCTURE",
+        "COMMUNICATION_INFRASTRUCTURE",
+        "COMMUNICATION_INTERFACES",
+        "USER_INTERFACE",
+        "USER_BEHAVIOUR",
+    ];
+    const attackerKeys = ["UNAUTHORISED_PARTIES", "SYSTEM_USERS", "APPLICATION_USERS", "ADMINISTRATORS"];
 
-    pointsOfAttacks: {
-        USER_INTERFACE: {
-            name: "User Interface",
-            description:
-                "the places and programmes, where and by which users interact with the system, usually via screen and input device, e.g. a browser on a PC",
-        },
-        PROCESSING_INFRASTRUCTURE: {
-            name: "Processing Infrastructure",
-            description:
-                "places of program execution – in principle everything which has a processor and its programming is not absolutely fixed, e.g. including database servers, where queries are processed",
-        },
-        DATA_STORAGE_INFRASTRUCTURE: {
-            name: "Data Storage Infrastructure",
-            description: "places where data is stored durably – hard disks, non-volatile semiconductor memory, …",
-        },
-        COMMUNICATION_INFRASTRUCTURE: {
-            name: "Communication Infrastructure",
-            description: "physical transport of data via cable or wireless",
-        },
-        COMMUNICATION_INTERFACES: {
-            name: "Communication Interfaces",
-            description:
-                "the connection to the means of communication on all OSI layers: network interfaces, wireless antenna, TCP Ports, APIs, …",
-        },
-        USER_BEHAVIOUR: {
-            name: "User Behaviour",
-            description: "The behaviour of a user (human)",
-        },
-    } as Record<string, { name: string; description: string }>,
+    const cellNames: Record<string, Record<string, string>> = {};
+    for (const poa of poaKeys) {
+        cellNames[poa] = {};
+        for (const attacker of attackerKeys) {
+            const key = `${poa}.${attacker}.name`;
+            const val = t(key);
+            if (val !== key) {
+                cellNames[poa]![attacker] = val;
+            }
+        }
+    }
 
-    probabilities: [
-        { name: "Very Unlikely", description: "The event is extremely rare and almost never expected to occur." },
-        { name: "Unlikely", description: "The event is unusual and occurs only in exceptional circumstances." },
-        { name: "Possible", description: "The event may occur under certain conditions." },
-        { name: "Likely", description: "The event is expected to occur in many circumstances." },
-        { name: "Very Likely", description: "The event is almost certain to occur." },
-    ],
-
-    // Valid cells of the 4x6 matrix keyed as cellNames[pointOfAttack][attacker]
-    cellNames: {
-        DATA_STORAGE_INFRASTRUCTURE: {
-            UNAUTHORISED_PARTIES: "Physical data storage access",
-            SYSTEM_USERS: "Internal breach on data storage",
-            ADMINISTRATORS: "Privilege abuse on data storage",
-        },
-        PROCESSING_INFRASTRUCTURE: {
-            UNAUTHORISED_PARTIES: "Physical attack on processing",
-            SYSTEM_USERS: "Internal breach during processing",
-            ADMINISTRATORS: "Privilege abuse on processing",
-        },
-        COMMUNICATION_INFRASTRUCTURE: {
-            UNAUTHORISED_PARTIES: "Physical attack on transmission",
-            SYSTEM_USERS: "Internal breach on transmission",
-            ADMINISTRATORS: "Privilege abuse on transmission",
-        },
-        COMMUNICATION_INTERFACES: {
-            UNAUTHORISED_PARTIES: "Physical interface attack",
-            SYSTEM_USERS: "Breach via interface access",
-            APPLICATION_USERS: "Detrimental interface usage",
-        },
-        USER_INTERFACE: {
-            UNAUTHORISED_PARTIES: "Physical UI access",
-            APPLICATION_USERS: "Detrimental UI usage",
-        },
-        USER_BEHAVIOUR: {
-            UNAUTHORISED_PARTIES: "Deception",
-        },
-    } as Record<string, Record<string, string>>,
-
-    damages: [
-        { name: "Negligible", description: "Minimal impact; operations continue essentially unaffected." },
-        { name: "Minor", description: "Limited impact; some disruption but quickly recoverable." },
-        { name: "Moderate", description: "Significant impact; noticeable disruption or data exposure." },
-        { name: "Major", description: "Severe impact; major disruption, large data breach, or financial loss." },
-        { name: "Critical", description: "Catastrophic impact; organisation-wide damage or irreversible harm." },
-    ],
-};
+    return {
+        coverPage: t("coverPage"),
+        tableOfContents: t("tableOfContents"),
+        chapter: t("chapter"),
+        pagenumber: t("pagenumber"),
+        method: t("method"),
+        explanationIdea: t("explanationIdea"),
+        explanationApplication: t("explanationApplication"),
+        attackersHeader: t("attackersHeader"),
+        pointsOfAttackHeader: t("pointsOfAttackHeader"),
+        explanationScale: t("explanationScale"),
+        probability: t("probability"),
+        damage: t("damage"),
+        risk: t("risk"),
+        riskMatrices: t("riskMatrices"),
+        before: t("before"),
+        after: t("after"),
+        gross: t("gross"),
+        net: t("net"),
+        systemImage: t("systemImage"),
+        assets: t("assets"),
+        measures: t("measures"),
+        riskList: t("riskList"),
+        threats: t("threats"),
+        name: t("name"),
+        component: t("component"),
+        description: t("description"),
+        confidentiality: t("confidentiality"),
+        integrity: t("integrity"),
+        availability: t("availability"),
+        confidentialityJustification: t("confidentialityJustification"),
+        integrityJustification: t("integrityJustification"),
+        availabilityJustification: t("availabilityJustification"),
+        attacker: t("attacker"),
+        pointOfAttack: t("pointOfAttack"),
+        confidentialityLevels: t("confidentialityLevels", { returnObjects: true }) as Record<string, string>,
+        attackers: t("attackers", { returnObjects: true }) as Record<string, { name: string; description: string }>,
+        pointsOfAttacks: t("pointsOfAttacks", { returnObjects: true }) as Record<
+            string,
+            { name: string; description: string }
+        >,
+        probabilities: Object.values(
+            t("probabilities", { returnObjects: true }) as Record<string, { name: string; description: string }>
+        ),
+        cellNames,
+        damages: Object.values(
+            t("damages", { returnObjects: true }) as Record<string, { name: string; description: string }>
+        ),
+    };
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -219,7 +195,9 @@ function renderMatrix(matrix: RiskMatrix, title: string): string {
 
     for (let y = 0; y < matrix.length; y++) {
         const row = matrix[y];
-        if (!row) continue;
+        if (!row) {
+            continue;
+        }
         const prob = 5 - y; // probability label (5 at top, 1 at bottom)
         const cells = row
             .map((cell) => {
@@ -242,7 +220,7 @@ function renderMatrix(matrix: RiskMatrix, title: string): string {
 // Section generators
 // ---------------------------------------------------------------------------
 
-function coverSection(data: ProjectReport, date: string, systemImageOnSeperatePage: boolean): string {
+function coverSection(T: Translations, data: ProjectReport, date: string, systemImageOnSeperatePage: boolean): string {
     const { project, systemImage } = data;
     const confidentialityLabel = T.confidentialityLevels[project.confidentialityLevel] ?? project.confidentialityLevel;
 
@@ -267,7 +245,7 @@ function coverSection(data: ProjectReport, date: string, systemImageOnSeperatePa
     return lines.join("\n");
 }
 
-function systemImageSection(systemImage: string | null): string {
+function systemImageSection(T: Translations, systemImage: string | null): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-systemImage")}${T.systemImage}`);
     lines.push("");
@@ -277,7 +255,7 @@ function systemImageSection(systemImage: string | null): string {
     return lines.join("\n");
 }
 
-function tableOfContentsSection(chapters: { label: string; id: string }[]): string {
+function tableOfContentsSection(T: Translations, chapters: { label: string; id: string }[]): string {
     const lines: string[] = [];
     lines.push(`## ${T.tableOfContents}`);
     lines.push("");
@@ -287,7 +265,7 @@ function tableOfContentsSection(chapters: { label: string; id: string }[]): stri
     return lines.join("\n");
 }
 
-function methodExplanationSection(): string {
+function methodExplanationSection(T: Translations): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-methodExplanation")}${T.method}`);
     lines.push("");
@@ -330,7 +308,7 @@ function methodExplanationSection(): string {
     return lines.join("\n");
 }
 
-function scaleExplanationSection(): string {
+function scaleExplanationSection(T: Translations): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-explanationScale")}${T.explanationScale}`);
     lines.push("");
@@ -357,6 +335,7 @@ function scaleExplanationSection(): string {
 }
 
 function matrixSection(
+    T: Translations,
     bruttoMatrix: RiskMatrix | null | undefined,
     nettoMatrix: RiskMatrix | null | undefined,
     tillScheduledAt: string | null | undefined,
@@ -395,9 +374,9 @@ function matrixSection(
     return lines.join("\n");
 }
 
-function assetsSection(assets: AssetWithReportId[]): string {
+function assetsSection(T: Translations, assets: AssetWithReportId[]): string {
     const lines: string[] = [];
-    lines.push(`## ${anchor("chapter-assetsDetails")}Assets`);
+    lines.push(`## ${anchor("chapter-assetsDetails")}${T.assets}`);
     lines.push("");
 
     assets.forEach((asset) => {
@@ -432,7 +411,7 @@ function assetsSection(assets: AssetWithReportId[]): string {
     return lines.join("\n");
 }
 
-function measuresSection(measures: ReportMeasure[]): string {
+function measuresSection(T: Translations, measures: ReportMeasure[]): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-measuresDetails")}${T.measures}`);
     lines.push("");
@@ -472,7 +451,7 @@ function measuresSection(measures: ReportMeasure[]): string {
     return lines.join("\n");
 }
 
-function threatsListSection(threats: ThreatReport[]): string {
+function threatsListSection(T: Translations, threats: ThreatReport[]): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-riskList")}${T.riskList}`);
     lines.push("");
@@ -489,7 +468,7 @@ function threatsListSection(threats: ThreatReport[]): string {
     return lines.join("\n");
 }
 
-function threatsDetailSection(threats: ThreatReport[]): string {
+function threatsDetailSection(T: Translations, threats: ThreatReport[]): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-riskDetails")}${T.threats}`);
     lines.push("");
@@ -536,7 +515,7 @@ function threatsDetailSection(threats: ThreatReport[]): string {
         }
 
         if (threat.assets && threat.assets.length > 0) {
-            lines.push(`**Assets:**`);
+            lines.push(`**${T.assets}:**`);
             lines.push("");
             threat.assets.forEach((asset) => {
                 const assetRid = asset.reportId ?? String(asset.id);
@@ -585,61 +564,80 @@ export function generateMarkdownReport(options: MarkdownReportOptions): string {
         showThreatListPage = true,
         showThreatsPage = true,
         systemImageOnSeperatePage = false,
+        language = "en",
     } = options;
+
+    const T = buildTranslations(language);
 
     const hasSystemImage = Boolean(data.systemImage);
 
     // Build chapter list for table of contents
     const chapters: { label: string; id: string }[] = [];
-    if (showMethodExplanation) chapters.push({ label: T.method, id: "chapter-methodExplanation" });
-    if (showScaleExplanation) chapters.push({ label: T.explanationScale, id: "chapter-explanationScale" });
-    if (systemImageOnSeperatePage && hasSystemImage) chapters.push({ label: T.systemImage, id: "chapter-systemImage" });
-    if (showMatrixPage) chapters.push({ label: T.riskMatrices, id: "chapter-matrix" });
-    if (showAssetsPage) chapters.push({ label: T.assets, id: "chapter-assetsDetails" });
-    if (showMeasuresPage) chapters.push({ label: T.measures, id: "chapter-measuresDetails" });
-    if (showThreatListPage) chapters.push({ label: T.riskList, id: "chapter-riskList" });
-    if (showThreatsPage) chapters.push({ label: T.threats, id: "chapter-riskDetails" });
+    if (showMethodExplanation) {
+        chapters.push({ label: T.method, id: "chapter-methodExplanation" });
+    }
+    if (showScaleExplanation) {
+        chapters.push({ label: T.explanationScale, id: "chapter-explanationScale" });
+    }
+    if (systemImageOnSeperatePage && hasSystemImage) {
+        chapters.push({ label: T.systemImage, id: "chapter-systemImage" });
+    }
+    if (showMatrixPage) {
+        chapters.push({ label: T.riskMatrices, id: "chapter-matrix" });
+    }
+    if (showAssetsPage) {
+        chapters.push({ label: T.assets, id: "chapter-assetsDetails" });
+    }
+    if (showMeasuresPage) {
+        chapters.push({ label: T.measures, id: "chapter-measuresDetails" });
+    }
+    if (showThreatListPage) {
+        chapters.push({ label: T.riskList, id: "chapter-riskList" });
+    }
+    if (showThreatsPage) {
+        chapters.push({ label: T.threats, id: "chapter-riskDetails" });
+    }
 
     const sections: string[] = [];
 
     if (showCoverPage) {
-        sections.push(coverSection(data, date, systemImageOnSeperatePage));
+        sections.push(coverSection(T, data, date, systemImageOnSeperatePage));
     }
 
     if (showTableOfContentsPage && chapters.length > 0) {
-        sections.push(tableOfContentsSection(chapters));
+        sections.push(tableOfContentsSection(T, chapters));
     }
 
     if (showMethodExplanation) {
-        sections.push(methodExplanationSection());
+        sections.push(methodExplanationSection(T));
     }
 
     if (showScaleExplanation) {
-        sections.push(scaleExplanationSection());
+        sections.push(scaleExplanationSection(T));
     }
 
     if (systemImageOnSeperatePage && data.systemImage) {
-        sections.push(systemImageSection(data.systemImage));
+        sections.push(systemImageSection(T, data.systemImage));
     }
 
     if (showMatrixPage) {
-        sections.push(matrixSection(bruttoMatrix, nettoMatrix, tillScheduledAt, data.milestones));
+        sections.push(matrixSection(T, bruttoMatrix, nettoMatrix, tillScheduledAt, data.milestones));
     }
 
     if (showAssetsPage && data.assets.length > 0) {
-        sections.push(assetsSection(data.assets));
+        sections.push(assetsSection(T, data.assets));
     }
 
     if (showMeasuresPage && data.measures.length > 0) {
-        sections.push(measuresSection(data.measures as ReportMeasure[]));
+        sections.push(measuresSection(T, data.measures as ReportMeasure[]));
     }
 
     if (showThreatListPage && data.threats.length > 0) {
-        sections.push(threatsListSection(data.threats));
+        sections.push(threatsListSection(T, data.threats));
     }
 
     if (showThreatsPage && data.threats.length > 0) {
-        sections.push(threatsDetailSection(data.threats));
+        sections.push(threatsDetailSection(T, data.threats));
     }
 
     return sections.join(`\n${hr()}\n`);

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -158,6 +158,74 @@ function buildTranslations(language: string): Translations {
 }
 
 // ---------------------------------------------------------------------------
+// Sanitization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip line breaks from user content used in single-line contexts: headings,
+ * table cells, link text, and inline emphasis. A newline in a heading or table
+ * cell terminates the element and the remainder can introduce new structure
+ * (e.g. `\n# Injected heading`).
+ */
+function escapeInline(s: string): string {
+    return s.replace(/[\r\n]+/g, " ");
+}
+
+/**
+ * Escape pipe characters that would split a table cell, on top of stripping
+ * line breaks.
+ */
+function escapeCell(s: string): string {
+    return escapeInline(s).replace(/\|/g, "\\|");
+}
+
+/**
+ * Escape closing square brackets that would prematurely end link text and
+ * allow an attacker-controlled URL to follow, on top of stripping line breaks.
+ */
+function escapeLinkText(s: string): string {
+    return escapeInline(s).replace(/\]/g, "\\]");
+}
+
+/**
+ * Percent-encode parentheses in URLs. A bare `)` ends the `(url)` part of a
+ * Markdown link, so user-supplied URLs must have it encoded.
+ */
+function escapeUrl(url: string): string {
+    return url.replace(/\(/g, "%28").replace(/\)/g, "%29");
+}
+
+/**
+ * For multi-line block text (e.g. project/asset descriptions) preserve the
+ * original line breaks but escape leading `#` so lines cannot become ATX
+ * headings, which would alter the document outline.
+ *
+ * Single newlines are converted to Markdown hard line breaks (two trailing
+ * spaces + newline) so they render as `<br>` rather than being merged into
+ * the surrounding paragraph. Double newlines (paragraph breaks) are kept
+ * intact.
+ */
+function escapeBlock(s: string): string {
+    return (
+        s
+            .replace(/\r\n?/g, "\n")
+            // ATX headings: `# heading` AND bare `###` (no trailing space/content)
+            .replace(/^(#{1,6})(?=[ \t]|$)/gm, "\\$1")
+            // Setext heading underlines and thematic breaks:
+            // lines consisting solely of -, =, *, _ (plus optional spaces/tabs)
+            .replace(/^([-=*_])[-=*_ \t]*$/gm, "\\$&")
+            // Fenced code blocks: ``` or ~~~ at line start swallow all following
+            // content (including headings) until a matching closing fence
+            .replace(/^(`{3,}|~{3,})/gm, "\\$1")
+            // HTML blocks: CommonMark treats lines starting with < as raw HTML;
+            // \< is a valid backslash escape that renders as a literal <
+            .replace(/^</gm, "\\<")
+            // Hard line breaks: single \n → two trailing spaces + \n
+            .replace(/([^\n])\n(?!\n)/g, "$1  \n")
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -166,7 +234,9 @@ function hr(): string {
 }
 
 function anchor(id: string): string {
-    return `<a id="${id}"></a>`;
+    // Strip characters that could break out of the HTML attribute value.
+    const safeId = id.replace(/["<>]/g, "");
+    return `<a id="${safeId}"></a>`;
 }
 
 function tocLink(label: string, id: string): string {
@@ -227,7 +297,7 @@ function coverSection(T: Translations, data: ProjectReport, date: string, system
     const confidentialityLabel = T.confidentialityLevels[project.confidentialityLevel] ?? project.confidentialityLevel;
 
     const lines: string[] = [];
-    lines.push(`# ${project.name}`);
+    lines.push(`# ${escapeInline(project.name)}`);
     lines.push("");
     lines.push("Cyber Security | MaibornWolff");
     lines.push("");
@@ -238,11 +308,11 @@ function coverSection(T: Translations, data: ProjectReport, date: string, system
     lines.push(`*${confidentialityLabel}*`);
     if (project.description) {
         lines.push("");
-        lines.push(project.description);
+        lines.push(escapeBlock(project.description));
     }
     if (!systemImageOnSeperatePage && systemImage) {
         lines.push("");
-        lines.push(`![${T.systemImage}](${systemImage})`);
+        lines.push(`![${T.systemImage}](${escapeUrl(systemImage)})`);
         lines.push("");
         lines.push(systemImageLegend(T));
     }
@@ -267,7 +337,7 @@ function systemImageSection(T: Translations, systemImage: string | null): string
     lines.push(`## ${anchor("chapter-systemImage")}${T.systemImage}`);
     lines.push("");
     if (systemImage) {
-        lines.push(`![${T.systemImage}](${systemImage})`);
+        lines.push(`![${T.systemImage}](${escapeUrl(systemImage)})`);
         lines.push("");
     }
     lines.push(systemImageLegend(T));
@@ -400,29 +470,39 @@ function assetsSection(T: Translations, assets: AssetWithReportId[]): string {
 
     assets.forEach((asset) => {
         const id = `asset-${asset.reportId}`;
-        lines.push(`### ${anchor(id)}${asset.reportId} ${asset.name}`);
+        lines.push(`### ${anchor(id)}${escapeInline(asset.reportId)} ${escapeInline(asset.name)}`);
         lines.push("");
-        lines.push(`*ID: ${asset.id}*`);
+        lines.push(`*ID: ${escapeInline(String(asset.id))}*`);
         lines.push("");
         lines.push(`| ${T.confidentiality} | ${T.integrity} | ${T.availability} |`);
         lines.push(`|---|---|---|`);
-        lines.push(`| ${asset.confidentiality} | ${asset.integrity} | ${asset.availability} |`);
+        lines.push(
+            `| ${escapeCell(String(asset.confidentiality))} | ${escapeCell(String(asset.integrity))} | ${escapeCell(String(asset.availability))} |`
+        );
         lines.push("");
 
         if (asset.description) {
-            lines.push(`**${T.description}:** ${asset.description}`);
+            lines.push(`**${T.description}:**`);
+            lines.push("");
+            lines.push(escapeBlock(asset.description));
             lines.push("");
         }
         if (asset.confidentialityJustification) {
-            lines.push(`**${T.confidentialityJustification}:** ${asset.confidentialityJustification}`);
+            lines.push(`**${T.confidentialityJustification}:**`);
+            lines.push("");
+            lines.push(escapeBlock(asset.confidentialityJustification));
             lines.push("");
         }
         if (asset.integrityJustification) {
-            lines.push(`**${T.integrityJustification}:** ${asset.integrityJustification}`);
+            lines.push(`**${T.integrityJustification}:**`);
+            lines.push("");
+            lines.push(escapeBlock(asset.integrityJustification));
             lines.push("");
         }
         if (asset.availabilityJustification) {
-            lines.push(`**${T.availabilityJustification}:** ${asset.availabilityJustification}`);
+            lines.push(`**${T.availabilityJustification}:**`);
+            lines.push("");
+            lines.push(escapeBlock(asset.availabilityJustification));
             lines.push("");
         }
     });
@@ -436,11 +516,11 @@ function measuresSection(T: Translations, measures: ReportMeasure[]): string {
     lines.push("");
 
     measures.forEach((measure) => {
-        const rid = measure.reportId ?? String(measure.id);
+        const rid = escapeInline(measure.reportId ?? String(measure.id));
         const id = `measure-${rid}`;
-        lines.push(`### ${anchor(id)}${rid} ${measure.name}`);
+        lines.push(`### ${anchor(id)}${rid} ${escapeInline(measure.name)}`);
         lines.push("");
-        lines.push(`*ID: ${measure.id}*`);
+        lines.push(`*ID: ${escapeInline(String(measure.id))}*`);
         lines.push("");
 
         const scheduledAtDate =
@@ -451,7 +531,9 @@ function measuresSection(T: Translations, measures: ReportMeasure[]): string {
         lines.push("");
 
         if (measure.description && measure.description.length > 0) {
-            lines.push(`**${T.description}:** ${measure.description}`);
+            lines.push(`**${T.description}:**`);
+            lines.push("");
+            lines.push(escapeBlock(measure.description));
             lines.push("");
         }
 
@@ -460,7 +542,8 @@ function measuresSection(T: Translations, measures: ReportMeasure[]): string {
             lines.push("");
             measure.threats.forEach((threat) => {
                 const threatRid = threat.reportId ?? String(threat.id);
-                const link = `[${threat.id} ${threat.name ?? ""}](#${threatAnchorId(threatRid)})`;
+                const linkText = escapeLinkText(`${threat.id} ${threat.name ?? ""}`);
+                const link = `[${linkText}](#${threatAnchorId(threatRid)})`;
                 lines.push(`- ${link}`);
             });
             lines.push("");
@@ -478,9 +561,9 @@ function threatsListSection(T: Translations, threats: ThreatReport[]): string {
     lines.push(`| ID | ${T.name} | ${T.component} |`);
     lines.push(`|----|---------|-----------|`);
     threats.forEach((threat) => {
-        const link = `[${threat.name}](#${threatAnchorId(threat.reportId)})`;
-        const component = threat.componentName ?? "";
-        lines.push(`| ${threat.id} | ${link} | ${component} |`);
+        const link = `[${escapeLinkText(threat.name)}](#${threatAnchorId(threat.reportId)})`;
+        const component = escapeCell(threat.componentName ?? "");
+        lines.push(`| ${escapeCell(String(threat.id))} | ${link} | ${component} |`);
     });
     lines.push("");
 
@@ -504,9 +587,9 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
             .filter(Boolean)
             .join(", ");
 
-        lines.push(`### ${anchor(id)}${threat.reportId} ${threat.name}`);
+        lines.push(`### ${anchor(id)}${escapeInline(threat.reportId)} ${escapeInline(threat.name)}`);
         lines.push("");
-        lines.push(`*ID: ${threat.id}*`);
+        lines.push(`*ID: ${escapeInline(String(threat.id))}*`);
         lines.push("");
 
         if (affectedGoals) {
@@ -517,11 +600,15 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
         // Risk table
         lines.push(`| | ${T.probability} | ${T.damage} | ${T.risk} |`);
         lines.push(`|---|---|---|---|`);
-        lines.push(`| ${T.gross} | ${threat.probability} | ${threat.damage} | ${threat.risk} |`);
-        lines.push(`| ${T.net} | ${threat.netProbability} | ${threat.netDamage} | ${threat.netRisk} |`);
+        lines.push(
+            `| ${T.gross} | ${escapeCell(String(threat.probability))} | ${escapeCell(String(threat.damage))} | ${escapeCell(String(threat.risk))} |`
+        );
+        lines.push(
+            `| ${T.net} | ${escapeCell(String(threat.netProbability))} | ${escapeCell(String(threat.netDamage))} | ${escapeCell(String(threat.netRisk))} |`
+        );
         lines.push("");
 
-        lines.push(`**${T.component}:** ${threat.componentName ?? "–"}`);
+        lines.push(`**${T.component}:** ${escapeInline(threat.componentName ?? "–")}`);
         lines.push("");
         lines.push(`**${T.attackersHeader}:** ${attackerName}`);
         lines.push("");
@@ -529,7 +616,9 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
         lines.push("");
 
         if (threat.description) {
-            lines.push(`**${T.description}:** ${threat.description}`);
+            lines.push(`**${T.description}:**`);
+            lines.push("");
+            lines.push(escapeBlock(threat.description));
             lines.push("");
         }
 
@@ -538,7 +627,8 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
             lines.push("");
             threat.assets.forEach((asset) => {
                 const assetRid = asset.reportId ?? String(asset.id);
-                const link = `[${assetRid} ${asset.name ?? ""}](#${assetAnchorId(assetRid)})`;
+                const linkText = escapeLinkText(`${assetRid} ${asset.name ?? ""}`);
+                const link = `[${linkText}](#${assetAnchorId(assetRid)})`;
                 lines.push(`- ${link}`);
             });
             lines.push("");
@@ -549,10 +639,11 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
             lines.push("");
             threat.measures.forEach((measure) => {
                 const mRid = measure.reportId ?? String(measure.measureId);
-                const link = `[${mRid} ${measure.name ?? ""}](#${measureAnchorId(mRid)})`;
+                const linkText = escapeLinkText(`${mRid} ${measure.name ?? ""}`);
+                const link = `[${linkText}](#${measureAnchorId(mRid)})`;
                 lines.push(`- ${link}`);
                 if (measure.description) {
-                    lines.push(`  *${measure.description}*`);
+                    lines.push(`  *${escapeInline(measure.description)}*`);
                 }
             });
             lines.push("");

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -174,7 +174,7 @@ function escapeInline(s: string): string {
  * line breaks.
  */
 function escapeCell(s: string): string {
-    return escapeInline(s).replace(/\|/g, "\\|");
+    return escapeInline(s).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 }
 
 /**

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -1,5 +1,7 @@
 import type { ProjectReport } from "#api/types/project.types.ts";
 import type { RiskMatrix, Milestone } from "#application/hooks/use-report.hook.ts";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { POA_COLORS } from "../colors/pointsOfAttack.colors";
 import i18next from "i18next";
 
 // ---------------------------------------------------------------------------
@@ -241,6 +243,21 @@ function coverSection(T: Translations, data: ProjectReport, date: string, system
     if (!systemImageOnSeperatePage && systemImage) {
         lines.push("");
         lines.push(`![${T.systemImage}](${systemImage})`);
+        lines.push("");
+        lines.push(systemImageLegend(T));
+    }
+    return lines.join("\n");
+}
+
+function systemImageLegend(T: Translations): string {
+    const lines: string[] = [];
+    lines.push(`| | ${T.pointsOfAttackHeader} |`);
+    lines.push(`|:---:|---|`);
+    for (const poa of Object.values(POINTS_OF_ATTACK)) {
+        const color = POA_COLORS[poa].normal;
+        const name = T.pointsOfAttacks[poa]?.name ?? poa;
+        const swatch = `<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg"><rect width="12" height="12" fill="${color}" rx="2"/></svg>`;
+        lines.push(`| ${swatch} \`${color}\` | ${name} |`);
     }
     return lines.join("\n");
 }
@@ -251,7 +268,9 @@ function systemImageSection(T: Translations, systemImage: string | null): string
     lines.push("");
     if (systemImage) {
         lines.push(`![${T.systemImage}](${systemImage})`);
+        lines.push("");
     }
+    lines.push(systemImageLegend(T));
     return lines.join("\n");
 }
 

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -144,11 +144,11 @@ function buildTranslations(language: string): Translations {
             { name: string; description: string }
         >,
         probabilities: Object.values(
-            t("probabilities", { returnObjects: true }) as Record<string, { name: string; description: string }>,
+            t("probabilities", { returnObjects: true }) as Record<string, { name: string; description: string }>
         ),
         cellNames,
         damages: Object.values(
-            t("damages", { returnObjects: true }) as Record<string, { name: string; description: string }>,
+            t("damages", { returnObjects: true }) as Record<string, { name: string; description: string }>
         ),
         matrixLegend: t("matrixLegend"),
         matrixAxisLegend: t("matrixAxisLegend"),
@@ -425,7 +425,7 @@ function matrixSection(
     bruttoMatrix: RiskMatrix | null | undefined,
     nettoMatrix: RiskMatrix | null | undefined,
     tillScheduledAt: string | null | undefined,
-    milestones: Milestone[] | null | undefined,
+    milestones: Milestone[] | null | undefined
 ): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-matrix")}${T.riskMatrices}`);
@@ -474,7 +474,7 @@ function assetsSection(T: Translations, assets: AssetWithReportId[]): string {
         lines.push(`| ${T.confidentiality} | ${T.integrity} | ${T.availability} |`);
         lines.push(`|---|---|---|`);
         lines.push(
-            `| ${escapeCell(String(asset.confidentiality))} | ${escapeCell(String(asset.integrity))} | ${escapeCell(String(asset.availability))} |`,
+            `| ${escapeCell(String(asset.confidentiality))} | ${escapeCell(String(asset.integrity))} | ${escapeCell(String(asset.availability))} |`
         );
         lines.push("");
 
@@ -598,10 +598,10 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
         lines.push(`| | ${T.probability} | ${T.damage} | ${T.risk} |`);
         lines.push(`|---|---|---|---|`);
         lines.push(
-            `| ${T.gross} | ${escapeCell(String(threat.probability))} | ${escapeCell(String(threat.damage))} | ${escapeCell(String(threat.risk))} |`,
+            `| ${T.gross} | ${escapeCell(String(threat.probability))} | ${escapeCell(String(threat.damage))} | ${escapeCell(String(threat.risk))} |`
         );
         lines.push(
-            `| ${T.net} | ${escapeCell(String(threat.netProbability))} | ${escapeCell(String(threat.netDamage))} | ${escapeCell(String(threat.netRisk))} |`,
+            `| ${T.net} | ${escapeCell(String(threat.netProbability))} | ${escapeCell(String(threat.netDamage))} | ${escapeCell(String(threat.netRisk))} |`
         );
         lines.push("");
 

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -1,6 +1,7 @@
 import type { ProjectReport } from "#api/types/project.types.ts";
 import type { RiskMatrix, Milestone } from "#application/hooks/use-report.hook.ts";
 import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { ATTACKERS } from "#api/types/attackers.types.ts";
 import { POA_COLORS } from "../colors/pointsOfAttack.colors";
 import i18next from "i18next";
 
@@ -16,22 +17,22 @@ type ReportMeasure = Omit<ProjectReport["measures"][number], "scheduledAt"> & {
 type AssetWithReportId = ProjectReport["assets"][number];
 
 export interface MarkdownReportOptions {
-    data: ProjectReport & { milestones?: Milestone[] | null };
-    bruttoMatrix?: RiskMatrix | null;
-    nettoMatrix?: RiskMatrix | null;
-    date?: string;
-    tillScheduledAt?: string | null;
-    showCoverPage?: boolean;
-    showTableOfContentsPage?: boolean;
-    showMethodExplanation?: boolean;
-    showScaleExplanation?: boolean;
-    showMatrixPage?: boolean;
-    showAssetsPage?: boolean;
-    showMeasuresPage?: boolean;
-    showThreatListPage?: boolean;
-    showThreatsPage?: boolean;
-    systemImageOnSeperatePage?: boolean;
-    language?: string;
+    data: ProjectReport & { milestones?: Milestone[] | null | undefined };
+    bruttoMatrix?: RiskMatrix | null | undefined;
+    nettoMatrix?: RiskMatrix | null | undefined;
+    date?: string | undefined;
+    tillScheduledAt?: string | null | undefined;
+    showCoverPage?: boolean | undefined;
+    showTableOfContentsPage?: boolean | undefined;
+    showMethodExplanation?: boolean | undefined;
+    showScaleExplanation?: boolean | undefined;
+    showMatrixPage?: boolean | undefined;
+    showAssetsPage?: boolean | undefined;
+    showMeasuresPage?: boolean | undefined;
+    showThreatListPage?: boolean | undefined;
+    showThreatsPage?: boolean | undefined;
+    systemImageOnSeperatePage?: boolean | undefined;
+    language?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,15 +85,8 @@ interface Translations {
 function buildTranslations(language: string): Translations {
     const t = i18next.getFixedT(language, "report");
 
-    const poaKeys = [
-        "DATA_STORAGE_INFRASTRUCTURE",
-        "PROCESSING_INFRASTRUCTURE",
-        "COMMUNICATION_INFRASTRUCTURE",
-        "COMMUNICATION_INTERFACES",
-        "USER_INTERFACE",
-        "USER_BEHAVIOUR",
-    ];
-    const attackerKeys = ["UNAUTHORISED_PARTIES", "SYSTEM_USERS", "APPLICATION_USERS", "ADMINISTRATORS"];
+    const poaKeys = Object.values(POINTS_OF_ATTACK);
+    const attackerKeys = Object.values(ATTACKERS);
 
     const cellNames: Record<string, Record<string, string>> = {};
     for (const poa of poaKeys) {

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -641,9 +641,10 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
                 const mRid = measure.reportId ?? String(measure.measureId);
                 const linkText = escapeLinkText(`${mRid} ${measure.name ?? ""}`);
                 const link = `[${linkText}](#${measureAnchorId(mRid)})`;
-                lines.push(`- ${link}`);
                 if (measure.description) {
-                    lines.push(`  *${escapeInline(measure.description)}*`);
+                    lines.push(`- ${link}<br>*${escapeInline(measure.description)}*`);
+                } else {
+                    lines.push(`- ${link}`);
                 }
             });
             lines.push("");

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -1,0 +1,646 @@
+import type { ProjectReport } from "#api/types/project.types.ts";
+import type { RiskMatrix, Milestone } from "#application/hooks/use-report.hook.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ThreatReport = ProjectReport["threats"][number];
+type ReportMeasure = Omit<ProjectReport["measures"][number], "scheduledAt"> & {
+    scheduledAt: string | Date;
+    reportId?: string;
+};
+type AssetWithReportId = ProjectReport["assets"][number];
+
+export interface MarkdownReportOptions {
+    data: ProjectReport & { milestones?: Milestone[] | null };
+    bruttoMatrix?: RiskMatrix | null;
+    nettoMatrix?: RiskMatrix | null;
+    date?: string;
+    tillScheduledAt?: string | null;
+    showCoverPage?: boolean;
+    showTableOfContentsPage?: boolean;
+    showMethodExplanation?: boolean;
+    showScaleExplanation?: boolean;
+    showMatrixPage?: boolean;
+    showAssetsPage?: boolean;
+    showMeasuresPage?: boolean;
+    showThreatListPage?: boolean;
+    showThreatsPage?: boolean;
+    systemImageOnSeperatePage?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Static translations (English)
+// The report i18n namespace is partially incomplete; we embed strings here
+// so the markdown generator has no runtime i18n dependency.
+// ---------------------------------------------------------------------------
+
+const T = {
+    coverPage: "Cover Page",
+    tableOfContents: "Table of Contents",
+    chapter: "Chapter",
+    pagenumber: "Page",
+    method: "The 4x6 Methodology",
+    explanationIdea:
+        "The 4x6 methodology is based on a matrix that specifies every conceivable threat from the four classes of attackers for any IT system abstracted to six classes of attack points.",
+    explanationApplication:
+        "The matrix is initially independent of specific attack techniques or attack targets. In the course of a threat analysis, this abstracted matrix is applied to a specific system architecture that was abstracted according to the above specification. From this, concrete attack scenarios are immediately developed in a manageable but nevertheless complete view.",
+    attackersHeader: "Attackers",
+    pointsOfAttackHeader: "Points Of Attack",
+    explanationScale: "Explanation of Probability and Damage Scale",
+    probability: "Probability",
+    damage: "Damage",
+    risk: "Risk",
+    riskMatrices: "Risk Matrices",
+    before: "Before",
+    after: "After",
+    gross: "gross",
+    net: "net",
+    systemImage: "System Image",
+    assets: "Assets",
+    measures: "Measures",
+    riskList: "List of Threats",
+    threats: "Threats",
+    name: "Name",
+    component: "Component",
+    description: "Description",
+    confidentiality: "Confidentiality",
+    integrity: "Integrity",
+    availability: "Availability",
+    confidentialityJustification: "Confidentiality Justification",
+    integrityJustification: "Integrity Justification",
+    availabilityJustification: "Availability Justification",
+    attacker: "Attacker",
+    pointOfAttack: "Point of Attack",
+
+    confidentialityLevels: {
+        PUBLIC: "Public",
+        INTERNAL: "Internal",
+        CONFIDENTIAL: "Confidential",
+        SECRET: "Secret",
+    } as Record<string, string>,
+
+    attackers: {
+        UNAUTHORISED_PARTIES: {
+            name: "Unauthorised Parties",
+            description: "Entities with no tie to and especially no authorisation on the system under consideration",
+        },
+        SYSTEM_USERS: {
+            name: "System Users",
+            description:
+                "Users being authorised to share use of resources with the application under consideration but not having authorisation on the application itself",
+        },
+        APPLICATION_USERS: {
+            name: "Application Users",
+            description: "Users being authorised to work with the application under consideration",
+        },
+        ADMINISTRATORS: {
+            name: "(Technical) Administrators",
+            description: "Users with elevated privileges who manage the infrastructure used by the application",
+        },
+    } as Record<string, { name: string; description: string }>,
+
+    pointsOfAttacks: {
+        USER_INTERFACE: {
+            name: "User Interface",
+            description:
+                "the places and programmes, where and by which users interact with the system, usually via screen and input device, e.g. a browser on a PC",
+        },
+        PROCESSING_INFRASTRUCTURE: {
+            name: "Processing Infrastructure",
+            description:
+                "places of program execution – in principle everything which has a processor and its programming is not absolutely fixed, e.g. including database servers, where queries are processed",
+        },
+        DATA_STORAGE_INFRASTRUCTURE: {
+            name: "Data Storage Infrastructure",
+            description: "places where data is stored durably – hard disks, non-volatile semiconductor memory, …",
+        },
+        COMMUNICATION_INFRASTRUCTURE: {
+            name: "Communication Infrastructure",
+            description: "physical transport of data via cable or wireless",
+        },
+        COMMUNICATION_INTERFACES: {
+            name: "Communication Interfaces",
+            description:
+                "the connection to the means of communication on all OSI layers: network interfaces, wireless antenna, TCP Ports, APIs, …",
+        },
+        USER_BEHAVIOUR: {
+            name: "User Behaviour",
+            description: "The behaviour of a user (human)",
+        },
+    } as Record<string, { name: string; description: string }>,
+
+    probabilities: [
+        { name: "Very Unlikely", description: "The event is extremely rare and almost never expected to occur." },
+        { name: "Unlikely", description: "The event is unusual and occurs only in exceptional circumstances." },
+        { name: "Possible", description: "The event may occur under certain conditions." },
+        { name: "Likely", description: "The event is expected to occur in many circumstances." },
+        { name: "Very Likely", description: "The event is almost certain to occur." },
+    ],
+
+    // Valid cells of the 4x6 matrix keyed as cellNames[pointOfAttack][attacker]
+    cellNames: {
+        DATA_STORAGE_INFRASTRUCTURE: {
+            UNAUTHORISED_PARTIES: "Physical data storage access",
+            SYSTEM_USERS: "Internal breach on data storage",
+            ADMINISTRATORS: "Privilege abuse on data storage",
+        },
+        PROCESSING_INFRASTRUCTURE: {
+            UNAUTHORISED_PARTIES: "Physical attack on processing",
+            SYSTEM_USERS: "Internal breach during processing",
+            ADMINISTRATORS: "Privilege abuse on processing",
+        },
+        COMMUNICATION_INFRASTRUCTURE: {
+            UNAUTHORISED_PARTIES: "Physical attack on transmission",
+            SYSTEM_USERS: "Internal breach on transmission",
+            ADMINISTRATORS: "Privilege abuse on transmission",
+        },
+        COMMUNICATION_INTERFACES: {
+            UNAUTHORISED_PARTIES: "Physical interface attack",
+            SYSTEM_USERS: "Breach via interface access",
+            APPLICATION_USERS: "Detrimental interface usage",
+        },
+        USER_INTERFACE: {
+            UNAUTHORISED_PARTIES: "Physical UI access",
+            APPLICATION_USERS: "Detrimental UI usage",
+        },
+        USER_BEHAVIOUR: {
+            UNAUTHORISED_PARTIES: "Deception",
+        },
+    } as Record<string, Record<string, string>>,
+
+    damages: [
+        { name: "Negligible", description: "Minimal impact; operations continue essentially unaffected." },
+        { name: "Minor", description: "Limited impact; some disruption but quickly recoverable." },
+        { name: "Moderate", description: "Significant impact; noticeable disruption or data exposure." },
+        { name: "Major", description: "Severe impact; major disruption, large data breach, or financial loss." },
+        { name: "Critical", description: "Catastrophic impact; organisation-wide damage or irreversible harm." },
+    ],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hr(): string {
+    return "\n---\n";
+}
+
+function anchor(id: string): string {
+    return `<a id="${id}"></a>`;
+}
+
+function tocLink(label: string, id: string): string {
+    return `[${label}](#${id})`;
+}
+
+function threatAnchorId(reportId: string): string {
+    return `threat-${reportId}`;
+}
+
+function assetAnchorId(reportId: string): string {
+    return `asset-${reportId}`;
+}
+
+function measureAnchorId(reportId: string): string {
+    return `measure-${reportId}`;
+}
+
+function renderMatrix(matrix: RiskMatrix, title: string): string {
+    const lines: string[] = [];
+    lines.push(`**${title}**\n`);
+
+    // Header row: damage 1–5
+    const header = `| P \\ D | D1 | D2 | D3 | D4 | D5 |`;
+    const separator = `|--------|----|----|----|----|-----|`;
+    lines.push(header);
+    lines.push(separator);
+
+    for (let y = 0; y < matrix.length; y++) {
+        const row = matrix[y];
+        if (!row) continue;
+        const prob = 5 - y; // probability label (5 at top, 1 at bottom)
+        const cells = row
+            .map((cell) => {
+                const colorLabel = cell.color === "green" ? "G" : cell.color === "yellow" ? "Y" : "R";
+                const count = typeof cell.amount === "number" ? String(cell.amount) : " ";
+                return `${colorLabel}${count !== " " ? `:${count}` : ""}`;
+            })
+            .join(" | ");
+        lines.push(`| P${prob} | ${cells} |`);
+    }
+
+    lines.push("");
+    lines.push(
+        "*G = green (low risk), Y = yellow (medium risk), R = red (high risk). Count shown when threats present.*"
+    );
+    return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section generators
+// ---------------------------------------------------------------------------
+
+function coverSection(data: ProjectReport, date: string, systemImageOnSeperatePage: boolean): string {
+    const { project, systemImage } = data;
+    const confidentialityLabel = T.confidentialityLevels[project.confidentialityLevel] ?? project.confidentialityLevel;
+
+    const lines: string[] = [];
+    lines.push(`# ${project.name}`);
+    lines.push("");
+    lines.push("Cyber Security | MaibornWolff");
+    lines.push("");
+    lines.push("ThreatSea by MaibornWolff");
+    lines.push("");
+    lines.push(`**${date}**`);
+    lines.push("");
+    lines.push(`*${confidentialityLabel}*`);
+    if (project.description) {
+        lines.push("");
+        lines.push(project.description);
+    }
+    if (!systemImageOnSeperatePage && systemImage) {
+        lines.push("");
+        lines.push(`![${T.systemImage}](${systemImage})`);
+    }
+    return lines.join("\n");
+}
+
+function systemImageSection(systemImage: string | null): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-systemImage")}${T.systemImage}`);
+    lines.push("");
+    if (systemImage) {
+        lines.push(`![${T.systemImage}](${systemImage})`);
+    }
+    return lines.join("\n");
+}
+
+function tableOfContentsSection(chapters: { label: string; id: string }[]): string {
+    const lines: string[] = [];
+    lines.push(`## ${T.tableOfContents}`);
+    lines.push("");
+    chapters.forEach((ch, i) => {
+        lines.push(`${i + 1}. ${tocLink(ch.label, ch.id)}`);
+    });
+    return lines.join("\n");
+}
+
+function methodExplanationSection(): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-methodExplanation")}${T.method}`);
+    lines.push("");
+    lines.push(T.explanationIdea);
+    lines.push("");
+
+    // 4x6 matrix (static, attackers × points of attack)
+    const attackerKeys = Object.keys(T.attackers);
+    const poaKeys = Object.keys(T.pointsOfAttacks);
+    const attackerNames = attackerKeys.map((k) => T.attackers[k]?.name ?? k);
+    const poaNames = poaKeys.map((k) => T.pointsOfAttacks[k]?.name ?? k);
+
+    // Table header
+    const header = `| | ${attackerNames.join(" | ")} |`;
+    const sep = `|---|${"---|".repeat(attackerNames.length)}`;
+    lines.push(header);
+    lines.push(sep);
+    poaKeys.forEach((poaKey, i) => {
+        const poaName = poaNames[i] ?? poaKey;
+        const cells = attackerKeys.map((attackerKey) => T.cellNames[poaKey]?.[attackerKey] ?? "");
+        lines.push(`| ${poaName} | ${cells.join(" | ")} |`);
+    });
+    lines.push("");
+
+    lines.push(`**${T.attackersHeader}:**`);
+    lines.push("");
+    Object.values(T.attackers).forEach((attacker) => {
+        lines.push(`- **${attacker.name}:** ${attacker.description}`);
+    });
+    lines.push("");
+
+    lines.push(`**${T.pointsOfAttackHeader}:**`);
+    lines.push("");
+    Object.values(T.pointsOfAttacks).forEach((poa) => {
+        lines.push(`- **${poa.name}:** ${poa.description}`);
+    });
+    lines.push("");
+
+    lines.push(T.explanationApplication);
+    return lines.join("\n");
+}
+
+function scaleExplanationSection(): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-explanationScale")}${T.explanationScale}`);
+    lines.push("");
+
+    lines.push(`**${T.probability}**`);
+    lines.push("");
+    T.probabilities.forEach((p, i) => {
+        lines.push(`**${i + 1} – ${p.name}**`);
+        lines.push("");
+        lines.push(p.description);
+        lines.push("");
+    });
+
+    lines.push(`**${T.damage}**`);
+    lines.push("");
+    T.damages.forEach((d, i) => {
+        lines.push(`**${i + 1} – ${d.name}**`);
+        lines.push("");
+        lines.push(d.description);
+        lines.push("");
+    });
+
+    return lines.join("\n");
+}
+
+function matrixSection(
+    bruttoMatrix: RiskMatrix | null | undefined,
+    nettoMatrix: RiskMatrix | null | undefined,
+    tillScheduledAt: string | null | undefined,
+    milestones: Milestone[] | null | undefined
+): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-matrix")}${T.riskMatrices}`);
+    lines.push("");
+
+    if (tillScheduledAt) {
+        const dateStr = new Date(tillScheduledAt).toISOString().split("T")[0];
+        lines.push(`*Start – ${dateStr}*`);
+        lines.push("");
+    }
+
+    if (bruttoMatrix) {
+        lines.push(renderMatrix(bruttoMatrix, T.before));
+        lines.push("");
+    }
+    if (nettoMatrix) {
+        lines.push(renderMatrix(nettoMatrix, T.after));
+        lines.push("");
+    }
+
+    const activeMilestones = milestones?.filter((m) => m.active);
+    if (activeMilestones && activeMilestones.length > 0) {
+        activeMilestones.forEach((milestone) => {
+            if (milestone.matrix) {
+                const title = milestone.scheduledAt.toISOString().split("T")[0];
+                lines.push(renderMatrix(milestone.matrix, title ?? ""));
+                lines.push("");
+            }
+        });
+    }
+
+    return lines.join("\n");
+}
+
+function assetsSection(assets: AssetWithReportId[]): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-assetsDetails")}Assets`);
+    lines.push("");
+
+    assets.forEach((asset) => {
+        const id = `asset-${asset.reportId}`;
+        lines.push(`### ${anchor(id)}${asset.reportId} ${asset.name}`);
+        lines.push("");
+        lines.push(`*ID: ${asset.id}*`);
+        lines.push("");
+        lines.push(`| ${T.confidentiality} | ${T.integrity} | ${T.availability} |`);
+        lines.push(`|---|---|---|`);
+        lines.push(`| ${asset.confidentiality} | ${asset.integrity} | ${asset.availability} |`);
+        lines.push("");
+
+        if (asset.description) {
+            lines.push(`**${T.description}:** ${asset.description}`);
+            lines.push("");
+        }
+        if (asset.confidentialityJustification) {
+            lines.push(`**${T.confidentialityJustification}:** ${asset.confidentialityJustification}`);
+            lines.push("");
+        }
+        if (asset.integrityJustification) {
+            lines.push(`**${T.integrityJustification}:** ${asset.integrityJustification}`);
+            lines.push("");
+        }
+        if (asset.availabilityJustification) {
+            lines.push(`**${T.availabilityJustification}:** ${asset.availabilityJustification}`);
+            lines.push("");
+        }
+    });
+
+    return lines.join("\n");
+}
+
+function measuresSection(measures: ReportMeasure[]): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-measuresDetails")}${T.measures}`);
+    lines.push("");
+
+    measures.forEach((measure) => {
+        const rid = measure.reportId ?? String(measure.id);
+        const id = `measure-${rid}`;
+        lines.push(`### ${anchor(id)}${rid} ${measure.name}`);
+        lines.push("");
+        lines.push(`*ID: ${measure.id}*`);
+        lines.push("");
+
+        const scheduledAtDate =
+            typeof measure.scheduledAt === "string"
+                ? new Date(measure.scheduledAt)
+                : new Date(measure.scheduledAt.getTime());
+        lines.push(`*${scheduledAtDate.toISOString().split("T")[0]}*`);
+        lines.push("");
+
+        if (measure.description && measure.description.length > 0) {
+            lines.push(`**${T.description}:** ${measure.description}`);
+            lines.push("");
+        }
+
+        if (measure.threats && measure.threats.length > 0) {
+            lines.push(`**${T.threats}:**`);
+            lines.push("");
+            measure.threats.forEach((threat) => {
+                const threatRid = threat.reportId ?? String(threat.id);
+                const link = `[${threat.id} ${threat.name ?? ""}](#${threatAnchorId(threatRid)})`;
+                lines.push(`- ${link}`);
+            });
+            lines.push("");
+        }
+    });
+
+    return lines.join("\n");
+}
+
+function threatsListSection(threats: ThreatReport[]): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-riskList")}${T.riskList}`);
+    lines.push("");
+
+    lines.push(`| ID | ${T.name} | ${T.component} |`);
+    lines.push(`|----|---------|-----------|`);
+    threats.forEach((threat) => {
+        const link = `[${threat.name}](#${threatAnchorId(threat.reportId)})`;
+        const component = threat.componentName ?? "";
+        lines.push(`| ${threat.id} | ${link} | ${component} |`);
+    });
+    lines.push("");
+
+    return lines.join("\n");
+}
+
+function threatsDetailSection(threats: ThreatReport[]): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-riskDetails")}${T.threats}`);
+    lines.push("");
+
+    threats.forEach((threat) => {
+        const id = threatAnchorId(threat.reportId);
+        const attackerName = T.attackers[threat.attacker]?.name ?? threat.attacker;
+        const poaName = T.pointsOfAttacks[threat.pointOfAttack]?.name ?? threat.pointOfAttack;
+        const affectedGoals = [
+            threat.confidentiality && T.confidentiality,
+            threat.integrity && T.integrity,
+            threat.availability && T.availability,
+        ]
+            .filter(Boolean)
+            .join(", ");
+
+        lines.push(`### ${anchor(id)}${threat.reportId} ${threat.name}`);
+        lines.push("");
+        lines.push(`*ID: ${threat.id}*`);
+        lines.push("");
+
+        if (affectedGoals) {
+            lines.push(`*${affectedGoals}*`);
+            lines.push("");
+        }
+
+        // Risk table
+        lines.push(`| | ${T.probability} | ${T.damage} | ${T.risk} |`);
+        lines.push(`|---|---|---|---|`);
+        lines.push(`| ${T.gross} | ${threat.probability} | ${threat.damage} | ${threat.risk} |`);
+        lines.push(`| ${T.net} | ${threat.netProbability} | ${threat.netDamage} | ${threat.netRisk} |`);
+        lines.push("");
+
+        lines.push(`**${T.component}:** ${threat.componentName ?? "–"}`);
+        lines.push("");
+        lines.push(`**${T.attackersHeader}:** ${attackerName}`);
+        lines.push("");
+        lines.push(`**${T.pointsOfAttackHeader}:** ${poaName}`);
+        lines.push("");
+
+        if (threat.description) {
+            lines.push(`**${T.description}:** ${threat.description}`);
+            lines.push("");
+        }
+
+        if (threat.assets && threat.assets.length > 0) {
+            lines.push(`**Assets:**`);
+            lines.push("");
+            threat.assets.forEach((asset) => {
+                const assetRid = asset.reportId ?? String(asset.id);
+                const link = `[${assetRid} ${asset.name ?? ""}](#${assetAnchorId(assetRid)})`;
+                lines.push(`- ${link}`);
+            });
+            lines.push("");
+        }
+
+        if (threat.measures && threat.measures.length > 0) {
+            lines.push(`**${T.measures}:**`);
+            lines.push("");
+            threat.measures.forEach((measure) => {
+                const mRid = measure.reportId ?? String(measure.measureId);
+                const link = `[${mRid} ${measure.name ?? ""}](#${measureAnchorId(mRid)})`;
+                lines.push(`- ${link}`);
+                if (measure.description) {
+                    lines.push(`  *${measure.description}*`);
+                }
+            });
+            lines.push("");
+        }
+    });
+
+    return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export function generateMarkdownReport(options: MarkdownReportOptions): string {
+    const {
+        data,
+        bruttoMatrix,
+        nettoMatrix,
+        date = new Date().toISOString().split("T")[0]!,
+        tillScheduledAt,
+        showCoverPage = true,
+        showTableOfContentsPage = true,
+        showMethodExplanation = true,
+        showScaleExplanation = true,
+        showMatrixPage = true,
+        showAssetsPage = true,
+        showMeasuresPage = true,
+        showThreatListPage = true,
+        showThreatsPage = true,
+        systemImageOnSeperatePage = false,
+    } = options;
+
+    const hasSystemImage = Boolean(data.systemImage);
+
+    // Build chapter list for table of contents
+    const chapters: { label: string; id: string }[] = [];
+    if (showMethodExplanation) chapters.push({ label: T.method, id: "chapter-methodExplanation" });
+    if (showScaleExplanation) chapters.push({ label: T.explanationScale, id: "chapter-explanationScale" });
+    if (systemImageOnSeperatePage && hasSystemImage) chapters.push({ label: T.systemImage, id: "chapter-systemImage" });
+    if (showMatrixPage) chapters.push({ label: T.riskMatrices, id: "chapter-matrix" });
+    if (showAssetsPage) chapters.push({ label: T.assets, id: "chapter-assetsDetails" });
+    if (showMeasuresPage) chapters.push({ label: T.measures, id: "chapter-measuresDetails" });
+    if (showThreatListPage) chapters.push({ label: T.riskList, id: "chapter-riskList" });
+    if (showThreatsPage) chapters.push({ label: T.threats, id: "chapter-riskDetails" });
+
+    const sections: string[] = [];
+
+    if (showCoverPage) {
+        sections.push(coverSection(data, date, systemImageOnSeperatePage));
+    }
+
+    if (showTableOfContentsPage && chapters.length > 0) {
+        sections.push(tableOfContentsSection(chapters));
+    }
+
+    if (showMethodExplanation) {
+        sections.push(methodExplanationSection());
+    }
+
+    if (showScaleExplanation) {
+        sections.push(scaleExplanationSection());
+    }
+
+    if (systemImageOnSeperatePage && data.systemImage) {
+        sections.push(systemImageSection(data.systemImage));
+    }
+
+    if (showMatrixPage) {
+        sections.push(matrixSection(bruttoMatrix, nettoMatrix, tillScheduledAt, data.milestones));
+    }
+
+    if (showAssetsPage && data.assets.length > 0) {
+        sections.push(assetsSection(data.assets));
+    }
+
+    if (showMeasuresPage && data.measures.length > 0) {
+        sections.push(measuresSection(data.measures as ReportMeasure[]));
+    }
+
+    if (showThreatListPage && data.threats.length > 0) {
+        sections.push(threatsListSection(data.threats));
+    }
+
+    if (showThreatsPage && data.threats.length > 0) {
+        sections.push(threatsDetailSection(data.threats));
+    }
+
+    return sections.join(`\n${hr()}\n`);
+}

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -182,7 +182,7 @@ function escapeCell(s: string): string {
  * allow an attacker-controlled URL to follow, on top of stripping line breaks.
  */
 function escapeLinkText(s: string): string {
-    return escapeInline(s).replace(/\]/g, "\\]");
+    return escapeInline(s).replace(/\\/g, "\\\\").replace(/\]/g, "\\]");
 }
 
 /**

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -80,6 +80,8 @@ interface Translations {
     probabilities: { name: string; description: string }[];
     cellNames: Record<string, Record<string, string>>;
     damages: { name: string; description: string }[];
+    matrixLegend: string;
+    matrixAxisLegend: string;
 }
 
 function buildTranslations(language: string): Translations {
@@ -142,12 +144,14 @@ function buildTranslations(language: string): Translations {
             { name: string; description: string }
         >,
         probabilities: Object.values(
-            t("probabilities", { returnObjects: true }) as Record<string, { name: string; description: string }>
+            t("probabilities", { returnObjects: true }) as Record<string, { name: string; description: string }>,
         ),
         cellNames,
         damages: Object.values(
-            t("damages", { returnObjects: true }) as Record<string, { name: string; description: string }>
+            t("damages", { returnObjects: true }) as Record<string, { name: string; description: string }>,
         ),
+        matrixLegend: t("matrixLegend"),
+        matrixAxisLegend: t("matrixAxisLegend"),
     };
 }
 
@@ -249,7 +253,7 @@ function measureAnchorId(reportId: string): string {
     return `measure-${reportId}`;
 }
 
-function renderMatrix(matrix: RiskMatrix, title: string): string {
+function renderMatrix(T: Translations, matrix: RiskMatrix, title: string): string {
     const lines: string[] = [];
     lines.push(`**${title}**\n`);
 
@@ -276,9 +280,8 @@ function renderMatrix(matrix: RiskMatrix, title: string): string {
     }
 
     lines.push("");
-    lines.push(
-        "*G = green (low risk), Y = yellow (medium risk), R = red (high risk). Count shown when threats present.*"
-    );
+    lines.push(`*${T.matrixAxisLegend}*`);
+    lines.push(`*${T.matrixLegend}*`);
     return lines.join("\n");
 }
 
@@ -422,7 +425,7 @@ function matrixSection(
     bruttoMatrix: RiskMatrix | null | undefined,
     nettoMatrix: RiskMatrix | null | undefined,
     tillScheduledAt: string | null | undefined,
-    milestones: Milestone[] | null | undefined
+    milestones: Milestone[] | null | undefined,
 ): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-matrix")}${T.riskMatrices}`);
@@ -435,11 +438,11 @@ function matrixSection(
     }
 
     if (bruttoMatrix) {
-        lines.push(renderMatrix(bruttoMatrix, T.before));
+        lines.push(renderMatrix(T, bruttoMatrix, T.before));
         lines.push("");
     }
     if (nettoMatrix) {
-        lines.push(renderMatrix(nettoMatrix, T.after));
+        lines.push(renderMatrix(T, nettoMatrix, T.after));
         lines.push("");
     }
 
@@ -448,7 +451,7 @@ function matrixSection(
         activeMilestones.forEach((milestone) => {
             if (milestone.matrix) {
                 const title = milestone.scheduledAt.toISOString().split("T")[0];
-                lines.push(renderMatrix(milestone.matrix, title ?? ""));
+                lines.push(renderMatrix(T, milestone.matrix, title ?? ""));
                 lines.push("");
             }
         });
@@ -471,7 +474,7 @@ function assetsSection(T: Translations, assets: AssetWithReportId[]): string {
         lines.push(`| ${T.confidentiality} | ${T.integrity} | ${T.availability} |`);
         lines.push(`|---|---|---|`);
         lines.push(
-            `| ${escapeCell(String(asset.confidentiality))} | ${escapeCell(String(asset.integrity))} | ${escapeCell(String(asset.availability))} |`
+            `| ${escapeCell(String(asset.confidentiality))} | ${escapeCell(String(asset.integrity))} | ${escapeCell(String(asset.availability))} |`,
         );
         lines.push("");
 
@@ -595,10 +598,10 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
         lines.push(`| | ${T.probability} | ${T.damage} | ${T.risk} |`);
         lines.push(`|---|---|---|---|`);
         lines.push(
-            `| ${T.gross} | ${escapeCell(String(threat.probability))} | ${escapeCell(String(threat.damage))} | ${escapeCell(String(threat.risk))} |`
+            `| ${T.gross} | ${escapeCell(String(threat.probability))} | ${escapeCell(String(threat.damage))} | ${escapeCell(String(threat.risk))} |`,
         );
         lines.push(
-            `| ${T.net} | ${escapeCell(String(threat.netProbability))} | ${escapeCell(String(threat.netDamage))} | ${escapeCell(String(threat.netRisk))} |`
+            `| ${T.net} | ${escapeCell(String(threat.netProbability))} | ${escapeCell(String(threat.netDamage))} | ${escapeCell(String(threat.netRisk))} |`,
         );
         lines.push("");
 

--- a/apps/frontend/src/view/report/testData/expected-report.de.md
+++ b/apps/frontend/src/view/report/testData/expected-report.de.md
@@ -1,0 +1,254 @@
+# Sample Project
+
+Cyber Security | MaibornWolff
+
+ThreatSea by MaibornWolff
+
+**2025-01-15**
+
+*intern*
+
+This is the project description.
+
+It spans multiple paragraphs.  
+With line breaks.
+
+---
+
+## Inhaltsverzeichnis
+
+1. [Die 4x6 Methodik](#chapter-methodExplanation)
+2. [Erklärung der Wahrscheinlichkeits- und Schadensskala](#chapter-explanationScale)
+3. [Risiko Matrizen](#chapter-matrix)
+4. [Assets](#chapter-assetsDetails)
+5. [Maßnahmen](#chapter-measuresDetails)
+6. [Auflistung der Bedrohungen](#chapter-riskList)
+7. [Bedrohungen](#chapter-riskDetails)
+
+---
+
+## <a id="chapter-methodExplanation"></a>Die 4x6 Methodik
+
+Die 4x6 Methodik basiert auf einer Matrix, die für jedes IT-System, das auf sechs Klassen von Angriffspunkten abstrahiert wird, für die vier Klassen von Angreifern jede erdenkliche Bedrohung wiedergibt.
+
+| | Dritte | Systembenutzer | Anwendungsbenutzer | (Technische) Administratoren |
+|---|---|---|---|---|
+| Benutzerschnittstelle | Physischer Oberflächenzugriff |  | Schädliche Oberflächennutzung |  |
+| Ausführungsinfrastruktur | Physischer Angriff auf die Ausführung | Übergriff in der Ausführung |  | Privilegienmissbrauch in der Ausführung |
+| Datenablagestruktur | Physischer Speichermedien-Zugriff | Übergriff auf Speichermedien |  | Privilegienmissbrauch auf Speichermedien |
+| Kommunikationsinfrastruktur | Physischer Angriff auf die Übertragung | Übergriff in der Übertragung |  | Privilegienmissbrauch in der Übertragung |
+| Kommunikationsschnittstelle | Physischer Angriff auf Schnittstellen | Übergriff über Schnittstellenzugriff | Schädliche Schnittstellennutzung |  |
+| Benutzerverhalten | Täuschung |  |  |  |
+
+**Angreifer:**
+
+- **Dritte:** Einheiten, die keinerlei Bezug zu und insbesondere keine Rechte auf dem betrachteten System haben
+- **Systembenutzer:** Benutzer, die von der betrachteten Anwendung genutzte Ressourcen berechtigterweise mitbenutzen, ohne auf der Anwendung selbst Rechte zu haben
+- **Anwendungsbenutzer:** Benutzer, die berechtigt mit der betrachteten Anwendung arbeiten
+- **(Technische) Administratoren:** Benutzer, die der Anwendung zugrundeliegende Infrastrukturen mit entsprechenden erweiterten Berechtigungen verwalten
+
+**Angriffspunkte:**
+
+- **Benutzerschnittstelle:** Orte und Programme, an und mit denen Benutzer mit dem System interagieren, meist per Bildschirm und Eingabegerät, z.B. Browser am PC
+- **Ausführungsinfrastruktur:** Orte der Programmausführung - im Prinzip alles, was einen Prozessor und keine absolut unveränderliche Programmierung hat, z.B. auch Datenbankserver, wo die Abfragen verarbeitet werden
+- **Datenablagestruktur:** Orte, wo Daten physisch dauerhaft abgelegt werden - Festplatten, persistente Halbleiterspeicher, etc.
+- **Kommunikationsinfrastruktur:** Orte der Programmausführung - im Prinzip alles, was einen Prozessor und keine absolut unveränderliche Programmierung hat, z.B. auch Datenbankserver, wo die Abfragen verarbeitet werden
+- **Kommunikationsschnittstelle:** Anschlüsse an die Kommunikationsverbindungen auf allen OSI-Schichten: Netzschnittstellen, Funkantennen, TCP-Ports, APIs ...
+- **Benutzerverhalten:** Das Verhalten eines Benutzers (Menschen)
+
+Die Matrix ist zunächst unabhängig von konkreten Angriffstechniken oder Angriffszielen. Im Laufe einer Bedrohungsanalyse wird diese abstrahierte Matrix auf eine konkrete Systemarchitektur, die gemäß der obigen Vorgabe abstrahiert wurde, angewendet. Daraus werden unmittelbar konkrete Angriffsszenarien in einer überschaubaren, aber dennoch vollständigen Sicht entwickelt.
+
+---
+
+## <a id="chapter-explanationScale"></a>Erklärung der Wahrscheinlichkeits- und Schadensskala
+
+**Wahrscheinlichkeit**
+
+**1 – extrem unwahrscheinlich**
+
+Die Bedrohung ist nur Angreifern auf dem Niveau eines Geheimdienstes zugänglich oder es müssen zahlreiche oder extrem unwahrscheinliche Ereignisse, die nicht vom Angreifer kontrolliert werden können, zusammentreffen.
+
+**2 – eher unwahrscheinlich**
+
+Nur Angreifern mit viel Zeit und/oder Geld können die Bedrohung realisieren oder es müssen nicht vom Angreifer kontrollierbare, unwahrscheinliche Ereignisse eintreten.
+
+**3 – möglich**
+
+Die Bedrohung kann nur von ernsthaften Angreifern mit erheblicher krimineller Energie und fundierten Kenntnissen realisiert werden.
+
+**4 – wahrscheinlich**
+
+Außer Absicht benötigt ein Angreifer höchsten Kenntnisse, die er sich über eine Internet-Recherche leicht aneignen kann (Niveau "Script Kiddies").
+
+**5 – nahezu sicher**
+
+Die Bedrohung kann bereits unbeabsichtigt (z.B. bei der regulären Tätigkeit eines gutwilligen Benutzers) eintreten.
+
+**Schaden**
+
+**1 – sehr geringfügig**
+
+
+
+**2 – bemerkbar**
+
+Kann leicht kompensiert werden (z.B. innerhalb der Organisation ohne ein dediziertes Projekt, ohne nennenswerte Einschränkungen bei anderen Aktivitäten, mit begrenztem finanziellen Aufwand, ...)
+
+**3 – deutlich spürbar**
+
+Kann nur mit Aufwand kompensiert werden (z.B. durch Verschiebung anderer Projekte, mit erheblichen finanziellen Mitteln oder Zeitaufwand, ...)
+
+**4 – bedrohlich**
+
+Für die Marktposition des Unternehmens
+
+**5 – existenzbedrohend**
+
+Für die Existenz des Unternehmens
+
+
+---
+
+## <a id="chapter-matrix"></a>Risiko Matrizen
+
+
+---
+
+## <a id="chapter-assetsDetails"></a>Assets
+
+### <a id="asset-A-01"></a>A-01 Customer Database
+
+*ID: 1*
+
+| Vertraulichkeit | Integrität | Verfügbarkeit |
+|---|---|---|
+| 4 | 3 | 2 |
+
+**Beschreibung:**
+
+Stores all customer PII data.
+
+**Begründung für Vertraulichkeit:**
+
+Contains names, addresses and payment data.
+
+**Begründung für Integrität:**
+
+Data must be accurate for billing.
+
+**Begründung für Verfügbarkeit:**
+
+Required during business hours.
+
+### <a id="asset-A-02"></a>A-02 Authentication Service
+
+*ID: 2*
+
+| Vertraulichkeit | Integrität | Verfügbarkeit |
+|---|---|---|
+| 5 | 5 | 4 |
+
+**Beschreibung:**
+
+Manages user sessions and tokens.
+
+**Begründung für Vertraulichkeit:**
+
+Holds credentials and session secrets.
+
+**Begründung für Integrität:**
+
+Tampered tokens grant unauthorised access.
+
+**Begründung für Verfügbarkeit:**
+
+Login must always be reachable.
+
+
+---
+
+## <a id="chapter-measuresDetails"></a>Maßnahmen
+
+### <a id="measure-M-01"></a>M-01 Input Validation
+
+*ID: 1*
+
+*2024-06-01*
+
+**Beschreibung:**
+
+Use parameterised queries and input sanitisation to prevent injection attacks.
+
+**Bedrohungen:**
+
+- [1 SQL Injection](#threat-T-01)
+
+
+---
+
+## <a id="chapter-riskList"></a>Auflistung der Bedrohungen
+
+| ID | Name | Komponente |
+|----|---------|-----------|
+| 1 | [SQL Injection](#threat-T-01) | Database Server |
+| 2 | [Brute Force Login](#threat-T-02) | Login Form |
+
+
+---
+
+## <a id="chapter-riskDetails"></a>Bedrohungen
+
+### <a id="threat-T-01"></a>T-01 SQL Injection
+
+*ID: 1*
+
+*Vertraulichkeit, Integrität*
+
+| | Wahrscheinlichkeit | Schaden | Risiko |
+|---|---|---|---|
+| brutto | 3 | 4 | 12 |
+| netto | 2 | 4 | 8 |
+
+**Komponente:** Database Server
+
+**Angreifer:** Dritte
+
+**Angriffspunkte:** Datenablagestruktur
+
+**Beschreibung:**
+
+An attacker injects SQL commands via unvalidated input.  
+This can lead to data exfiltration or destruction.
+
+**Assets:**
+
+- [A-01 Customer Database](#asset-A-01)
+
+**Maßnahmen:**
+
+- [M-01 Input Validation](#measure-M-01)<br>*Parameterised queries have been added to all database calls.*
+
+### <a id="threat-T-02"></a>T-02 Brute Force Login
+
+*ID: 2*
+
+*Vertraulichkeit*
+
+| | Wahrscheinlichkeit | Schaden | Risiko |
+|---|---|---|---|
+| brutto | 4 | 3 | 12 |
+| netto | 2 | 3 | 6 |
+
+**Komponente:** Login Form
+
+**Angreifer:** Dritte
+
+**Angriffspunkte:** Benutzerschnittstelle
+
+**Beschreibung:**
+
+Repeated login attempts to guess credentials.
+
+**Assets:**
+
+- [A-02 Authentication Service](#asset-A-02)

--- a/apps/frontend/src/view/report/testData/expected-report.de.md
+++ b/apps/frontend/src/view/report/testData/expected-report.de.md
@@ -52,7 +52,7 @@ Die 4x6 Methodik basiert auf einer Matrix, die für jedes IT-System, das auf sec
 - **Benutzerschnittstelle:** Orte und Programme, an und mit denen Benutzer mit dem System interagieren, meist per Bildschirm und Eingabegerät, z.B. Browser am PC
 - **Ausführungsinfrastruktur:** Orte der Programmausführung - im Prinzip alles, was einen Prozessor und keine absolut unveränderliche Programmierung hat, z.B. auch Datenbankserver, wo die Abfragen verarbeitet werden
 - **Datenablagestruktur:** Orte, wo Daten physisch dauerhaft abgelegt werden - Festplatten, persistente Halbleiterspeicher, etc.
-- **Kommunikationsinfrastruktur:** Orte der Programmausführung - im Prinzip alles, was einen Prozessor und keine absolut unveränderliche Programmierung hat, z.B. auch Datenbankserver, wo die Abfragen verarbeitet werden
+- **Kommunikationsinfrastruktur:** Physische Übertragung von Daten über Kabel oder Funk
 - **Kommunikationsschnittstelle:** Anschlüsse an die Kommunikationsverbindungen auf allen OSI-Schichten: Netzschnittstellen, Funkantennen, TCP-Ports, APIs ...
 - **Benutzerverhalten:** Das Verhalten eines Benutzers (Menschen)
 

--- a/apps/frontend/src/view/report/testData/expected-report.en.md
+++ b/apps/frontend/src/view/report/testData/expected-report.en.md
@@ -1,0 +1,254 @@
+# Sample Project
+
+Cyber Security | MaibornWolff
+
+ThreatSea by MaibornWolff
+
+**2025-01-15**
+
+*internal*
+
+This is the project description.
+
+It spans multiple paragraphs.  
+With line breaks.
+
+---
+
+## Table of Contents
+
+1. [The 4x6 Methodology](#chapter-methodExplanation)
+2. [Explanation of Probability and Damage Scale](#chapter-explanationScale)
+3. [Risk Matrices](#chapter-matrix)
+4. [Assets](#chapter-assetsDetails)
+5. [Measures](#chapter-measuresDetails)
+6. [List of Threats](#chapter-riskList)
+7. [Threats](#chapter-riskDetails)
+
+---
+
+## <a id="chapter-methodExplanation"></a>The 4x6 Methodology
+
+The 4x6 methodology is based on a matrix that specifies every conceivable threat from the four classes of attackers for any IT system abstracted to six classes of attack points.
+
+| | Unauthorised Parties | System Users | Application Users | (Technical) Administrators |
+|---|---|---|---|---|
+| User Interface | Physical UI access |  | Detrimental UI usage |  |
+| Processing Infrastructure | Physical attack on processing | Internal breach during processing |  | Privilege abuse on processing |
+| Data Storage Infrastructure | Physical data storage access | Internal breach on data storage |  | Privilege abuse on data storage |
+| Communication Infrastructure | Physical attack on transmission | Internal breach on transmission |  | Privilege abuse on transmission |
+| Communication Interfaces | Physical interface attack | Breach via interface access | Detrimental interface usage |  |
+| User Behaviour | Deception |  |  |  |
+
+**Attackers:**
+
+- **Unauthorised Parties:** Entities with no tie to and especially no authorisation on the system under consideration
+- **System Users:** Users being authorised to share use of resources with the application under consideration but not having authorisation on the application itself
+- **Application Users:** Users being authorised to work with the application under consideration
+- **(Technical) Administrators:** Users with elevated privileges who manage the infrastructure used by the application
+
+**Points Of Attack:**
+
+- **User Interface:** the places and programms, where and by which users interact with the system, usually via screen and input device, e.g. a browser on a PC
+- **Processing Infrastructure:** places of program execution - in principle everything which has a processor and its programming is not absolutely fixed, e.g. including database servers, where queries are processed
+- **Data Storage Infrastructure:** places where data is stored durably - hard disks, non-volatile semiconductor memory, ...
+- **Communication Infrastructure:** physical transport of data via cable or wireless
+- **Communication Interfaces:** the connection to the means of communication on all OSI layers: network interfaces, wireless antenna, TCP Ports, APIs, ...
+- **User Behaviour:** The behaviour of an user (human)
+
+The matrix is initially independent of specific attack techniques or attack targets. In the course of a threat analysis, this abstracted matrix is applied to a specific system architecture that was abstracted according to the above specification. From this, concrete attack scenarios are immediately developed in a manageable but nevertheless complete view.
+
+---
+
+## <a id="chapter-explanationScale"></a>Explanation of Probability and Damage Scale
+
+**Probability**
+
+**1 – extremely unlikely**
+
+Only attackers on the level of state secret services can realise the attack or several highly unlikely events not under control of the attacker have to occur together.
+
+**2 – rather unlikely**
+
+Only attackers with much time and/or money can realise the threat or unlikely events not under control of the attacker need to occur.
+
+**3 – possible**
+
+The threat can only be realised by serious attackers with considerable criminal energy and in-depth knowledge.
+
+**4 – probable**
+
+An attacker needs only intent, but no more knowledge than what can be derived from internet research (alike "script kiddies").
+
+**5 – almost certain**
+
+The threat can occur unintentionally, e.g. during regular usage by a non-malicious user.
+
+**Damage**
+
+**1 – very neglectable**
+
+
+
+**2 – noticeable**
+
+Can easily be compensated (e.g. within the organisation not using a dedicated project, without noteworthy cutback in other activities, with limited financial effort, ...).
+
+**3 – quite noticeable**
+
+Can only be compensated with effort (e.g. by postponing other projects, with considerable financial resources or expenditure of time, ...)
+
+**4 – threatening**
+
+For the market position of the company
+
+**5 – very threatening**
+
+For the existence of the company
+
+
+---
+
+## <a id="chapter-matrix"></a>Risk Matrices
+
+
+---
+
+## <a id="chapter-assetsDetails"></a>Assets
+
+### <a id="asset-A-01"></a>A-01 Customer Database
+
+*ID: 1*
+
+| Confidentiality | Integrity | Availability |
+|---|---|---|
+| 4 | 3 | 2 |
+
+**Description:**
+
+Stores all customer PII data.
+
+**Justification for Confidentiality:**
+
+Contains names, addresses and payment data.
+
+**Justification for Integrity:**
+
+Data must be accurate for billing.
+
+**Justification for Availability:**
+
+Required during business hours.
+
+### <a id="asset-A-02"></a>A-02 Authentication Service
+
+*ID: 2*
+
+| Confidentiality | Integrity | Availability |
+|---|---|---|
+| 5 | 5 | 4 |
+
+**Description:**
+
+Manages user sessions and tokens.
+
+**Justification for Confidentiality:**
+
+Holds credentials and session secrets.
+
+**Justification for Integrity:**
+
+Tampered tokens grant unauthorised access.
+
+**Justification for Availability:**
+
+Login must always be reachable.
+
+
+---
+
+## <a id="chapter-measuresDetails"></a>Measures
+
+### <a id="measure-M-01"></a>M-01 Input Validation
+
+*ID: 1*
+
+*2024-06-01*
+
+**Description:**
+
+Use parameterised queries and input sanitisation to prevent injection attacks.
+
+**Threats:**
+
+- [1 SQL Injection](#threat-T-01)
+
+
+---
+
+## <a id="chapter-riskList"></a>List of Threats
+
+| ID | Name | Component |
+|----|---------|-----------|
+| 1 | [SQL Injection](#threat-T-01) | Database Server |
+| 2 | [Brute Force Login](#threat-T-02) | Login Form |
+
+
+---
+
+## <a id="chapter-riskDetails"></a>Threats
+
+### <a id="threat-T-01"></a>T-01 SQL Injection
+
+*ID: 1*
+
+*Confidentiality, Integrity*
+
+| | Probability | Damage | Risk |
+|---|---|---|---|
+| gross | 3 | 4 | 12 |
+| net | 2 | 4 | 8 |
+
+**Component:** Database Server
+
+**Attackers:** Unauthorised Parties
+
+**Points Of Attack:** Data Storage Infrastructure
+
+**Description:**
+
+An attacker injects SQL commands via unvalidated input.  
+This can lead to data exfiltration or destruction.
+
+**Assets:**
+
+- [A-01 Customer Database](#asset-A-01)
+
+**Measures:**
+
+- [M-01 Input Validation](#measure-M-01)<br>*Parameterised queries have been added to all database calls.*
+
+### <a id="threat-T-02"></a>T-02 Brute Force Login
+
+*ID: 2*
+
+*Confidentiality*
+
+| | Probability | Damage | Risk |
+|---|---|---|---|
+| gross | 4 | 3 | 12 |
+| net | 2 | 3 | 6 |
+
+**Component:** Login Form
+
+**Attackers:** Unauthorised Parties
+
+**Points Of Attack:** User Interface
+
+**Description:**
+
+Repeated login attempts to guess credentials.
+
+**Assets:**
+
+- [A-02 Authentication Service](#asset-A-02)

--- a/apps/frontend/src/view/report/testData/project-report.fixture.json
+++ b/apps/frontend/src/view/report/testData/project-report.fixture.json
@@ -1,0 +1,165 @@
+{
+    "systemImage": null,
+    "milestones": null,
+    "project": {
+        "id": 1,
+        "catalogId": 1,
+        "name": "Sample Project",
+        "description": "This is the project description.\n\nIt spans multiple paragraphs.\nWith line breaks.",
+        "confidentialityLevel": "INTERNAL",
+        "lineOfToleranceGreen": 6,
+        "lineOfToleranceRed": 12,
+        "createdAt": "2024-01-01T00:00:00.000Z",
+        "updatedAt": "2024-01-15T00:00:00.000Z"
+    },
+    "assets": [
+        {
+            "id": 1,
+            "name": "Customer Database",
+            "description": "Stores all customer PII data.",
+            "confidentiality": 4,
+            "integrity": 3,
+            "availability": 2,
+            "confidentialityJustification": "Contains names, addresses and payment data.",
+            "integrityJustification": "Data must be accurate for billing.",
+            "availabilityJustification": "Required during business hours.",
+            "projectId": 1,
+            "reportId": "A-01",
+            "createdAt": "2024-01-01T00:00:00.000Z",
+            "updatedAt": "2024-01-01T00:00:00.000Z"
+        },
+        {
+            "id": 2,
+            "name": "Authentication Service",
+            "description": "Manages user sessions and tokens.",
+            "confidentiality": 5,
+            "integrity": 5,
+            "availability": 4,
+            "confidentialityJustification": "Holds credentials and session secrets.",
+            "integrityJustification": "Tampered tokens grant unauthorised access.",
+            "availabilityJustification": "Login must always be reachable.",
+            "projectId": 1,
+            "reportId": "A-02",
+            "createdAt": "2024-01-01T00:00:00.000Z",
+            "updatedAt": "2024-01-01T00:00:00.000Z"
+        }
+    ],
+    "threats": [
+        {
+            "id": 1,
+            "pointOfAttackId": "poa-1",
+            "catalogThreatId": 1,
+            "name": "SQL Injection",
+            "description": "An attacker injects SQL commands via unvalidated input.\nThis can lead to data exfiltration or destruction.",
+            "pointOfAttack": "DATA_STORAGE_INFRASTRUCTURE",
+            "attacker": "UNAUTHORISED_PARTIES",
+            "probability": 3,
+            "confidentiality": true,
+            "integrity": true,
+            "availability": false,
+            "doneEditing": true,
+            "projectId": 1,
+            "componentName": "Database Server",
+            "componentType": null,
+            "interfaceName": null,
+            "damage": 4,
+            "risk": 12,
+            "netProbability": 2,
+            "netDamage": 4,
+            "netRisk": 8,
+            "reportId": "T-01",
+            "bruttoColor": "red",
+            "nettoColor": "yellow",
+            "assets": [
+                { "id": 1, "name": "Customer Database", "reportId": "A-01" }
+            ],
+            "measures": [
+                {
+                    "id": 1,
+                    "measureId": 1,
+                    "threatId": 1,
+                    "description": "Parameterised queries have been added to all database calls.",
+                    "setsOutOfScope": false,
+                    "impactsProbability": true,
+                    "impactsDamage": false,
+                    "probability": 2,
+                    "damage": null,
+                    "projectId": 1,
+                    "reportId": "M-01",
+                    "name": "Input Validation",
+                    "scheduledAt": "2024-06-01T00:00:00.000Z",
+                    "createdAt": "2024-01-01T00:00:00.000Z",
+                    "updatedAt": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "createdAt": "2024-01-01T00:00:00.000Z",
+            "updatedAt": "2024-01-01T00:00:00.000Z"
+        },
+        {
+            "id": 2,
+            "pointOfAttackId": "poa-2",
+            "catalogThreatId": 2,
+            "name": "Brute Force Login",
+            "description": "Repeated login attempts to guess credentials.",
+            "pointOfAttack": "USER_INTERFACE",
+            "attacker": "UNAUTHORISED_PARTIES",
+            "probability": 4,
+            "confidentiality": true,
+            "integrity": false,
+            "availability": false,
+            "doneEditing": true,
+            "projectId": 1,
+            "componentName": "Login Form",
+            "componentType": null,
+            "interfaceName": null,
+            "damage": 3,
+            "risk": 12,
+            "netProbability": 2,
+            "netDamage": 3,
+            "netRisk": 6,
+            "reportId": "T-02",
+            "bruttoColor": "red",
+            "nettoColor": "green",
+            "assets": [
+                { "id": 2, "name": "Authentication Service", "reportId": "A-02" }
+            ],
+            "measures": [],
+            "createdAt": "2024-01-01T00:00:00.000Z",
+            "updatedAt": "2024-01-01T00:00:00.000Z"
+        }
+    ],
+    "measures": [
+        {
+            "id": 1,
+            "name": "Input Validation",
+            "description": "Use parameterised queries and input sanitisation to prevent injection attacks.",
+            "scheduledAt": "2024-06-01T00:00:00.000Z",
+            "projectId": 1,
+            "catalogMeasureId": null,
+            "reportId": "M-01",
+            "threats": [
+                { "id": 1, "reportId": "T-01", "name": "SQL Injection" }
+            ],
+            "createdAt": "2024-01-01T00:00:00.000Z",
+            "updatedAt": "2024-01-01T00:00:00.000Z"
+        }
+    ],
+    "measureImpacts": [
+        {
+            "id": 1,
+            "measureId": 1,
+            "threatId": 1,
+            "description": "Parameterised queries have been added to all database calls.",
+            "setsOutOfScope": false,
+            "impactsProbability": true,
+            "impactsDamage": false,
+            "probability": 2,
+            "damage": null,
+            "projectId": 1,
+            "measureReportId": "M-01",
+            "threatReportId": "T-01",
+            "createdAt": "2024-01-01T00:00:00.000Z",
+            "updatedAt": "2024-01-01T00:00:00.000Z"
+        }
+    ]
+}


### PR DESCRIPTION
Add option to download report as markdown file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added markdown download capability for reports alongside existing PDF export.
  * Added risk matrix legend and axis explanations to reports.

* **Documentation**
  * Updated German translations for report buttons with more specific labeling (PDF-Report, Markdown).
  * Updated English translations for report buttons with clarified labels (Download PDF, Download Markdown).
  * Added German and English translations for risk matrix legends and axis descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MaibornWolff/ThreatSea/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->