### PR TITLE
  feat(ui): apply measures from edit threat dialog

### DIFF
--- a/apps/frontend/src/application/hooks/use-matrix.hook.ts
+++ b/apps/frontend/src/application/hooks/use-matrix.hook.ts
@@ -10,6 +10,7 @@ import { useAppSelector } from "./use-app-redux.hook.ts";
 import { projectsSelectors } from "#application/selectors/projects.selectors.ts";
 import type { SortDirection } from "#application/actions/list.actions.ts";
 import type { MatrixColorKey } from "#view/colors/matrix.ts";
+import { calcDamage } from "#utils/helpers.ts";
 
 export interface ThreatMeasure {
     measureId: number;
@@ -93,25 +94,12 @@ export const useMatrix = ({ projectId, catalogId }: UseMatrixArgs) => {
         () =>
             threatsRaw
                 .map((item) => {
-                    const { confidentiality, integrity, availability, probability, assets } = item;
-                    const damage = assets.reduce((value, asset) => {
-                        if (confidentiality && value < asset.confidentiality) {
-                            value = asset.confidentiality;
-                        }
-                        if (integrity && value < asset.integrity) {
-                            value = asset.integrity;
-                        }
-                        if (availability && value < asset.availability) {
-                            value = asset.availability;
-                        }
-                        return value;
-                    }, 0); // default 0 if no protection goal is affected
-                    const risk = probability * damage;
+                    const damage = calcDamage(item);
+                    const risk = item.probability * damage;
                     return {
                         ...item,
                         risk,
                         damage,
-                        assets,
                     };
                 })
                 .map((threat) => {

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -1,5 +1,6 @@
 import type { Asset } from "#api/types/asset.types.ts";
 import type { ExtendedProject } from "#api/types/project.types.ts";
+import type { ExtendedThreat } from "#api/types/threat.types.ts";
 import {
     AnchorOrientation,
     type Annotation,
@@ -10,6 +11,7 @@ import {
     type SystemPointOfAttack,
 } from "#api/types/system.types.ts";
 import type { SystemConnectionPoint } from "#application/adapters/system-connection-point.adapter.ts";
+import { ATTACKERS } from "#api/types/attackers.types.ts";
 import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
 import { USER_ROLES } from "#api/types/user-roles.types.ts";
@@ -28,6 +30,29 @@ export const createAsset = (overrides: Partial<Asset> = {}): Asset => ({
     projectId: 1,
     createdAt: new Date("2025-01-01"),
     updatedAt: new Date("2025-01-01"),
+    ...overrides,
+});
+
+export const createThreat = (overrides: Partial<ExtendedThreat> = {}): ExtendedThreat => ({
+    id: 1,
+    pointOfAttackId: "poa-1",
+    catalogThreatId: 1,
+    name: "Test Threat",
+    description: "",
+    pointOfAttack: POINTS_OF_ATTACK.USER_INTERFACE,
+    attacker: ATTACKERS.UNAUTHORISED_PARTIES,
+    probability: 3,
+    confidentiality: true,
+    integrity: false,
+    availability: false,
+    doneEditing: false,
+    projectId: 1,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    componentName: "Test Component",
+    componentType: null,
+    interfaceName: null,
+    assets: [],
     ...overrides,
 });
 

--- a/apps/frontend/src/test-utils/mock-hooks.ts
+++ b/apps/frontend/src/test-utils/mock-hooks.ts
@@ -4,6 +4,7 @@ import * as confirmHook from "#application/hooks/use-confirm.hook.ts";
 import * as alertHook from "#application/hooks/use-alert.hook.ts";
 import * as editorHook from "#application/hooks/use-editor.hook.ts";
 import * as assetsHook from "#application/hooks/use-assets.hook.ts";
+import * as threatMeasuresListHook from "#application/hooks/use-threat-measures-list.hook.ts";
 
 /**
  * @module mock-hooks - Reusable hook spies.
@@ -23,6 +24,7 @@ type UseConfirmResult = ReturnType<typeof confirmHook.useConfirm>;
 type UseAlertResult = ReturnType<typeof alertHook.useAlert>;
 type UseEditorResult = ReturnType<typeof editorHook.useEditor>;
 type UseAssetsResult = ReturnType<typeof assetsHook.useAssets>;
+type UseThreatMeasuresListResult = ReturnType<typeof threatMeasuresListHook.useThreatMeasuresList>;
 
 export const mockUseDialog = (config?: Partial<UseDialogResult>): MockInstance => {
     return vi.spyOn(dialogHook, "useDialog").mockImplementation(() => ({
@@ -148,6 +150,20 @@ export const mockUseAssets = (config?: Partial<UseAssetsResult>): MockInstance =
         isPending: false,
         loadAssets: vi.fn(),
         deleteAsset: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseThreatMeasuresList = (config?: Partial<UseThreatMeasuresListResult>): MockInstance => {
+    return vi.spyOn(threatMeasuresListHook, "useThreatMeasuresList").mockImplementation(() => ({
+        threatMeasures: [],
+        sortBy: "measureName",
+        sortDirection: "asc",
+        searchValue: "",
+        setSortBy: vi.fn(),
+        setSortDirection: vi.fn(),
+        setSearchValue: vi.fn(),
+        deleteMeasureImpact: vi.fn(),
         ...config,
     }));
 };

--- a/apps/frontend/src/translations/de/threat-dialog-page.de.json
+++ b/apps/frontend/src/translations/de/threat-dialog-page.de.json
@@ -1,4 +1,5 @@
 {
+  "applyMeasure": "Maßnahme anwenden",
   "measureThreatDeleteMessage": "Sind Sie sicher, dass Sie die Maßnahme '{{measureName}}' nicht länger auf die Bedrohung '{{threatName}}' anwenden möchten?",
   "noThreatsFound": "Noch auf keine Bedrohung angewendet",
   "setsOutOfScope": "Out of Scope gesetzt",

--- a/apps/frontend/src/translations/en/threat-dialog-page.en.json
+++ b/apps/frontend/src/translations/en/threat-dialog-page.en.json
@@ -1,4 +1,5 @@
 {
+  "applyMeasure": "Apply Measure",
   "measureThreatDeleteMessage": "Do you really want to no longer apply the measure '{{measureName}}' to the threat '{{threatName}}'?",
   "noThreatsFound": "Not applied to any threat",
   "setsOutOfScope": "Set out of Scope by measure",

--- a/apps/frontend/src/utils/helpers.test.ts
+++ b/apps/frontend/src/utils/helpers.test.ts
@@ -1,0 +1,52 @@
+import { calcDamage } from "./helpers";
+
+describe("calcDamage", () => {
+    const assets = [
+        { confidentiality: 1, integrity: 4, availability: 2 },
+        { confidentiality: 3, integrity: 2, availability: 5 },
+    ];
+
+    it("returns the highest confidentiality across assets when only confidentiality is impacted", () => {
+        const damage = calcDamage({
+            assets,
+            confidentiality: true,
+            integrity: false,
+            availability: false,
+        });
+
+        expect(damage).toBe(3);
+    });
+
+    it("returns the highest integrity across assets when only integrity is impacted", () => {
+        const damage = calcDamage({
+            assets,
+            confidentiality: false,
+            integrity: true,
+            availability: false,
+        });
+
+        expect(damage).toBe(4);
+    });
+
+    it("returns the highest availability across assets when only availability is impacted", () => {
+        const damage = calcDamage({
+            assets,
+            confidentiality: false,
+            integrity: false,
+            availability: true,
+        });
+
+        expect(damage).toBe(5);
+    });
+
+    it("returns the overall max across only impacted protection goals", () => {
+        const damage = calcDamage({
+            assets,
+            confidentiality: true,
+            integrity: true,
+            availability: false,
+        });
+
+        expect(damage).toBe(4);
+    });
+});

--- a/apps/frontend/src/utils/helpers.ts
+++ b/apps/frontend/src/utils/helpers.ts
@@ -1,3 +1,31 @@
+import type { Asset } from "#api/types/asset.types.ts";
+
+interface DamageInput {
+    assets: Pick<Asset, "confidentiality" | "integrity" | "availability">[];
+    confidentiality: boolean;
+    integrity: boolean;
+    availability: boolean;
+}
+
 export function hasOwnProperty<O extends object, K extends PropertyKey>(obj: O, key: K): obj is O & Record<K, unknown> {
     return Object.prototype.hasOwnProperty.call(obj, key);
 }
+
+/**
+ * Returns the gross damage of a threat: the highest C/I/A rating across its
+ * assets, restricted to the protection goals the threat actually impacts.
+ */
+export const calcDamage = (threat: DamageInput): number => {
+    return threat.assets.reduce((maxValue, asset) => {
+        if (threat.confidentiality && maxValue < asset.confidentiality) {
+            maxValue = asset.confidentiality;
+        }
+        if (threat.integrity && maxValue < asset.integrity) {
+            maxValue = asset.integrity;
+        }
+        if (threat.availability && maxValue < asset.availability) {
+            maxValue = asset.availability;
+        }
+        return maxValue;
+    }, 0);
+};

--- a/apps/frontend/src/view/components/editor-components/annotations-canvas-layer.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/annotations-canvas-layer.component.test.tsx
@@ -1,5 +1,5 @@
-import { act, createRef, type RefObject } from "react";
-import { screen } from "@testing-library/react";
+import { createRef, type RefObject } from "react";
+import { act, screen } from "@testing-library/react";
 import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { createAnnotation } from "#test-utils/builders.ts";
 import { AnnotationsCanvasLayer, type AnnotationsCanvasLayerHandle } from "./annotations-canvas-layer.component";

--- a/apps/frontend/src/view/components/threatMeasuresTable.component.tsx
+++ b/apps/frontend/src/view/components/threatMeasuresTable.component.tsx
@@ -132,17 +132,21 @@ export const ThreatMeasuresTable = ({
                         </TableHead>
                         <TableBody data-testid="AssetsBody">
                             {(!threatMeasures || threatMeasures.length === 0) && (
-                                <Typography
-                                    sx={{
-                                        paddingTop: 2,
-                                        paddingLeft: 2,
-                                        minHeight: 60,
-                                        fontSize: "0.75rem",
-                                        fontStyle: "italic",
-                                    }}
-                                >
-                                    {t("noThreatsFound")}
-                                </Typography>
+                                <TableRow>
+                                    <TableCell colSpan={5}>
+                                        <Typography
+                                            sx={{
+                                                paddingTop: 2,
+                                                paddingLeft: 2,
+                                                minHeight: 60,
+                                                fontSize: "0.75rem",
+                                                fontStyle: "italic",
+                                            }}
+                                        >
+                                            {t("noThreatsFound")}
+                                        </Typography>
+                                    </TableCell>
+                                </TableRow>
                             )}
                             {threatMeasures?.map((threatMeasure) => (
                                 <ThreatMeasuresTableRow

--- a/apps/frontend/src/view/dialogs/add-threat.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat.dialog.test.tsx
@@ -1,0 +1,65 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddThreatDialog from "./add-threat.dialog";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createAsset, createProject, createThreat } from "#test-utils/builders.ts";
+import { mockUseConfirm, mockUseDialog, mockUseThreatMeasuresList } from "#test-utils/mock-hooks.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+
+mockUseDialog();
+mockUseConfirm();
+mockUseThreatMeasuresList();
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react-router-dom")>();
+    return { ...actual, useNavigate: () => navigate };
+});
+
+const setup = (userRole: USER_ROLES = USER_ROLES.EDITOR) => {
+    const project = createProject({ id: 7 });
+    const threat = createThreat({
+        id: 42,
+        assets: [createAsset({ confidentiality: 4, integrity: 2, availability: 1 })],
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<AddThreatDialog threat={threat} project={project} userRole={userRole} open={true} />);
+    return { project, threat, user };
+};
+
+describe("AddThreatDialog — Apply Measure button", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders the Apply Measure button on the Measures tab for EDITOR role", async () => {
+        const { user } = setup(USER_ROLES.EDITOR);
+
+        await user.click(screen.getByRole("tab", { name: /measures/i }));
+
+        expect(screen.getByRole("button", { name: /apply measure/i })).toBeInTheDocument();
+    });
+
+    it("does not render the Apply Measure button for VIEWER role", async () => {
+        const { user } = setup(USER_ROLES.VIEWER);
+
+        await user.click(screen.getByRole("tab", { name: /measures/i }));
+
+        expect(screen.queryByRole("button", { name: /apply measure/i })).not.toBeInTheDocument();
+    });
+
+    it("navigates to the apply-measure route with the threat and computed damage on click", async () => {
+        const { project, threat, user } = setup(USER_ROLES.EDITOR);
+
+        await user.click(screen.getByRole("tab", { name: /measures/i }));
+        await user.click(screen.getByRole("button", { name: /apply measure/i }));
+
+        expect(navigate).toHaveBeenCalledOnce();
+        expect(navigate).toHaveBeenCalledWith(`/projects/${project.id}/threats/measureImpacts/edit`, {
+            state: {
+                threat: { ...threat, damage: 4 },
+                project,
+            },
+        });
+    });
+});

--- a/apps/frontend/src/view/dialogs/add-threat.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat.dialog.tsx
@@ -27,7 +27,7 @@ import {
     Typography,
     type DialogProps,
 } from "@mui/material";
-import { InfoOutlined } from "@mui/icons-material";
+import { Add, InfoOutlined } from "@mui/icons-material";
 import { useRef, useState, type ChangeEvent, type MouseEvent, type SyntheticEvent } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -49,6 +49,7 @@ import type { ExtendedProject } from "#api/types/project.types.ts";
 import type { ThreatMeasure } from "#application/hooks/use-threat-measures-list.hook.ts";
 import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
 import type { Measure } from "#api/types/measure.types.ts";
+import { calcDamage } from "#utils/helpers.ts";
 
 type ThreatTab = "MAIN" | "ASSETS" | "MEASURES";
 
@@ -202,6 +203,15 @@ const AddThreatDialog = ({ threat, project, userRole, ...props }: AddThreatDialo
         const { measureImpact } = measureThreat;
         const data = { ...measureImpact, projectId };
         deleteMeasureImpact(data);
+    };
+
+    const onClickApplyMeasure = () => {
+        navigate(`/projects/${projectId}/threats/measureImpacts/edit`, {
+            state: {
+                threat: { ...threat, damage: calcDamage(threat) },
+                project,
+            },
+        });
     };
 
     /**
@@ -603,6 +613,15 @@ const AddThreatDialog = ({ threat, project, userRole, ...props }: AddThreatDialo
                             <Box sx={{ display: "flex", alignItems: "center" }}>
                                 <SearchField onChange={onChangeSearchValue} data-testid="SearchAsset" />
                             </Box>
+                            {checkUserRole(userRole, USER_ROLES.EDITOR) && (
+                                <Button
+                                    endIcon={<Add />}
+                                    onClick={onClickApplyMeasure}
+                                    data-testid="ApplyMeasureFromThreat"
+                                >
+                                    {t("applyMeasure")}
+                                </Button>
+                            )}
                         </Box>
                         <ThreatMeasuresTable
                             threatMeasures={threatMeasures}

--- a/apps/frontend/src/view/dialogs/measureImpactByMeasure.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measureImpactByMeasure.dialog.tsx
@@ -35,7 +35,9 @@ import type { Project } from "#api/types/project.types.ts";
 import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
 import type { DialogValue } from "#application/reducers/dialogs.reducer.ts";
 import type { CatalogMeasure } from "#api/types/catalog-measure.types.ts";
-import type { ThreatWithMetrics } from "#application/hooks/use-matrix.hook.ts";
+import type { ExtendedThreat } from "#api/types/threat.types.ts";
+
+export type ApplyMeasureThreat = ExtendedThreat & { damage: number };
 
 interface FormValues {
     id: number | undefined;
@@ -52,7 +54,7 @@ interface MeasureImpactFormValues extends FormValues, Omit<MeasureImpact, keyof 
 
 interface MeasureImpactByMeasureDialogProps extends DialogProps {
     project: Project;
-    threat: ThreatWithMetrics;
+    threat: ApplyMeasureThreat;
     measureImpact: MeasureImpact | null;
 }
 

--- a/apps/frontend/src/view/pages/measure-impact-by-measure-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/measure-impact-by-measure-dialog.page.tsx
@@ -2,8 +2,7 @@ import { useParams, useLocation, Navigate } from "react-router-dom";
 import type { Location } from "react-router-dom";
 import type { Project } from "#api/types/project.types.ts";
 import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
-import MeasureImpactByMeasureDialog from "#view/dialogs/measureImpactByMeasure.dialog.tsx";
-import type { ThreatWithMetrics } from "#application/hooks/use-matrix.hook.ts";
+import MeasureImpactByMeasureDialog, { type ApplyMeasureThreat } from "#view/dialogs/measureImpactByMeasure.dialog.tsx";
 
 /**
  * on this page a measureImpact can be created or edited
@@ -13,7 +12,7 @@ import type { ThreatWithMetrics } from "#application/hooks/use-matrix.hook.ts";
  * @return {JSX.Element}
  */
 interface MeasureImpactByMeasureDialogLocationState {
-    threat: ThreatWithMetrics;
+    threat: ApplyMeasureThreat;
     project: Project;
     measureImpact?: MeasureImpact | null;
 }

--- a/apps/frontend/src/view/pages/threats.page.tsx
+++ b/apps/frontend/src/view/pages/threats.page.tsx
@@ -22,6 +22,7 @@ import { CustomTableHeaderCell } from "#view/components/table-header.component.t
 import { CreatePage } from "#view/components/create-page.component.tsx";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import ThreatDialogPage from "./threat-dialog.page";
+import { MeasureImpactByMeasureDialogPage } from "./measure-impact-by-measure-dialog.page";
 import { withProject } from "#view/components/with-project.hoc.tsx";
 import { useAppDispatch, useAppSelector } from "#application/hooks/use-app-redux.hook.ts";
 
@@ -522,6 +523,7 @@ const ThreatsPageBody = () => {
                 </Box>
                 <Routes>
                     <Route path="edit" element={<ThreatDialogPage />} />
+                    <Route path="measureImpacts/edit" element={<MeasureImpactByMeasureDialogPage />} />
                 </Routes>
             </Page>
         </Box>


### PR DESCRIPTION
## Summary
  Resolves #730 — Apply measures from threat dialog.
  
  - Adds an "Apply Measure" (+) button on the Measures tab of the Edit Threat dialog
  so users can apply a measure without leaving the dialog.
  - Reuses the existing Apply Measure dialog by mounting `measureImpacts/edit` as a
  sibling route under the threats page.
  - Extracts gross-damage computation into a shared `calcDamage` helper so the new
  button and the risk page agree on the value.
  
  ## Screenshots
<img width="933" height="604" alt="Screenshot 2026-06-01 at 17 53 06" src="https://github.com/user-attachments/assets/55b198d4-d5a9-4f8b-b9fe-db0f5153fd1e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Apply Measure" action to threat dialog, allowing users with edit permissions to apply measures directly.
  * Added translations for the "Apply Measure" label in English and German.

* **Bug Fixes**
  * Improved empty-state rendering in the threat measures table for better visual consistency.

* **Tests**
  * Added test coverage for the new "Apply Measure" functionality and damage calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->