### PR TITLE
test(playwright): add editor drawing e2e tests

### DIFF
--- a/apps/frontend/playwright/pages/editor.page.ts
+++ b/apps/frontend/playwright/pages/editor.page.ts
@@ -101,12 +101,9 @@ export class EditorPage extends BasePage {
         this.shapesButton = page.getByRole("button", { name: "Shapes" });
         this.pencilButton = page.getByRole("button", { name: "Pencil", exact: true });
         this.textToolButton = page.getByRole("button", { name: "Text", exact: true });
-        // For a selected shape this is the only "Delete annotation" control on the page
-        // (the floating text toolbar only renders while a text annotation is active).
+        // Unambiguous for a selected shape; the floating text toolbar adds one only while editing text.
         this.deleteAnnotationButton = page.getByRole("button", { name: "Delete annotation" });
-        // The floating text toolbar is the only Paper tagged data-edit-protected.
         this.textEditingToolbar = page.locator(".MuiPaper-root[data-edit-protected]");
-        // The inline annotation editor is the only <textarea> on the editor page.
         this.annotationTextarea = page.locator("textarea");
     }
 
@@ -232,10 +229,8 @@ export class EditorPage extends BasePage {
         return { x: box.x + pos.x, y: box.y + pos.y };
     }
 
-    // The drawing preview lives in React state set on mousedown. Pausing between
-    // pointer steps lets React commit and the rAF-throttled move handler flush,
-    // so the preview exists when mouseup commits it. Without the pauses a synthetic
-    // drag fires fast enough that mouseup sees a still-null preview and draws nothing.
+    // Pause between pointer steps so React commits the mousedown draw-preview before mouseup;
+    // a too-fast synthetic drag would commit a still-null preview and draw nothing.
     private static readonly DRAW_STEP_DELAY_MS = 100;
 
     private async pressDragThrough(points: { x: number; y: number }[]): Promise<void> {

--- a/apps/frontend/playwright/pages/editor.page.ts
+++ b/apps/frontend/playwright/pages/editor.page.ts
@@ -45,6 +45,16 @@ export class EditorPage extends BasePage {
     readonly deleteComponentMenuItem: Locator;
     readonly confirmButton: Locator;
 
+    // Drawing toolbar (annotations)
+    readonly centerEditorButton: Locator;
+    readonly exportSystemImageButton: Locator;
+    readonly shapesButton: Locator;
+    readonly pencilButton: Locator;
+    readonly textToolButton: Locator;
+    readonly deleteAnnotationButton: Locator;
+    readonly textEditingToolbar: Locator;
+    readonly annotationTextarea: Locator;
+
     constructor(page: Page) {
         super(page);
         this.canvas = page.locator("canvas").nth(2);
@@ -84,13 +94,27 @@ export class EditorPage extends BasePage {
         this.poaRequiredError = this.componentDialog.getByText("At least one point of attack must be selected");
         this.deleteComponentMenuItem = page.getByTestId("DeleteComponent");
         this.confirmButton = page.getByTestId("confirm-button");
+
+        // Toolbar buttons carry no data-testid; they expose i18n aria-labels (en bundle).
+        this.centerEditorButton = page.getByRole("button", { name: "Center editor" });
+        this.exportSystemImageButton = page.getByRole("button", { name: "Export System Image" });
+        this.shapesButton = page.getByRole("button", { name: "Shapes" });
+        this.pencilButton = page.getByRole("button", { name: "Pencil", exact: true });
+        this.textToolButton = page.getByRole("button", { name: "Text", exact: true });
+        // For a selected shape this is the only "Delete annotation" control on the page
+        // (the floating text toolbar only renders while a text annotation is active).
+        this.deleteAnnotationButton = page.getByRole("button", { name: "Delete annotation" });
+        // The floating text toolbar is the only Paper tagged data-edit-protected.
+        this.textEditingToolbar = page.locator(".MuiPaper-root[data-edit-protected]");
+        // The inline annotation editor is the only <textarea> on the editor page.
+        this.annotationTextarea = page.locator("textarea");
     }
 
     async goto(projectId: number): Promise<void> {
         await this.page.goto(`/projects/${projectId}/system`);
     }
 
-    private async waitForEditorReady(): Promise<void> {
+    async waitForEditorReady(): Promise<void> {
         await this.page.waitForURL(/\/projects\/\d+\/system/);
         await this.canvas.waitFor({ state: "visible" });
         // Auto-centering runs in requestAnimationFrame after data loads;
@@ -177,6 +201,108 @@ export class EditorPage extends BasePage {
 
     wifiIcon(): Locator {
         return this.page.getByTestId("WifiIcon");
+    }
+
+    shapeToolButton(name: string): Locator {
+        return this.page.getByRole("button", { name, exact: true });
+    }
+
+    async selectShapeTool(name: string): Promise<void> {
+        await this.shapesButton.click();
+        await this.shapeToolButton(name).click();
+    }
+
+    private async canvasBox(): Promise<{ x: number; y: number; width: number; height: number }> {
+        const box = await this.canvas.boundingBox();
+        if (!box) {
+            throw new Error("Canvas bounding box unavailable");
+        }
+        return box;
+    }
+
+    private async toPagePoint(
+        box: { x: number; y: number; width: number; height: number },
+        konvaX: number,
+        konvaY: number
+    ): Promise<{ x: number; y: number }> {
+        const pos = await this.toCanvasPosition(konvaX, konvaY);
+        if (pos.x < 0 || pos.y < 0 || pos.x > box.width || pos.y > box.height) {
+            throw new Error(`Konva point (${konvaX}, ${konvaY}) maps outside the canvas viewport`);
+        }
+        return { x: box.x + pos.x, y: box.y + pos.y };
+    }
+
+    // The drawing preview lives in React state set on mousedown. Pausing between
+    // pointer steps lets React commit and the rAF-throttled move handler flush,
+    // so the preview exists when mouseup commits it. Without the pauses a synthetic
+    // drag fires fast enough that mouseup sees a still-null preview and draws nothing.
+    private static readonly DRAW_STEP_DELAY_MS = 100;
+
+    private async pressDragThrough(points: { x: number; y: number }[]): Promise<void> {
+        const [first, ...rest] = points;
+        if (!first) {
+            throw new Error("A drag needs at least one point");
+        }
+        await this.page.mouse.move(first.x, first.y);
+        await this.page.mouse.down();
+        await this.page.waitForTimeout(EditorPage.DRAW_STEP_DELAY_MS);
+        for (const point of rest) {
+            await this.page.mouse.move(point.x, point.y, { steps: 5 });
+            await this.page.waitForTimeout(EditorPage.DRAW_STEP_DELAY_MS);
+        }
+        await this.page.mouse.up();
+    }
+
+    /** Press-drag from one Konva point to another to draw a rect/circle/line/arrow. */
+    async drawBox(fromX: number, fromY: number, toX: number, toY: number): Promise<void> {
+        await this.waitForEditorReady();
+        const box = await this.canvasBox();
+        const from = await this.toPagePoint(box, fromX, fromY);
+        const to = await this.toPagePoint(box, toX, toY);
+        // The midpoint keeps the rAF-throttled preview tracking before the final corner.
+        await this.pressDragThrough([from, { x: (from.x + to.x) / 2, y: (from.y + to.y) / 2 }, to]);
+    }
+
+    /** Press-drag through a list of Konva points to draw a freehand stroke. */
+    async drawFreehand(points: [number, number][]): Promise<void> {
+        await this.waitForEditorReady();
+        const box = await this.canvasBox();
+        const pagePoints: { x: number; y: number }[] = [];
+        for (const [konvaX, konvaY] of points) {
+            pagePoints.push(await this.toPagePoint(box, konvaX, konvaY));
+        }
+        await this.pressDragThrough(pagePoints);
+    }
+
+    /** Count Konva nodes of a given className (e.g. "Rect", "Circle", "Line") across the stage. */
+    async countKonvaShapes(className: string): Promise<number> {
+        return this.page.evaluate((cn) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const stage = (globalThis as any).Konva?.stages?.[0];
+            if (!stage) {
+                throw new Error("No Konva stage found");
+            }
+            return stage.find(cn).length;
+        }, className);
+    }
+
+    async getStageScale(): Promise<number> {
+        return this.page.evaluate(() => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const stage = (globalThis as any).Konva?.stages?.[0];
+            if (!stage) {
+                throw new Error("No Konva stage found");
+            }
+            return stage.scaleX();
+        });
+    }
+
+    async zoomIn(ticks = 3): Promise<void> {
+        const box = await this.canvasBox();
+        await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        for (let i = 0; i < ticks; i++) {
+            await this.page.mouse.wheel(0, -120);
+        }
     }
 
     async addCommunication(): Promise<void> {

--- a/apps/frontend/playwright/pages/editor.page.ts
+++ b/apps/frontend/playwright/pages/editor.page.ts
@@ -204,6 +204,11 @@ export class EditorPage extends BasePage {
         return this.page.getByRole("button", { name, exact: true });
     }
 
+    // Color picker preset chips are labelled by their hex value (e.g. "#e74c3c").
+    colorPresetChip(hex: string): Locator {
+        return this.page.getByRole("button", { name: hex });
+    }
+
     async selectShapeTool(name: string): Promise<void> {
         await this.shapesButton.click();
         await this.shapeToolButton(name).click();

--- a/apps/frontend/playwright/tests/editor-drawing.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/editor-drawing.page.e2e.spec.ts
@@ -178,7 +178,7 @@ test.describe("Editor Drawing Tests", () => {
             await pg.clickCanvas(570, 430);
             await expect(pg.deleteAnnotationButton).toBeVisible();
 
-            const redChip = page.getByRole("button", { name: "#e74c3c" });
+            const redChip = pg.colorPresetChip("#e74c3c");
             await expect(redChip).toHaveAttribute("aria-pressed", "false");
             await redChip.click();
             await expect(redChip).toHaveAttribute("aria-pressed", "true");

--- a/apps/frontend/playwright/tests/editor-drawing.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/editor-drawing.page.e2e.spec.ts
@@ -60,11 +60,8 @@ test.afterEach(async ({ page, request }) => {
     }
 });
 
-// The sample project places its components around Konva coordinates
-// Users (465, 305), Client (810, 305) and Server (810, 545). The region between
-// Users and Client and below their connection (x ≈ 490–650, y ≈ 420–520) is empty
-// and well inside the viewport, so annotations drawn there don't overlap any
-// component, label or connection.
+// Draw in the empty area between the components (Konva x ≈ 490–650, y ≈ 420–520)
+// so annotations don't overlap any component, label or connection.
 
 test.describe("Editor Drawing Tests", () => {
     test.describe("Toolbar Button Tests", () => {
@@ -101,12 +98,10 @@ test.describe("Editor Drawing Tests", () => {
 
             await pg.shapeToolButton("Rectangle").click();
             await expect(pg.shapesButton).toHaveAttribute("aria-pressed", "true");
-            // Selecting a shape closes the sub-toolbar.
             await expect(pg.shapeToolButton("Rectangle")).toHaveCount(0);
         });
 
-        // The pencil and text buttons' clickable-and-functional behaviour (including
-        // toggling off) is covered by the freehand and text drawing tests below.
+        // Pencil/text button behaviour (incl. toggling off) is covered by the freehand and text tests below.
     });
 
     test.describe("Shape Drawing Tests", () => {
@@ -119,8 +114,7 @@ test.describe("Editor Drawing Tests", () => {
         }
         const BOX_SHAPES: BoxShape[] = [
             { tool: "Rectangle", className: "Rect", from: [490, 430], to: [650, 510], selectAt: [570, 430] },
-            // Click a 45° point on the ring — the stroke-only circle has no fill to hit,
-            // and the exact top tangent is too thin a target to land reliably.
+            // Click a 45° ring point — the stroke-only circle has no fill and the top tangent is too thin to hit reliably.
             { tool: "Circle", className: "Circle", from: [490, 420], to: [620, 550], selectAt: [601, 439] },
             { tool: "Line", className: "Line", from: [490, 440], to: [650, 510], selectAt: [570, 475] },
             { tool: "Arrow", className: "Arrow", from: [490, 440], to: [650, 510], selectAt: [570, 475] },

--- a/apps/frontend/playwright/tests/editor-drawing.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/editor-drawing.page.e2e.spec.ts
@@ -1,0 +1,231 @@
+import { test, expect } from "@playwright/test";
+import type { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { getProjects, importProject, deleteProject } from "../utils/project.api.ts";
+import { deleteCatalog } from "../utils/catalog.api.ts";
+import { buildTestId } from "../builder/test-data.builder.ts";
+import { EditorPage } from "../pages/editor.page.ts";
+import threatsFixture from "../fixtures/threats.json" with { type: "json" };
+
+type ExportedProject = typeof threatsFixture.project;
+let exportedProject: ExportedProject;
+let projectId: number | undefined;
+let catalogId: number | undefined;
+let projectName: string | undefined;
+
+test.beforeAll(() => {
+    exportedProject = {
+        ...threatsFixture.project,
+        project: {
+            ...threatsFixture.project.project,
+            role: threatsFixture.project.project.role as USER_ROLES,
+        },
+    };
+});
+
+test.beforeEach(async ({ page, request, browserName }, { testId }) => {
+    projectId = undefined;
+    catalogId = undefined;
+    projectName = undefined;
+
+    const pg = new EditorPage(page);
+    await page.goto("/projects");
+    const token = await pg.getCsrfToken();
+    const tid = buildTestId(browserName, testId);
+    const projectData = structuredClone(exportedProject);
+    projectName = `${exportedProject.project.name} ${tid}`;
+    projectData.project.name = projectName;
+    projectData.catalog.name = `${exportedProject.catalog.name} ${tid}`;
+    await importProject(request, token, projectData);
+    const projects = await getProjects(request, token);
+    const project = projects.find((p) => p.name === projectName);
+    if (!project) {
+        throw new Error(`Project "${projectName}" not found after import`);
+    }
+    projectId = project.id;
+    catalogId = project.catalogId;
+    await pg.goto(projectId);
+});
+
+test.afterEach(async ({ page, request }) => {
+    const token = await new EditorPage(page).getCsrfToken();
+    const projects = await getProjects(request, token);
+    const project = projects.find((p) => p.id === projectId || p.name === projectName);
+    if (project) {
+        await deleteProject(request, token, project.id);
+    }
+    const remaining = await getProjects(request, token);
+    const stillUsed = remaining.some((p) => p.catalogId === catalogId);
+    if (catalogId && !stillUsed) {
+        await deleteCatalog(request, token, catalogId);
+    }
+});
+
+// The sample project places its components around Konva coordinates
+// Users (465, 305), Client (810, 305) and Server (810, 545). The region between
+// Users and Client and below their connection (x ≈ 490–650, y ≈ 420–520) is empty
+// and well inside the viewport, so annotations drawn there don't overlap any
+// component, label or connection.
+
+test.describe("Editor Drawing Tests", () => {
+    test.describe("Toolbar Button Tests", () => {
+        test("re-centers the editor with the center button", async ({ page }) => {
+            const pg = new EditorPage(page);
+            await pg.waitForEditorReady();
+
+            const fitted = await pg.getStageScale();
+            await pg.zoomIn();
+            expect(await pg.getStageScale()).toBeGreaterThan(fitted);
+
+            await pg.centerEditorButton.click();
+            await expect.poll(() => pg.getStageScale()).toBeCloseTo(fitted, 3);
+        });
+
+        test("exports the system view as a PNG image", async ({ page }) => {
+            const pg = new EditorPage(page);
+            await pg.waitForEditorReady();
+
+            const downloadPromise = page.waitForEvent("download");
+            await pg.exportSystemImageButton.click();
+            const download = await downloadPromise;
+            expect(download.suggestedFilename()).toBe("systemView.png");
+        });
+
+        test("opens the shapes sub-toolbar and activates a shape", async ({ page }) => {
+            const pg = new EditorPage(page);
+            await pg.waitForEditorReady();
+
+            await pg.shapesButton.click();
+            for (const name of ["Rectangle", "Circle", "Line", "Arrow"]) {
+                await expect(pg.shapeToolButton(name)).toBeVisible();
+            }
+
+            await pg.shapeToolButton("Rectangle").click();
+            await expect(pg.shapesButton).toHaveAttribute("aria-pressed", "true");
+            // Selecting a shape closes the sub-toolbar.
+            await expect(pg.shapeToolButton("Rectangle")).toHaveCount(0);
+        });
+
+        // The pencil and text buttons' clickable-and-functional behaviour (including
+        // toggling off) is covered by the freehand and text drawing tests below.
+    });
+
+    test.describe("Shape Drawing Tests", () => {
+        interface BoxShape {
+            tool: string;
+            className: string;
+            from: [number, number];
+            to: [number, number];
+            selectAt: [number, number];
+        }
+        const BOX_SHAPES: BoxShape[] = [
+            { tool: "Rectangle", className: "Rect", from: [490, 430], to: [650, 510], selectAt: [570, 430] },
+            // Click a 45° point on the ring — the stroke-only circle has no fill to hit,
+            // and the exact top tangent is too thin a target to land reliably.
+            { tool: "Circle", className: "Circle", from: [490, 420], to: [620, 550], selectAt: [601, 439] },
+            { tool: "Line", className: "Line", from: [490, 440], to: [650, 510], selectAt: [570, 475] },
+            { tool: "Arrow", className: "Arrow", from: [490, 440], to: [650, 510], selectAt: [570, 475] },
+        ];
+
+        for (const shape of BOX_SHAPES) {
+            test(`draws a ${shape.tool} and deletes it`, async ({ page }) => {
+                const pg = new EditorPage(page);
+                await pg.waitForEditorReady();
+
+                const before = await pg.countKonvaShapes(shape.className);
+
+                await pg.selectShapeTool(shape.tool);
+                await expect(pg.shapesButton).toHaveAttribute("aria-pressed", "true");
+
+                await pg.drawBox(...shape.from, ...shape.to);
+                await expect.poll(() => pg.countKonvaShapes(shape.className)).toBe(before + 1);
+
+                await pg.clickCanvas(...shape.selectAt);
+                await expect(pg.deleteAnnotationButton).toBeVisible();
+                await pg.deleteAnnotationButton.click();
+
+                await expect.poll(() => pg.countKonvaShapes(shape.className)).toBe(before);
+            });
+        }
+
+        test("draws a freehand stroke with the pencil and deletes it", async ({ page }) => {
+            const pg = new EditorPage(page);
+            await pg.waitForEditorReady();
+
+            const before = await pg.countKonvaShapes("Line");
+
+            await pg.pencilButton.click();
+            await expect(pg.pencilButton).toHaveAttribute("aria-pressed", "true");
+
+            await pg.drawFreehand([
+                [490, 440],
+                [540, 460],
+                [590, 440],
+                [640, 470],
+            ]);
+            await expect.poll(() => pg.countKonvaShapes("Line")).toBe(before + 1);
+
+            // The pencil stays active after drawing — switch it off before selecting.
+            await pg.pencilButton.click();
+            await expect(pg.pencilButton).toHaveAttribute("aria-pressed", "false");
+
+            await pg.clickCanvas(540, 460);
+            await expect(pg.deleteAnnotationButton).toBeVisible();
+            await pg.deleteAnnotationButton.click();
+
+            await expect.poll(() => pg.countKonvaShapes("Line")).toBe(before);
+        });
+
+        test("changes a shape's colour from the sidebar", async ({ page }) => {
+            const pg = new EditorPage(page);
+            await pg.waitForEditorReady();
+
+            await pg.selectShapeTool("Rectangle");
+            await pg.drawBox(490, 430, 650, 510);
+            await pg.clickCanvas(570, 430);
+            await expect(pg.deleteAnnotationButton).toBeVisible();
+
+            const redChip = page.getByRole("button", { name: "#e74c3c" });
+            await expect(redChip).toHaveAttribute("aria-pressed", "false");
+            await redChip.click();
+            await expect(redChip).toHaveAttribute("aria-pressed", "true");
+        });
+    });
+
+    test.describe("Text Annotation Tests", () => {
+        test("adds a text box, types into it, and deletes it", async ({ page }) => {
+            const pg = new EditorPage(page);
+            await pg.waitForEditorReady();
+
+            const before = await pg.countKonvaShapes("Text");
+
+            await pg.textToolButton.click();
+            await expect(pg.textToolButton).toHaveAttribute("aria-pressed", "true");
+
+            await pg.drawBox(490, 440, 640, 490);
+            // Text auto-enters edit mode: the inline editor receives focus.
+            await expect(pg.annotationTextarea).toBeFocused();
+            await pg.annotationTextarea.fill("Custom remark");
+            await expect(pg.annotationTextarea).toHaveValue("Custom remark");
+            await expect.poll(() => pg.countKonvaShapes("Text")).toBe(before + 1);
+
+            const deleteText = pg.textEditingToolbar.getByRole("button", { name: "Delete annotation" });
+            await deleteText.click();
+            await expect.poll(() => pg.countKonvaShapes("Text")).toBe(before);
+        });
+
+        test("applies bold formatting to a text annotation", async ({ page }) => {
+            const pg = new EditorPage(page);
+            await pg.waitForEditorReady();
+
+            await pg.textToolButton.click();
+            await pg.drawBox(490, 440, 640, 490);
+            await expect(pg.annotationTextarea).toBeFocused();
+            await pg.annotationTextarea.fill("Bold remark");
+
+            const bold = pg.textEditingToolbar.getByRole("button", { name: "Bold" });
+            await expect(bold).toHaveAttribute("aria-pressed", "false");
+            await bold.click();
+            await expect(bold).toHaveAttribute("aria-pressed", "true");
+        });
+    });
+});

--- a/apps/frontend/playwright/tests/editor-drawing.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/editor-drawing.page.e2e.spec.ts
@@ -55,7 +55,7 @@ test.afterEach(async ({ page, request }) => {
     }
     const remaining = await getProjects(request, token);
     const stillUsed = remaining.some((p) => p.catalogId === catalogId);
-    if (catalogId && !stillUsed) {
+    if (catalogId !== undefined && !stillUsed) {
         await deleteCatalog(request, token, catalogId);
     }
 });


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  Adds Playwright E2E coverage for the system editor's drawing toolbar, closing #817.                                                                                                                            
                                                                                                                                                                                                                 
  ## Covered                                                                                                                                                                                                     
  - **Toolbar:** center editor, PNG export, nested shapes sub-toolbar                                                                                                                                            
  - **Draw + delete:** rectangle, circle, line, arrow, freehand, text box                                                                                                                                        
  - **Formatting (#595):** shape colour picker, bold text                                                                                                                                                        
                                                                                                                                                                                                                 
  ## Notes                                                                                                                                                                                                       
  - Drives the Konva canvas via pointer press-drags; controls located by i18n `aria-label`s (no app source changes).                                                                                             
  - Creation/deletion verified via Konva node-count deltas; text via the inline `<textarea>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new end-to-end coverage for the editor drawing experience, validating toolbar actions (center re-centering, PNG export download name, shapes sub-toolbar activation, delete), drawing flows for rectangle/circle/line/arrow with element count checks, freehand pencil strokes and deletion, and text annotation creation/editing/deletion (including bold formatting).
  * Enhanced editor drawing test utilities for more reliable canvas interactions and shape verification, including zoom/press-drag based drawing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->