### PR TITLE
fix(ui): correct empty-state message in threat dialog measures table

### DIFF
--- a/apps/frontend/src/translations/de/threat-dialog-page.de.json
+++ b/apps/frontend/src/translations/de/threat-dialog-page.de.json
@@ -1,7 +1,7 @@
 {
   "applyMeasure": "Maßnahme anwenden",
   "measureThreatDeleteMessage": "Sind Sie sicher, dass Sie die Maßnahme '{{measureName}}' nicht länger auf die Bedrohung '{{threatName}}' anwenden möchten?",
-  "noThreatsFound": "Noch auf keine Bedrohung angewendet",
+  "noMeasuresApplied": "Noch keine Maßnahme angewendet",
   "setsOutOfScope": "Out of Scope gesetzt",
   "editMeasureImpact": "Auswirkung bearbeiten",
   "deleteMeasureImpact": "Auswirkung Löschen",

--- a/apps/frontend/src/translations/en/threat-dialog-page.en.json
+++ b/apps/frontend/src/translations/en/threat-dialog-page.en.json
@@ -1,7 +1,7 @@
 {
   "applyMeasure": "Apply Measure",
   "measureThreatDeleteMessage": "Do you really want to no longer apply the measure '{{measureName}}' to the threat '{{threatName}}'?",
-  "noThreatsFound": "Not applied to any threat",
+  "noMeasuresApplied": "Not applied to any measure",
   "setsOutOfScope": "Set out of Scope by measure",
   "editMeasureImpact": "Edit Impact",
   "deleteMeasureImpact": "Delete Impact",

--- a/apps/frontend/src/view/components/threatMeasuresTable.component.tsx
+++ b/apps/frontend/src/view/components/threatMeasuresTable.component.tsx
@@ -143,7 +143,7 @@ export const ThreatMeasuresTable = ({
                                                 fontStyle: "italic",
                                             }}
                                         >
-                                            {t("noThreatsFound")}
+                                            {t("noMeasuresApplied")}
                                         </Typography>
                                     </TableCell>
                                 </TableRow>


### PR DESCRIPTION
- The empty-state message in the threat dialog's "Measures" tab incorrectly read "Not applied to any threat" / "Noch auf keine Bedrohung angewendet", which describes the wrong direction — that table lists measures, not threats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty state messaging in the threat measures dialog to more accurately communicate to users when no measures have been applied, providing clearer and more helpful feedback.

* **Localization**
  * Updated English and German translation strings to maintain consistency and clarity with the revised user interface messaging throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->