### PR TITLE
  fix(catalogs): fix edit/delete dialogs and localize alert banners

### DIFF
--- a/apps/frontend/playwright/tests/catalog.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/catalog.page.e2e.spec.ts
@@ -305,16 +305,14 @@ test.describe("Catalog Page Tests", () => {
         }
     });
 
-    // TODO: Fix requires event.stopPropagation() on delete button in catalog threat/measure list items
-    test.skip("Should delete an existing catalog threat", async ({ page }) => {
+    test("Should delete an existing catalog threat", async ({ page }) => {
         const pg = new CatalogPage(page);
         await pg.threatDeleteButtons.first().click();
         await pg.confirmButton.click();
         await expect(pg.threatListEntries).toHaveCount(DEFAULT_THREATS - 1);
     });
 
-    // TODO: Fix requires event.stopPropagation() on delete button in catalog threat/measure list items
-    test.skip("Should delete an existing catalog measure", async ({ page }) => {
+    test("Should delete an existing catalog measure", async ({ page }) => {
         const pg = new CatalogPage(page);
         await pg.measureDeleteButtons.first().click();
         await pg.confirmButton.click();

--- a/apps/frontend/playwright/tests/catalogs.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/catalogs.page.e2e.spec.ts
@@ -98,8 +98,7 @@ test.describe("Catalogs Page Tests", () => {
         }
     });
 
-    // TODO: Fix requires event.stopPropagation() on rename/delete buttons in CatalogListItem (catalogs.page.tsx)
-    test.skip("Should update an existing catalog", async ({ page, request, browserName }, { testId }) => {
+    test("Should update an existing catalog", async ({ page, request, browserName }, { testId }) => {
         const pg = new CatalogsPage(page);
         const tid = buildTestId(browserName, testId);
         const token = await pg.getCsrfToken();
@@ -117,8 +116,7 @@ test.describe("Catalogs Page Tests", () => {
         await expect(pg.catalogEntryNameFilter(tid)).toContainText(updatedName);
     });
 
-    // TODO: Fix requires event.stopPropagation() on rename/delete buttons in CatalogListItem (catalogs.page.tsx)
-    test.skip("Should delete an existing catalog", async ({ page, request, browserName }, { testId }) => {
+    test("Should delete an existing catalog", async ({ page, request, browserName }, { testId }) => {
         const pg = new CatalogsPage(page);
         const tid = buildTestId(browserName, testId);
         const token = await pg.getCsrfToken();
@@ -133,8 +131,7 @@ test.describe("Catalogs Page Tests", () => {
         await expect(pg.catalogEntryNameFilter(tid)).toHaveCount(1);
     });
 
-    // TODO: Fix requires event.stopPropagation() on rename button in CatalogListItem (catalogs.page.tsx)
-    test.skip("Should not create/update catalogs with invalid inputs", async ({ page, request, browserName }, {
+    test("Should not create/update catalogs with invalid inputs", async ({ page, request, browserName }, {
         testId,
     }) => {
         const pg = new CatalogsPage(page);

--- a/apps/frontend/src/application/middlewares/catalogMeasures/catalog-measures.middleware.ts
+++ b/apps/frontend/src/application/middlewares/catalogMeasures/catalog-measures.middleware.ts
@@ -91,6 +91,6 @@ const handleFailedRequest: AppMiddleware =
         }
     };
 
-const catalogThreatsMiddlewares: AppMiddleware[] = [handleSuccessfulRequest, handleFailedRequest];
+const catalogMeasuresMiddlewares: AppMiddleware[] = [handleSuccessfulRequest, handleFailedRequest];
 
-export default catalogThreatsMiddlewares;
+export default catalogMeasuresMiddlewares;

--- a/apps/frontend/src/application/middlewares/catalogMeasures/catalog-measures.middleware.ts
+++ b/apps/frontend/src/application/middlewares/catalogMeasures/catalog-measures.middleware.ts
@@ -3,6 +3,7 @@ import type { AppMiddleware } from "#application/middlewares/types.ts";
 import { AlertActions } from "#application/actions/alert.actions.ts";
 import { CatalogMeasuresActions } from "#application/actions/catalog-measures.actions.ts";
 import { socket } from "#api/system-socket.api.ts";
+import { translationUtil } from "#utils/translations.ts";
 
 const asyncThunks = [
     CatalogMeasuresActions.createCatalogMeasure,
@@ -27,7 +28,7 @@ const handleSuccessfulRequest: AppMiddleware =
                 socket.emit("remove_catalog_measure", JSON.stringify(payload));
                 dispatch(
                     AlertActions.openSuccessAlert({
-                        text: `Catalog Measure '${payload.name}' was deleted successfully`,
+                        text: translationUtil.t("catalogPage:catalogMeasures.alert.deleted", { name: payload.name }),
                     })
                 );
             } else if (CatalogMeasuresActions.importCatalogMeasures.fulfilled.match(action)) {
@@ -38,7 +39,9 @@ const handleSuccessfulRequest: AppMiddleware =
                 });
                 dispatch(
                     AlertActions.openSuccessAlert({
-                        text: `${payload.length} Catalog Measures were successfully imported`,
+                        text: translationUtil.t("catalogPage:catalogMeasures.alert.imported", {
+                            amount: payload.length,
+                        }),
                     })
                 );
             } else {
@@ -47,7 +50,7 @@ const handleSuccessfulRequest: AppMiddleware =
                 socket.emit("set_catalog_measure", JSON.stringify(payload));
                 dispatch(
                     AlertActions.openSuccessAlert({
-                        text: `Catalog Measure '${payload.name}' was saved successfully`,
+                        text: translationUtil.t("catalogPage:catalogMeasures.alert.saved", { name: payload.name }),
                     })
                 );
             }
@@ -64,20 +67,24 @@ const handleFailedRequest: AppMiddleware =
                 const { arg: catalogMeasure } = action.meta;
                 dispatch(
                     AlertActions.openErrorAlert({
-                        text: `Failed to delete Catalog Measure '${catalogMeasure.name}'`,
+                        text: translationUtil.t("catalogPage:catalogMeasures.alert.deleteFailed", {
+                            name: catalogMeasure.name,
+                        }),
                     })
                 );
             } else if (CatalogMeasuresActions.importCatalogMeasures.rejected.match(action)) {
                 dispatch(
                     AlertActions.openErrorAlert({
-                        text: "Failed to import Catalog Measures",
+                        text: translationUtil.t("catalogPage:catalogMeasures.alert.importFailed"),
                     })
                 );
             } else {
                 const { arg: catalogMeasure } = action.meta;
                 dispatch(
                     AlertActions.openErrorAlert({
-                        text: `Failed to save Catalog Measure '${catalogMeasure.name}'`,
+                        text: translationUtil.t("catalogPage:catalogMeasures.alert.saveFailed", {
+                            name: catalogMeasure.name,
+                        }),
                     })
                 );
             }

--- a/apps/frontend/src/application/middlewares/catalogThreats/catalog-threats.middleware.ts
+++ b/apps/frontend/src/application/middlewares/catalogThreats/catalog-threats.middleware.ts
@@ -3,6 +3,7 @@ import type { AppMiddleware } from "#application/middlewares/types.ts";
 import { AlertActions } from "#application/actions/alert.actions.ts";
 import { CatalogThreatsActions } from "#application/actions/catalog-threats.actions.ts";
 import { socket } from "#api/system-socket.api.ts";
+import { translationUtil } from "#utils/translations.ts";
 
 const asyncThunks = [
     CatalogThreatsActions.createCatalogThreat,
@@ -27,7 +28,7 @@ const handleSuccessfulRequest: AppMiddleware =
                 socket.emit("remove_catalog_threat", JSON.stringify(payload));
                 dispatch(
                     AlertActions.openSuccessAlert({
-                        text: `Catalog Threat '${payload.name}' was deleted successfully`,
+                        text: translationUtil.t("catalogPage:catalogThreats.alert.deleted", { name: payload.name }),
                     })
                 );
             } else if (CatalogThreatsActions.importCatalogThreats.fulfilled.match(action)) {
@@ -38,7 +39,9 @@ const handleSuccessfulRequest: AppMiddleware =
                 });
                 dispatch(
                     AlertActions.openSuccessAlert({
-                        text: `${payload.length} Catalog Threats were successfully imported`,
+                        text: translationUtil.t("catalogPage:catalogThreats.alert.imported", {
+                            amount: payload.length,
+                        }),
                     })
                 );
             } else {
@@ -47,7 +50,7 @@ const handleSuccessfulRequest: AppMiddleware =
                 socket.emit("set_catalog_threat", JSON.stringify(payload));
                 dispatch(
                     AlertActions.openSuccessAlert({
-                        text: `Catalog Threat '${payload.name}' was saved successfully`,
+                        text: translationUtil.t("catalogPage:catalogThreats.alert.saved", { name: payload.name }),
                     })
                 );
             }
@@ -64,20 +67,20 @@ const handleFailedRequest: AppMiddleware =
                 const { arg: asset } = action.meta;
                 dispatch(
                     AlertActions.openErrorAlert({
-                        text: `Failed to delete Catalog Threat '${asset.name}'`,
+                        text: translationUtil.t("catalogPage:catalogThreats.alert.deleteFailed", { name: asset.name }),
                     })
                 );
             } else if (CatalogThreatsActions.importCatalogThreats.rejected.match(action)) {
                 dispatch(
                     AlertActions.openErrorAlert({
-                        text: "Failed to import Catalog Threats",
+                        text: translationUtil.t("catalogPage:catalogThreats.alert.importFailed"),
                     })
                 );
             } else {
                 const { arg: asset } = action.meta;
                 dispatch(
                     AlertActions.openErrorAlert({
-                        text: `Failed to save Catalog Threat '${asset.name}'`,
+                        text: translationUtil.t("catalogPage:catalogThreats.alert.saveFailed", { name: asset.name }),
                     })
                 );
             }

--- a/apps/frontend/src/application/middlewares/catalogs/catalogs.middleware.ts
+++ b/apps/frontend/src/application/middlewares/catalogs/catalogs.middleware.ts
@@ -3,6 +3,7 @@ import type { AppMiddleware } from "#application/middlewares/types.ts";
 import { socket } from "#api/system-socket.api.ts";
 import { AlertActions } from "#application/actions/alert.actions.ts";
 import { CatalogsActions } from "#application/actions/catalogs.actions.ts";
+import { translationUtil } from "#utils/translations.ts";
 
 const asyncThunks = [
     CatalogsActions.createCatalog,
@@ -25,7 +26,7 @@ const handleSuccessfulRequest: AppMiddleware =
                 dispatch(CatalogsActions.removeCatalog(catalog));
                 dispatch(
                     AlertActions.openSuccessAlert({
-                        text: `Catalog '${catalog.name}' was deleted successfully`,
+                        text: translationUtil.t("catalogsPage:alert.deleted", { catalogName: catalog.name }),
                     })
                 );
             } else {
@@ -34,7 +35,7 @@ const handleSuccessfulRequest: AppMiddleware =
                 dispatch(CatalogsActions.setCatalog(catalog));
                 dispatch(
                     AlertActions.openSuccessAlert({
-                        text: `Catalog '${catalog.name}' was saved successfully`,
+                        text: translationUtil.t("catalogsPage:alert.saved", { catalogName: catalog.name }),
                     })
                 );
             }
@@ -50,7 +51,7 @@ const handleFailedRequest: AppMiddleware =
             const { arg: catalog } = action.meta;
             dispatch(
                 AlertActions.openErrorAlert({
-                    text: `Failed to save Catalog '${catalog.name}''`,
+                    text: translationUtil.t("catalogsPage:alert.saveFailed", { catalogName: catalog.name }),
                 })
             );
         }

--- a/apps/frontend/src/application/middlewares/index.ts
+++ b/apps/frontend/src/application/middlewares/index.ts
@@ -10,7 +10,7 @@ import threats from "./threats/threats.middleware";
 import measures from "./measures/measures.middleware";
 import measureImpacts from "./measureImpacts/measureImpacts.middleware";
 import catalogThreats from "./catalogThreats/catalog-threats.middleware";
-import catalogMeasures from "./catalogMeasures/catalog-threats.middleware";
+import catalogMeasures from "./catalogMeasures/catalog-measures.middleware";
 import errors from "./error.middleware";
 import members from "./members.middleware";
 import user from "./user/user.middleware";

--- a/apps/frontend/src/translations/de/catalog-page.de.json
+++ b/apps/frontend/src/translations/de/catalog-page.de.json
@@ -13,9 +13,25 @@
   "exportMeasures": "Maßnahmen exportieren",
   "importMeasures": "Maßnahmen importieren",
   "catalogThreats": {
-    "deleteMessage": "Sind Sie sicher, dass Sie die Bedrohung '{{name}}' löschen möchten?"
+    "deleteMessage": "Sind Sie sicher, dass Sie die Bedrohung '{{name}}' löschen möchten?",
+    "alert": {
+      "deleted": "Die Katalog-Bedrohung '{{name}}' wurde erfolgreich gelöscht.",
+      "saved": "Die Katalog-Bedrohung '{{name}}' wurde erfolgreich gespeichert.",
+      "imported": "{{amount}} Katalog-Bedrohungen wurden erfolgreich importiert.",
+      "deleteFailed": "Die Katalog-Bedrohung '{{name}}' konnte nicht gelöscht werden.",
+      "saveFailed": "Die Katalog-Bedrohung '{{name}}' konnte nicht gespeichert werden.",
+      "importFailed": "Die Katalog-Bedrohungen konnten nicht importiert werden."
+    }
   },
   "catalogMeasures": {
-    "deleteMessage": "Sind Sie sicher, dass Sie die Maßnahme '{{name}}' löschen möchten?"
+    "deleteMessage": "Sind Sie sicher, dass Sie die Maßnahme '{{name}}' löschen möchten?",
+    "alert": {
+      "deleted": "Die Katalog-Maßnahme '{{name}}' wurde erfolgreich gelöscht.",
+      "saved": "Die Katalog-Maßnahme '{{name}}' wurde erfolgreich gespeichert.",
+      "imported": "{{amount}} Katalog-Maßnahmen wurden erfolgreich importiert.",
+      "deleteFailed": "Die Katalog-Maßnahme '{{name}}' konnte nicht gelöscht werden.",
+      "saveFailed": "Die Katalog-Maßnahme '{{name}}' konnte nicht gespeichert werden.",
+      "importFailed": "Die Katalog-Maßnahmen konnten nicht importiert werden."
+    }
   }
 }

--- a/apps/frontend/src/translations/de/catalogs-page.de.json
+++ b/apps/frontend/src/translations/de/catalogs-page.de.json
@@ -15,5 +15,10 @@
     "alert.created.failure": "Der Katalog {{catalogName}} konnte nicht erstellt werden."
   },
   "deleteMessage": "Wollen Sie den Katalog '{{ catalogName }}' wirklich löschen?",
-  "heading": "Kataloge"
+  "heading": "Kataloge",
+  "alert": {
+    "deleted": "Der Katalog '{{catalogName}}' wurde erfolgreich gelöscht.",
+    "saved": "Der Katalog '{{catalogName}}' wurde erfolgreich gespeichert.",
+    "saveFailed": "Der Katalog '{{catalogName}}' konnte nicht gespeichert werden."
+  }
 }

--- a/apps/frontend/src/translations/en/catalog-page.en.json
+++ b/apps/frontend/src/translations/en/catalog-page.en.json
@@ -7,10 +7,26 @@
   "noThreatFound": "Threat not found",
   "noMeasureFound": "Measure not found",
   "catalogThreats": {
-    "deleteMessage": "Do you really want to delete the catalog threat '{{name}}'?"
+    "deleteMessage": "Do you really want to delete the catalog threat '{{name}}'?",
+    "alert": {
+      "deleted": "Catalog Threat '{{name}}' was deleted successfully.",
+      "saved": "Catalog Threat '{{name}}' was saved successfully.",
+      "imported": "{{amount}} Catalog Threats were successfully imported.",
+      "deleteFailed": "Failed to delete Catalog Threat '{{name}}'.",
+      "saveFailed": "Failed to save Catalog Threat '{{name}}'.",
+      "importFailed": "Failed to import Catalog Threats."
+    }
   },
   "catalogMeasures": {
-    "deleteMessage": "Do you really want to delete the catalog measure '{{name}}'?"
+    "deleteMessage": "Do you really want to delete the catalog measure '{{name}}'?",
+    "alert": {
+      "deleted": "Catalog Measure '{{name}}' was deleted successfully.",
+      "saved": "Catalog Measure '{{name}}' was saved successfully.",
+      "imported": "{{amount}} Catalog Measures were successfully imported.",
+      "deleteFailed": "Failed to delete Catalog Measure '{{name}}'.",
+      "saveFailed": "Failed to save Catalog Measure '{{name}}'.",
+      "importFailed": "Failed to import Catalog Measures."
+    }
   },
   "exportData": "Export",
   "importData": "Import",

--- a/apps/frontend/src/translations/en/catalogs-page.en.json
+++ b/apps/frontend/src/translations/en/catalogs-page.en.json
@@ -15,5 +15,10 @@
     "alert.created.failure": "Failed to create Catalog {{catalogName}}."
   },
   "deleteMessage": "Do you really want to delete the catalog '{{ catalogName }}'?",
-  "heading": "Catalogs"
+  "heading": "Catalogs",
+  "alert": {
+    "deleted": "Catalog '{{catalogName}}' was deleted successfully.",
+    "saved": "Catalog '{{catalogName}}' was saved successfully.",
+    "saveFailed": "Failed to save Catalog '{{catalogName}}'."
+  }
 }

--- a/apps/frontend/src/view/components/catalog-measures-list-box.component.tsx
+++ b/apps/frontend/src/view/components/catalog-measures-list-box.component.tsx
@@ -339,9 +339,10 @@ export const CatalogMeasuresListBox = ({
                                                     },
                                                     color: "text.primary",
                                                 }}
-                                                onClick={(event: React.MouseEvent) =>
-                                                    handleDeleteCatalogMeasure(event, catalogMeasure)
-                                                }
+                                                onClick={(event: React.MouseEvent) => {
+                                                    event.stopPropagation();
+                                                    handleDeleteCatalogMeasure(event, catalogMeasure);
+                                                }}
                                                 data-testid="catalog-page_measures-list-entry_delete-button"
                                             >
                                                 <Delete sx={{ fontSize: 18 }} />

--- a/apps/frontend/src/view/components/catalog-threats-list-box.component.tsx
+++ b/apps/frontend/src/view/components/catalog-threats-list-box.component.tsx
@@ -318,7 +318,10 @@ export const CatalogThreatsListBox = ({ catalogId, attacker, pointOfAttack, user
                                                     },
                                                     color: "text.primary",
                                                 }}
-                                                onClick={(e) => handleDeleteCatalogThreat(e, catalogThreat)}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    handleDeleteCatalogThreat(e, catalogThreat);
+                                                }}
                                                 data-testid="catalog-page_threats-list-entry_delete-button"
                                             >
                                                 <Delete sx={{ fontSize: 18 }} />

