### PR TITLE
fix(risk): prevent matrix time view spooling back when opening threat

### DIFF
--- a/apps/frontend/src/application/hooks/use-matrix.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-matrix.hook.test.tsx
@@ -1,0 +1,153 @@
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import type { ReactNode } from "react";
+import { useMatrix } from "./use-matrix.hook";
+import { createStore } from "#application/store.ts";
+import { createMeasure, createMeasureImpact, createThreat } from "#test-utils/builders.ts";
+import {
+    mockUseCatalogMeasures,
+    mockUseMeasureImpacts,
+    mockUseMeasures,
+    mockUseThreats,
+} from "#test-utils/mock-hooks.ts";
+import type { Measure } from "#api/types/measure.types.ts";
+import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
+import type { ExtendedThreat } from "#api/types/threat.types.ts";
+
+interface SetupArgs {
+    threats?: ExtendedThreat[];
+    measures?: Measure[];
+    measureImpacts?: MeasureImpact[];
+}
+
+const renderUseMatrix = ({ threats = [], measures = [], measureImpacts = [] }: SetupArgs = {}) => {
+    mockUseThreats({ items: threats });
+    mockUseMeasures({ items: measures });
+    mockUseMeasureImpacts({ items: measureImpacts });
+    mockUseCatalogMeasures();
+
+    const store = createStore();
+    const wrapper = ({ children }: { children: ReactNode }) => <Provider store={store}>{children}</Provider>;
+    return renderHook(() => useMatrix({ projectId: 1, catalogId: 1, language: "en" }), { wrapper });
+};
+
+// A threat wired to a single measure through a measure impact, so the threat's
+// derived `measures[0].active` flag reflects the timeline-date comparison.
+const linkedSetup = (scheduledAt: Date): SetupArgs => ({
+    threats: [createThreat({ id: 1 })],
+    measures: [createMeasure({ id: 10, scheduledAt })],
+    measureImpacts: [createMeasureImpact({ id: 1, measureId: 10, threatId: 1 })],
+});
+
+describe("useMatrix", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("timeline", () => {
+        it("anchors an empty timeline to today's midnight when there are no measures", () => {
+            const { result } = renderUseMatrix({ measures: [] });
+            const { timeline } = result.current;
+
+            expect(timeline.marks).toEqual([]);
+            expect(timeline.minValue).toBe(-1);
+            expect(timeline.maxValue).toBe(0);
+            expect(timeline.startDate.getTime()).toBe(timeline.endDate.getTime());
+            expect(timeline.startDate.getHours()).toBe(0);
+            expect(timeline.startDate.getMinutes()).toBe(0);
+            expect(timeline.startDate.getSeconds()).toBe(0);
+        });
+
+        it("prepends a Start mark and adds one ISO-labelled mark per measure", () => {
+            const measure = createMeasure({ id: 10, scheduledAt: new Date("2025-03-10T09:30:00Z") });
+
+            const { result } = renderUseMatrix({ measures: [measure] });
+            const { marks } = result.current.timeline;
+
+            expect(marks).toHaveLength(2);
+            expect(marks[0]).toEqual({ value: -1, tooltipText: "Start", date: null, label: "Start" });
+            expect(marks[1]?.value).toBe(0);
+            expect(marks[1]?.tooltipText).toBe("2025-03-10");
+            expect(marks[1]?.label).toBe("2025-03-10");
+        });
+
+        it("does not mutate the measure's scheduledAt while building marks", () => {
+            const scheduledAt = new Date("2025-03-10T09:30:00Z");
+            const originalTime = scheduledAt.getTime();
+            const measure = createMeasure({ id: 10, scheduledAt });
+
+            const { result } = renderUseMatrix({ measures: [measure] });
+            const { marks } = result.current.timeline;
+
+            expect(marks[1]?.date).toBe(scheduledAt);
+            expect(scheduledAt.getTime()).toBe(originalTime);
+            expect(measure.scheduledAt.getTime()).toBe(originalTime);
+        });
+
+        it("maps mark values to whole-day offsets from the earliest measure", () => {
+            const measures = [
+                createMeasure({ id: 1, scheduledAt: new Date("2025-03-10T08:00:00Z") }),
+                createMeasure({ id: 2, scheduledAt: new Date("2025-03-12T20:00:00Z") }),
+                createMeasure({ id: 3, scheduledAt: new Date("2025-03-15T00:00:00Z") }),
+            ];
+
+            const { result } = renderUseMatrix({ measures });
+            const { marks, minValue, maxValue } = result.current.timeline;
+
+            expect(marks.slice(1).map((mark) => mark.value)).toEqual([0, 2, 5]);
+            expect(minValue).toBe(-1);
+            expect(maxValue).toBe(5);
+        });
+
+        it("collapses measures on the same calendar day to the same mark value", () => {
+            const measures = [
+                createMeasure({ id: 1, scheduledAt: new Date("2025-03-10T01:00:00Z") }),
+                createMeasure({ id: 2, scheduledAt: new Date("2025-03-10T23:00:00Z") }),
+            ];
+
+            const { result } = renderUseMatrix({ measures });
+            const { marks, maxValue } = result.current.timeline;
+
+            expect(marks.slice(1).map((mark) => mark.value)).toEqual([0, 0]);
+            expect(maxValue).toBe(0);
+        });
+    });
+
+    describe("measure active flag", () => {
+        it("is inactive while no timeline date is selected", () => {
+            const { result } = renderUseMatrix(linkedSetup(new Date("2025-03-10T12:00:00Z")));
+
+            expect(result.current.threats[0]?.measures[0]?.active).toBe(false);
+        });
+
+        it("activates when the timeline date is the same day but an earlier clock time", () => {
+            const { result } = renderUseMatrix(linkedSetup(new Date("2025-03-10T18:00:00Z")));
+
+            act(() => {
+                result.current.setTimelineDate(new Date("2025-03-10T06:00:00Z"));
+            });
+
+            expect(result.current.threats[0]?.measures[0]?.active).toBe(true);
+        });
+
+        it("stays inactive when the timeline date is on an earlier day", () => {
+            const { result } = renderUseMatrix(linkedSetup(new Date("2025-03-10T12:00:00Z")));
+
+            act(() => {
+                result.current.setTimelineDate(new Date("2025-03-09T23:00:00Z"));
+            });
+
+            expect(result.current.threats[0]?.measures[0]?.active).toBe(false);
+        });
+
+        it("activates when the timeline date is on a later day", () => {
+            const { result } = renderUseMatrix(linkedSetup(new Date("2025-03-10T12:00:00Z")));
+
+            act(() => {
+                result.current.setTimelineDate(new Date("2025-03-11T01:00:00Z"));
+            });
+
+            expect(result.current.threats[0]?.measures[0]?.active).toBe(true);
+        });
+    });
+});

