### PR TITLE
feat(dialogs): show threat/measure name in edit dialog title

### DIFF
--- a/apps/frontend/src/translations/de/common.de.json
+++ b/apps/frontend/src/translations/de/common.de.json
@@ -10,6 +10,7 @@
   "copy": "Maßnahme duplizieren",
   "deleteMeasureText": "Wollen Sie wirklich die Maßnahme '{{ measureName }}' löschen?",
   "editMeasure": "Maßnahme bearbeiten",
+  "editMeasureWithName": "Maßnahme bearbeiten: {{ name }}",
   "measure": "Maßnahme",
   "measures": "Maßnahmen",
   "scheduledTooltip": "Geplante Maßnahme",
@@ -22,6 +23,7 @@
 
   "addThreatBtn": "Bedrohung hinzufügen",
   "editThreat": "Bedrohung bearbeiten",
+  "editThreatWithName": "Bedrohung bearbeiten: {{ name }}",
   "threat": "Bedrohung",
   "threats": "Bedrohungen",
 

--- a/apps/frontend/src/translations/en/common.en.json
+++ b/apps/frontend/src/translations/en/common.en.json
@@ -9,6 +9,7 @@
   "copy": "Duplicate Measure",
   "deleteMeasureText": "Do you really want to delete the measure '{{ measureName }}'?",
   "editMeasure": "Edit Measure",
+  "editMeasureWithName": "Edit Measure: {{ name }}",
   "measure": "Measure",
   "measures": "Measures",
   "reset": "Reset Measure",
@@ -21,6 +22,7 @@
 
   "addThreatBtn": "Add Threat",
   "editThreat": "Edit Threat",
+  "editThreatWithName": "Edit Threat: {{ name }}",
   "threat": "Threat",
   "threats": "Threats",
 

--- a/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.tsx
@@ -211,7 +211,7 @@ const AddThreatDialog = ({ threat, project, userRole, ...props }: AddThreatDialo
                     fontWeight: "bold",
                 }}
             >
-                {t("editThreat")}
+                {t("editThreatWithName", { name: threat.name })}
             </DialogTitle>
             <List>
                 <ListItem>

--- a/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
@@ -214,7 +214,7 @@ const MeasureDetailsDialog = ({ project, measure, ...props }: MeasureDetailsDial
                     fontWeight: "bold",
                 }}
             >
-                {isNew ? t("addMeasure") : t("editMeasure")}
+                {isNew ? t("addMeasure") : t("editMeasureWithName", { name: measure.name })}
             </DialogTitle>
             <Tabs onChange={handleChangeTab} value={tab} sx={{ marginBottom: 1 }}>
                 <Tab


### PR DESCRIPTION
## Summary
  Resolves #731

  - Show the threat/measure name in the edit-dialog title so it stays visible on every tab (Assets, Measures, Threats), not just the main tab where the  name field lives.
  - Helps users keep track of which item they're editing during mass edits.
  
  ### Screenshots
  
<img width="950" height="405" alt="edit-measure-with-title" src="https://github.com/user-attachments/assets/a2bdac53-bdee-4509-994c-71ffdb2a8bb9" />
<img width="953" height="483" alt="edit-threat-with-title" src="https://github.com/user-attachments/assets/ddb21d5a-ab0f-419b-babe-e22e5c69f2c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When editing threats or measures, the dialog title now prominently displays the specific item name for clearer context and improved user awareness of exactly what is being modified.

* **Localization**
  * Added and updated German and English translation strings to support the enhanced dialog titles that now include the names of threats and measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->