--- a/apps/frontend/src/view/pages/catalogs.page.tsx
+++ b/apps/frontend/src/view/pages/catalogs.page.tsx
@@ -318,7 +318,10 @@ const CatalogListItem = ({ catalog, onClick, onClickEdit, onClickDelete, ...prop
                 <ListItemSecondaryAction>
                     <IconButton
                         data-testid="catalogs-page_rename-catalog-button"
-                        onClick={(event) => onClickEdit(event, catalog)}
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            onClickEdit(event, catalog);
+                        }}
                         title={t("editCatalogBtn")}
                         sx={{
                             color: "text.primary",
@@ -333,7 +336,10 @@ const CatalogListItem = ({ catalog, onClick, onClickEdit, onClickDelete, ...prop
                         sx={{
                             color: "text.primary",
                         }}
-                        onClick={(event) => onClickDelete(event, catalog)}
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            onClickDelete(event, catalog);
+                        }}
                     >
                         <Delete sx={{ fontSize: 18 }} />
                     </IconButton>


### PR DESCRIPTION
## Summary

  Resolves #794 

  - Fix Edit/Delete buttons on catalogs, catalog threats, and catalog measures that triggered the row's navigation instead of (or in addition to) the intended dialog — clicks now stop propagating to the parent ListItem.
  - Localize the success/error alert banners that were hardcoded in English so they respect the selected language .
  - Re-enable the Playwright E2E tests that were skipped pending this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented catalog threats and measures delete/edit buttons from triggering the parent item navigation.
  * Corrected middleware wiring for catalog measures and updated alert handling.
* **Tests**
  * Re-enabled previously skipped Playwright tests for catalog threats/measures deletion and catalogs update/delete and invalid-input cases.
* **Internationalization**
  * Added/expanded localized catalog and catalogs page alert messages (success/failure, including import and pluralization) using translation-based strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->