--- a/apps/frontend/src/application/hooks/use-matrix.hook.ts
+++ b/apps/frontend/src/application/hooks/use-matrix.hook.ts
@@ -72,6 +72,8 @@ const sortableThreatFields: (keyof Pick<
     "name" | "description" | "componentName" | "attacker" | "pointOfAttack"
 >)[] = ["name", "description", "componentName", "attacker", "pointOfAttack"];
 
+const toDayNumber = (date: Date): number => Math.floor(date.getTime() / 1000 / 3600 / 24);
+
 export const useMatrix = ({ projectId, catalogId }: UseMatrixArgs) => {
     const project = useAppSelector((state) => projectsSelectors.selectById(state, projectId));
     const defaultGreen = project?.lineOfToleranceGreen ?? 6;
@@ -113,7 +115,7 @@ export const useMatrix = ({ projectId, catalogId }: UseMatrixArgs) => {
                             })
                             .map((measure) => {
                                 const active =
-                                    !!timelineDate && timelineDate.getTime() >= measure?.scheduledAt?.getTime();
+                                    !!timelineDate && toDayNumber(timelineDate) >= toDayNumber(measure.scheduledAt);
                                 return {
                                     measureId: measure.id,
                                     active: active,
@@ -258,19 +260,17 @@ export const useMatrix = ({ projectId, catalogId }: UseMatrixArgs) => {
 
         const startDate = measures[0]?.scheduledAt ?? new Date();
         const endDate = measures[measures.length - 1]?.scheduledAt ?? new Date();
-        const maxDate = Math.floor(endDate.getTime() / 1000 / 3600 / 24);
-        const minDate = Math.floor(startDate.getTime() / 1000 / 3600 / 24);
+        const maxDate = toDayNumber(endDate);
+        const minDate = toDayNumber(startDate);
         const minValue = -1;
         const maxValue = maxDate - minDate;
         const marks: TimelineMark[] = measures.map((measure) => {
-            const value = Math.floor(measure.scheduledAt.getTime() / 1000 / 3600 / 24) - minDate;
+            const value = toDayNumber(measure.scheduledAt) - minDate;
             const tooltipText = measure.scheduledAt.toISOString().split("T")[0] ?? "";
-            const date = measure.scheduledAt;
-            date.setHours(0, 0, 0, 0);
             return {
                 value: value,
                 tooltipText: tooltipText,
-                date: date,
+                date: measure.scheduledAt,
                 label: tooltipText,
             };
         });

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -1,6 +1,8 @@
 import type { Asset } from "#api/types/asset.types.ts";
 import type { ExtendedProject } from "#api/types/project.types.ts";
 import type { ExtendedThreat } from "#api/types/threat.types.ts";
+import type { Measure } from "#api/types/measure.types.ts";
+import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
 import {
     AnchorOrientation,
     type Annotation,
@@ -147,6 +149,34 @@ export function createAnnotation<T extends AnnotationType>(
         ...overrides,
     } as unknown as Extract<Annotation, { type: T }>;
 }
+
+export const createMeasure = (overrides: Partial<Measure> = {}): Measure => ({
+    id: 1,
+    name: "Test Measure",
+    description: "",
+    scheduledAt: new Date("2025-01-01"),
+    projectId: 1,
+    catalogMeasureId: null,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    ...overrides,
+});
+
+export const createMeasureImpact = (overrides: Partial<MeasureImpact> = {}): MeasureImpact => ({
+    id: 1,
+    measureId: 1,
+    threatId: 1,
+    description: "",
+    setsOutOfScope: false,
+    impactsProbability: false,
+    impactsDamage: false,
+    probability: null,
+    damage: null,
+    projectId: 1,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    ...overrides,
+});
 
 export const createConnection = (overrides: Partial<SystemConnection> = {}): SystemConnection => ({
     id: "conn-1",

--- a/apps/frontend/src/test-utils/mock-hooks.ts
+++ b/apps/frontend/src/test-utils/mock-hooks.ts
@@ -5,6 +5,10 @@ import * as alertHook from "#application/hooks/use-alert.hook.ts";
 import * as editorHook from "#application/hooks/use-editor.hook.ts";
 import * as assetsHook from "#application/hooks/use-assets.hook.ts";
 import * as threatMeasuresListHook from "#application/hooks/use-threat-measures-list.hook.ts";
+import * as threatsHook from "#application/hooks/use-threats.hook.ts";
+import * as measuresHook from "#application/hooks/use-measures.hook.ts";
+import * as measureImpactsHook from "#application/hooks/use-measureImpacts.hook.ts";
+import * as catalogMeasuresHook from "#application/hooks/use-catalog-measures.hook.ts";
 
 /**
  * @module mock-hooks - Reusable hook spies.
@@ -25,6 +29,10 @@ type UseAlertResult = ReturnType<typeof alertHook.useAlert>;
 type UseEditorResult = ReturnType<typeof editorHook.useEditor>;
 type UseAssetsResult = ReturnType<typeof assetsHook.useAssets>;
 type UseThreatMeasuresListResult = ReturnType<typeof threatMeasuresListHook.useThreatMeasuresList>;
+type UseThreatsResult = ReturnType<typeof threatsHook.useThreats>;
+type UseMeasuresResult = ReturnType<typeof measuresHook.useMeasures>;
+type UseMeasureImpactsResult = ReturnType<typeof measureImpactsHook.useMeasureImpacts>;
+type UseCatalogMeasuresResult = ReturnType<typeof catalogMeasuresHook.useCatalogMeasures>;
 
 export const mockUseDialog = (config?: Partial<UseDialogResult>): MockInstance => {
     return vi.spyOn(dialogHook, "useDialog").mockImplementation(() => ({
@@ -164,6 +172,47 @@ export const mockUseThreatMeasuresList = (config?: Partial<UseThreatMeasuresList
         setSortDirection: vi.fn(),
         setSearchValue: vi.fn(),
         deleteMeasureImpact: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseThreats = (config?: Partial<UseThreatsResult>): MockInstance => {
+    return vi.spyOn(threatsHook, "useThreats").mockImplementation(() => ({
+        items: [],
+        isPending: false,
+        loadThreats: vi.fn(),
+        deleteThreat: vi.fn(),
+        duplicateThreat: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseMeasures = (config?: Partial<UseMeasuresResult>): MockInstance => {
+    return vi.spyOn(measuresHook, "useMeasures").mockImplementation(() => ({
+        items: [],
+        isPending: false,
+        loadMeasures: vi.fn(),
+        deleteMeasure: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseMeasureImpacts = (config?: Partial<UseMeasureImpactsResult>): MockInstance => {
+    return vi.spyOn(measureImpactsHook, "useMeasureImpacts").mockImplementation(() => ({
+        items: [],
+        isPending: false,
+        loadMeasureImpacts: vi.fn(),
+        deleteMeasureImpact: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseCatalogMeasures = (config?: Partial<UseCatalogMeasuresResult>): MockInstance => {
+    return vi.spyOn(catalogMeasuresHook, "useCatalogMeasures").mockImplementation(() => ({
+        items: [],
+        isPending: false,
+        loadCatalogMeasures: vi.fn(),
+        deleteCatalogMeasure: vi.fn(),
         ...config,
     }));
 };


### PR DESCRIPTION
Summary

  Resolves #797

  - Stops the risk-matrix time view from spooling back to the start when a threat is opened, by no longer mutating each measure's scheduledAt while building timeline marks.
  - Switches the timeline/measure-active logic to a whole-day comparison (toDayNumber), so a measure counts as active on its scheduled day regardless of clock time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for matrix timeline behavior, including empty timeline handling, mark generation, and date-based offset mapping.
  * Added validation for measure selection logic based on timeline date matching.

* **Refactor**
  * Optimized day-number calculations for timeline value computation and measure state management.
  * Updated test utilities with new builder and mock functions for test data generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->