### PR TITLE
feat(projects): add project actions menu to the in-project header

### DIFF
--- a/apps/frontend/src/application/middlewares/system/system.middleware.test.ts
+++ b/apps/frontend/src/application/middlewares/system/system.middleware.test.ts
@@ -67,6 +67,45 @@ describe("system.middleware — handleSaveSystem", () => {
     });
 });
 
+describe("system.middleware — handleSaveSystem skips a project being deleted", () => {
+    let updateSystemSpy: MockInstance;
+
+    const buildState = (role: USER_ROLES, deletingProjectId: number | undefined) => {
+        const base = projectsReducer(undefined, { type: "@@INIT" });
+        return { ...base, current: { role } as ProjectsState["current"], deletingProjectId };
+    };
+
+    beforeEach(() => {
+        updateSystemSpy = vi.spyOn(SystemAPI, "updateSystem").mockResolvedValue({
+            id: 1,
+            projectId: 1,
+            data: null,
+            image: null,
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("does not dispatch updateSystem when the saved project is the one being deleted", async () => {
+        const store = createStore({ projects: buildState(USER_ROLES.EDITOR, 1) });
+        store.dispatch(SystemActions.saveSystem({ projectId: 1, image: undefined }));
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(updateSystemSpy).not.toHaveBeenCalled();
+    });
+
+    it("still dispatches updateSystem when a different project is being deleted", async () => {
+        const store = createStore({ projects: buildState(USER_ROLES.EDITOR, 99) });
+        store.dispatch(SystemActions.saveSystem({ projectId: 1, image: undefined }));
+
+        await vi.waitFor(() => expect(updateSystemSpy).toHaveBeenCalledTimes(1));
+    });
+});
+
 describe("system.middleware — getSystem awaits in-flight save", () => {
     const systemResponse = { id: 1, projectId: 1, data: null, image: null };
     let getSystemSpy: MockInstance;

--- a/apps/frontend/src/application/middlewares/system/system.middleware.ts
+++ b/apps/frontend/src/application/middlewares/system/system.middleware.ts
@@ -20,6 +20,9 @@ const handleSaveSystem: AppMiddleware =
             SystemActions.saveSystem.match(action)
         ) {
             const { projectId, image } = action.payload;
+            if (getState().projects.deletingProjectId === projectId) {
+                return;
+            }
             const { system, editor } = getState();
             const {
                 id,

--- a/apps/frontend/src/application/reducers/projects.reducer.test.ts
+++ b/apps/frontend/src/application/reducers/projects.reducer.test.ts
@@ -1,0 +1,149 @@
+import projectsReducer from "./projects.reducer";
+import { ProjectsActions } from "#application/actions/projects.actions.ts";
+import { createProject } from "#test-utils/builders.ts";
+
+const getInitialState = () => projectsReducer(undefined, { type: "@@INIT" });
+
+const withEntities = (...projects: ReturnType<typeof createProject>[]) =>
+    projectsReducer(getInitialState(), ProjectsActions.getProjects.fulfilled(projects, "req", undefined));
+
+describe("projectsReducer — deletingProjectId lifecycle", () => {
+    describe("initial state", () => {
+        it("has deletingProjectId undefined", () => {
+            expect(getInitialState().deletingProjectId).toBeUndefined();
+        });
+
+        it("has no current project", () => {
+            expect(getInitialState().current).toBeUndefined();
+        });
+    });
+
+    describe("deleteProject.pending", () => {
+        it("marks the project being deleted by its id", () => {
+            const project = createProject({ id: 7 });
+            const next = projectsReducer(getInitialState(), ProjectsActions.deleteProject.pending("req", project));
+
+            expect(next.deletingProjectId).toBe(7);
+        });
+    });
+
+    describe("deleteProject.rejected", () => {
+        it("clears the marker when the rejected delete is the one in flight", () => {
+            const project = createProject({ id: 7 });
+            const pending = projectsReducer(getInitialState(), ProjectsActions.deleteProject.pending("req", project));
+
+            const next = projectsReducer(
+                pending,
+                ProjectsActions.deleteProject.rejected(new Error("nope"), "req", project)
+            );
+
+            expect(next.deletingProjectId).toBeUndefined();
+        });
+
+        it("leaves the marker untouched when a different project's delete rejects", () => {
+            const deleting = createProject({ id: 7 });
+            const other = createProject({ id: 9 });
+            const pending = projectsReducer(getInitialState(), ProjectsActions.deleteProject.pending("req", deleting));
+
+            const next = projectsReducer(
+                pending,
+                ProjectsActions.deleteProject.rejected(new Error("nope"), "req", other)
+            );
+
+            expect(next.deletingProjectId).toBe(7);
+        });
+    });
+
+    describe("getProjectFromBackend.fulfilled", () => {
+        it("sets the fetched project as current and clears the deletion marker", () => {
+            const project = createProject({ id: 3, name: "Fetched" });
+            const next = projectsReducer(
+                getInitialState(),
+                ProjectsActions.getProjectFromBackend.fulfilled(project, "req", project.id)
+            );
+
+            expect(next.current).toEqual(project);
+            expect(next.deletingProjectId).toBeUndefined();
+            expect(next.isPending).toBe(false);
+        });
+
+        it("clears a stale marker for a different project when another project is loaded", () => {
+            const deleting = createProject({ id: 7 });
+            const opened = createProject({ id: 3, name: "Opened" });
+            const pending = projectsReducer(getInitialState(), ProjectsActions.deleteProject.pending("req", deleting));
+
+            const next = projectsReducer(
+                pending,
+                ProjectsActions.getProjectFromBackend.fulfilled(opened, "req", opened.id)
+            );
+
+            expect(next.current).toEqual(opened);
+            expect(next.deletingProjectId).toBeUndefined();
+        });
+
+        it("ignores a late fetch for the project being deleted (does not resurrect it as current)", () => {
+            const project = createProject({ id: 7 });
+            const pending = projectsReducer(getInitialState(), ProjectsActions.deleteProject.pending("req", project));
+
+            const next = projectsReducer(
+                pending,
+                ProjectsActions.getProjectFromBackend.fulfilled(project, "req", project.id)
+            );
+
+            expect(next.current).toBeUndefined();
+            expect(next.deletingProjectId).toBe(7);
+            expect(next.isPending).toBe(false);
+        });
+    });
+
+    describe("getProjectFromRedux", () => {
+        it("sets the current project from the store and clears the marker for a different project", () => {
+            const deleting = createProject({ id: 7 });
+            const opened = createProject({ id: 3, name: "Opened" });
+            let state = withEntities(deleting, opened);
+            state = projectsReducer(state, ProjectsActions.deleteProject.pending("req", deleting));
+
+            const next = projectsReducer(state, ProjectsActions.getProjectFromRedux(3));
+
+            expect(next.current).toEqual(opened);
+            expect(next.deletingProjectId).toBeUndefined();
+        });
+
+        it("keeps the marker when the requested project is the one being deleted", () => {
+            const deleting = createProject({ id: 7 });
+            let state = withEntities(deleting);
+            state = projectsReducer(state, ProjectsActions.deleteProject.pending("req", deleting));
+
+            const next = projectsReducer(state, ProjectsActions.getProjectFromRedux(7));
+
+            expect(next.current).toEqual(deleting);
+            expect(next.deletingProjectId).toBe(7);
+        });
+    });
+
+    describe("removeProject", () => {
+        it("drops the current project when the removed one was open", () => {
+            const open = createProject({ id: 7 });
+            let state = withEntities(open);
+            state = projectsReducer(state, ProjectsActions.getProjectFromRedux(7));
+
+            const next = projectsReducer(state, ProjectsActions.removeProject(open));
+
+            expect(next.current).toBeUndefined();
+            expect(next.entities[7]).toBeUndefined();
+        });
+
+        it("keeps the current project when a different one is removed", () => {
+            const open = createProject({ id: 7 });
+            const other = createProject({ id: 3 });
+            let state = withEntities(open, other);
+            state = projectsReducer(state, ProjectsActions.getProjectFromRedux(7));
+
+            const next = projectsReducer(state, ProjectsActions.removeProject(other));
+
+            expect(next.current).toEqual(open);
+            expect(next.entities[3]).toBeUndefined();
+            expect(next.entities[7]).toBeDefined();
+        });
+    });
+});

--- a/apps/frontend/src/application/reducers/projects.reducer.ts
+++ b/apps/frontend/src/application/reducers/projects.reducer.ts
@@ -38,11 +38,12 @@ const projectsReducer = createReducer(defaultState, (builder) => {
     });
 
     builder.addCase(ProjectsActions.getProjectFromBackend.fulfilled, (state, action) => {
-        state.current = action.payload;
         state.isPending = false;
-        if (state.deletingProjectId !== action.payload.id) {
-            state.deletingProjectId = undefined;
+        if (state.deletingProjectId === action.payload?.id) {
+            return;
         }
+        state.current = action.payload;
+        state.deletingProjectId = undefined;
     });
 
     builder.addCase(ProjectsActions.getProjectFromBackend.rejected, (state) => {
@@ -90,6 +91,9 @@ const projectsReducer = createReducer(defaultState, (builder) => {
     builder.addCase(ProjectsActions.removeProject, (state, action) => {
         projectsAdapter.removeOne(state, action.payload.id);
         state.isPending = false;
+        if (state.current?.id === action.payload.id) {
+            state.current = undefined;
+        }
     });
 
     builder.addCase(ProjectsActions.changeOwnProjectRole, (state, action) => {

--- a/apps/frontend/src/application/reducers/projects.reducer.ts
+++ b/apps/frontend/src/application/reducers/projects.reducer.ts
@@ -9,12 +9,14 @@ type ProjectsAdapterState = ReturnType<typeof projectsAdapter.getInitialState>;
 export type ProjectsState = ProjectsAdapterState & {
     isPending: boolean;
     current: ExtendedProject | undefined;
+    deletingProjectId: number | undefined;
 };
 
 const defaultState: ProjectsState = {
     ...projectsAdapter.getInitialState(),
     isPending: false,
     current: undefined,
+    deletingProjectId: undefined,
 };
 
 const projectsReducer = createReducer(defaultState, (builder) => {
@@ -38,10 +40,25 @@ const projectsReducer = createReducer(defaultState, (builder) => {
     builder.addCase(ProjectsActions.getProjectFromBackend.fulfilled, (state, action) => {
         state.current = action.payload;
         state.isPending = false;
+        if (state.deletingProjectId !== action.payload.id) {
+            state.deletingProjectId = undefined;
+        }
     });
 
     builder.addCase(ProjectsActions.getProjectFromBackend.rejected, (state) => {
         state.isPending = false;
+    });
+
+    // Marks a project as being deleted so the editor's lazy/Suspense teardown skips saving/refetching
+    // it. Not cleared on `fulfilled` (teardown can fire after the project leaves the store)
+    builder.addCase(ProjectsActions.deleteProject.pending, (state, action) => {
+        state.deletingProjectId = action.meta.arg.id;
+    });
+
+    builder.addCase(ProjectsActions.deleteProject.rejected, (state, action) => {
+        if (state.deletingProjectId === action.meta.arg.id) {
+            state.deletingProjectId = undefined;
+        }
     });
 
     builder.addCase(ProjectsActions.createProject.pending, (state) => {
@@ -54,6 +71,9 @@ const projectsReducer = createReducer(defaultState, (builder) => {
 
     builder.addCase(ProjectsActions.getProjectFromRedux, (state, action) => {
         state.current = state.entities[action.payload];
+        if (state.deletingProjectId !== action.payload) {
+            state.deletingProjectId = undefined;
+        }
     });
 
     builder.addCase(ProjectsActions.setProject, (state, action) => {

--- a/apps/frontend/src/test-utils/mock-hooks.ts
+++ b/apps/frontend/src/test-utils/mock-hooks.ts
@@ -9,6 +9,7 @@ import * as threatsHook from "#application/hooks/use-threats.hook.ts";
 import * as measuresHook from "#application/hooks/use-measures.hook.ts";
 import * as measureImpactsHook from "#application/hooks/use-measureImpacts.hook.ts";
 import * as catalogMeasuresHook from "#application/hooks/use-catalog-measures.hook.ts";
+import * as projectExportHook from "#application/hooks/use-export.hook.ts";
 
 /**
  * @module mock-hooks - Reusable hook spies.
@@ -33,6 +34,7 @@ type UseThreatsResult = ReturnType<typeof threatsHook.useThreats>;
 type UseMeasuresResult = ReturnType<typeof measuresHook.useMeasures>;
 type UseMeasureImpactsResult = ReturnType<typeof measureImpactsHook.useMeasureImpacts>;
 type UseCatalogMeasuresResult = ReturnType<typeof catalogMeasuresHook.useCatalogMeasures>;
+type UseProjectExportResult = ReturnType<typeof projectExportHook.useProjectExport>;
 
 export const mockUseDialog = (config?: Partial<UseDialogResult>): MockInstance => {
     return vi.spyOn(dialogHook, "useDialog").mockImplementation(() => ({
@@ -214,6 +216,13 @@ export const mockUseCatalogMeasures = (config?: Partial<UseCatalogMeasuresResult
         isPending: false,
         loadCatalogMeasures: vi.fn(),
         deleteCatalogMeasure: vi.fn(),
+        ...config,
+    }));
+};
+
+export const mockUseProjectExport = (config?: Partial<UseProjectExportResult>): MockInstance => {
+    return vi.spyOn(projectExportHook, "useProjectExport").mockImplementation(() => ({
+        exportProject: vi.fn(),
         ...config,
     }));
 };

--- a/apps/frontend/src/view/components/create-page.component.test.tsx
+++ b/apps/frontend/src/view/components/create-page.component.test.tsx
@@ -1,0 +1,156 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { MouseEvent } from "react";
+import type { ExtendedProject } from "#api/types/project.types.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { ProjectsActions } from "#application/actions/projects.actions.ts";
+import projectsReducer from "#application/reducers/projects.reducer.ts";
+import { navigationReducer } from "#application/reducers/navigation.reducer.ts";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { translationUtil } from "#utils/translations.ts";
+import { createProject } from "#test-utils/builders.ts";
+import { mockUseConfirm } from "#test-utils/mock-hooks.ts";
+
+// Importing the real #main.tsx bootstraps the whole app (createStore + ReactDOM render).
+// The layout effect only reads this global store, so a minimal stub is enough.
+vi.mock("#main.tsx", () => ({
+    store: { getState: () => ({ projects: { deletingProjectId: undefined } }) },
+}));
+
+vi.mock("./header-level-one-nav.component", () => ({ HeaderLevelOneNav: () => null }));
+vi.mock("./header-project-tabs.component", () => ({ HeaderProjectTabs: () => null }));
+vi.mock("#view/pages/project-dialog.page.tsx", () => ({ default: () => null }));
+vi.mock("#application/hooks/use-project-tabs.hook.ts", () => ({ useProjectTabs: () => [] }));
+
+vi.mock("./project-actions-menu.component", () => ({
+    ProjectActionsMenu: ({
+        project,
+        onClickEditProject,
+        onClickDeleteProject,
+        testIdPrefix,
+    }: {
+        project: ExtendedProject;
+        onClickEditProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
+        onClickDeleteProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
+        testIdPrefix: string;
+    }) => (
+        <div data-testid="project-actions-menu-stub" data-prefix={testIdPrefix}>
+            <button onClick={(event) => onClickEditProject(event, project)}>header-edit</button>
+            <button onClick={(event) => onClickDeleteProject(event, project)}>header-delete</button>
+        </div>
+    ),
+}));
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react-router-dom")>();
+    return {
+        ...actual,
+        useNavigate: () => navigate,
+        Routes: () => null,
+    };
+});
+
+import { CreatePage } from "./create-page.component";
+
+const openConfirm = vi.fn();
+
+const HeaderRightSlot = () => null;
+const PageBody = () => <div data-testid="page-body" />;
+
+const setup = (
+    project: ExtendedProject | undefined,
+    { showProjectInfo = true }: { showProjectInfo?: boolean } = {}
+) => {
+    mockUseConfirm({ openConfirm });
+
+    const Page = CreatePage(HeaderRightSlot, PageBody);
+    const user = userEvent.setup();
+
+    renderWithProviders(<Page />, {
+        preloadedState: {
+            projects: { ...projectsReducer(undefined, { type: "@@INIT" }), current: project },
+            navigation: { ...navigationReducer(undefined, { type: "@@INIT" }), showProjectInfo },
+        },
+        initialEntries: ["/projects/1"],
+    });
+
+    return { user };
+};
+
+describe("CreatePage — project header actions", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("renders the actions menu for an owner", () => {
+        setup(createProject({ id: 1, role: USER_ROLES.OWNER }));
+
+        const menu = screen.getByTestId("project-actions-menu-stub");
+        expect(menu).toBeInTheDocument();
+        expect(menu).toHaveAttribute("data-prefix", "project-header_action-menu");
+    });
+
+    it("renders a plain edit button (not the menu) that edits the project for a non-owner", async () => {
+        const project = createProject({ id: 1, role: USER_ROLES.EDITOR });
+        const { user } = setup(project);
+
+        expect(screen.queryByTestId("project-actions-menu-stub")).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole("button"));
+
+        expect(navigate).toHaveBeenCalledWith("/projects/1/editProject", { state: { project } });
+    });
+
+    it("renders no project actions when the project info is hidden", () => {
+        setup(createProject({ id: 1, role: USER_ROLES.OWNER }), { showProjectInfo: false });
+
+        expect(screen.queryByTestId("project-actions-menu-stub")).not.toBeInTheDocument();
+        expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("navigates to the edit-project route with the project when edit is triggered", async () => {
+        const project = createProject({ id: 1, name: "Headered", role: USER_ROLES.OWNER });
+        const { user } = setup(project);
+
+        await user.click(screen.getByRole("button", { name: "header-edit" }));
+
+        expect(navigate).toHaveBeenCalledWith("/projects/1/editProject", { state: { project } });
+    });
+
+    it("opens a delete confirmation carrying the project and localized copy", async () => {
+        const project = createProject({ id: 1, name: "Doomed", role: USER_ROLES.OWNER });
+        const { user } = setup(project);
+
+        await user.click(screen.getByRole("button", { name: "header-delete" }));
+
+        expect(openConfirm).toHaveBeenCalledTimes(1);
+        const confirmArgs = openConfirm.mock.calls[0]![0];
+        expect(confirmArgs.state).toEqual(project);
+        expect(confirmArgs.message).toContain("Doomed");
+        expect(confirmArgs.acceptText).toBe(translationUtil.t("delete", { ns: "projectsPage" }));
+        expect(confirmArgs.cancelText).toBe(translationUtil.t("cancel", { ns: "projectsPage" }));
+        expect(typeof confirmArgs.onAccept).toBe("function");
+    });
+
+    it("deletes the project and leaves the page when the confirmation is accepted", async () => {
+        // Stub the thunk with an inert one: we assert the delete is dispatched for this
+        // project, without running its async lifecycle through the store.
+        const deleteProject = vi
+            .spyOn(ProjectsActions, "deleteProject")
+            .mockReturnValue((() => Promise.resolve()) as never);
+        const project = createProject({ id: 1, name: "Doomed", role: USER_ROLES.OWNER });
+        const { user } = setup(project);
+
+        await user.click(screen.getByRole("button", { name: "header-delete" }));
+        const confirmArgs = openConfirm.mock.calls[0]![0];
+        confirmArgs.onAccept(project);
+
+        expect(deleteProject).toHaveBeenCalledWith(project);
+        expect(navigate).toHaveBeenCalledWith("/projects");
+    });
+});

--- a/apps/frontend/src/view/components/create-page.component.tsx
+++ b/apps/frontend/src/view/components/create-page.component.tsx
@@ -373,9 +373,7 @@ export const CreatePage = <P extends object>(
                                                 onClickEditProject={handleEditProject}
                                                 onClickDeleteProject={handleDeleteProject}
                                                 testIdPrefix="project-header_action-menu"
-                                                triggerSize="medium"
-                                                triggerSx={{ ml: 1, color: "text.primary" }}
-                                                triggerIconSx={{ fontSize: "1rem" }}
+                                                variant="header"
                                             />
                                         ) : (
                                             <IconButton

--- a/apps/frontend/src/view/components/create-page.component.tsx
+++ b/apps/frontend/src/view/components/create-page.component.tsx
@@ -3,7 +3,7 @@ import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
 import SyncIcon from "@mui/icons-material/Sync";
 import { IconButton, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
-import { useLayoutEffect, useState, type ComponentType } from "react";
+import { useLayoutEffect, useState, type ComponentType, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppDispatch, useAppSelector } from "#application/hooks/use-app-redux.hook.ts";
 import { Link, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
@@ -17,8 +17,12 @@ import logo from "#images/threatsealogo-dez.png";
 import ErrorBoundary from "#view/wrappers/error.wrapper.tsx";
 import { useTheme } from "@mui/material/styles";
 import { useProjectTabs } from "#application/hooks/use-project-tabs.hook.ts";
+import { useConfirm } from "#application/hooks/use-confirm.hook.ts";
+import { checkUserRole, USER_ROLES } from "#api/types/user-roles.types.ts";
+import type { ExtendedProject } from "#api/types/project.types.ts";
 import { HeaderLevelOneNav } from "./header-level-one-nav.component";
 import { HeaderProjectTabs } from "./header-project-tabs.component";
+import { ProjectActionsMenu } from "./project-actions-menu.component";
 import ProjectDialogPage from "#view/pages/project-dialog.page.tsx";
 import { Edit } from "@mui/icons-material";
 
@@ -93,6 +97,10 @@ export const CreatePage = <P extends object>(
             if (showProjectInfo && projectId) {
                 const pid = parseInt(projectId);
 
+                if (store.getState().projects.deletingProjectId === pid) {
+                    return;
+                }
+
                 if (projectsSelectors.selectById(store.getState(), pid)) {
                     dispatch(ProjectsActions.getProjectFromRedux(pid));
                 } else {
@@ -112,15 +120,30 @@ export const CreatePage = <P extends object>(
         }, [showProjectInfo, projectId, dispatch, getCatalogInfo, catalogId, catalog?.id, currentProjectJSON]);
 
         const { t } = useTranslation("mainMenu");
+        const { t: tProjects } = useTranslation("projectsPage");
+        const { openConfirm } = useConfirm<ExtendedProject>();
         const footerLinks = [
             { url: "/imprint", text: t("imprint") },
             { url: "/privacy-policy", text: t("privacy") },
         ];
 
-        const handleProjectInfoClick = (event: React.MouseEvent) => {
+        const handleEditProject = (event: MouseEvent<HTMLElement>, projectToEdit: ExtendedProject) => {
             event.stopPropagation();
             navigate(`${pathname}/editProject`, {
-                state: { project },
+                state: { project: projectToEdit },
+            });
+        };
+
+        const handleDeleteProject = (_event: MouseEvent<HTMLElement>, projectToDelete: ExtendedProject) => {
+            openConfirm({
+                state: projectToDelete,
+                message: tProjects("deleteMessage", { projectName: projectToDelete.name }),
+                acceptText: tProjects("delete"),
+                cancelText: tProjects("cancel"),
+                onAccept: (confirmedProject) => {
+                    dispatch(ProjectsActions.deleteProject(confirmedProject));
+                    navigate("/projects");
+                },
             });
         };
 
@@ -343,19 +366,32 @@ export const CreatePage = <P extends object>(
                                             ? new Date(project.createdAt).toISOString().split("T")[0]
                                             : ""}
                                     </Typography>
-                                    <IconButton
-                                        onClick={(event) => handleProjectInfoClick(event)}
-                                        sx={{
-                                            ml: 1,
-                                            "&:hover": {
-                                                color: "secondary.main",
-                                            },
-                                            color: "text.primary",
-                                            fontSize: "1rem",
-                                        }}
-                                    >
-                                        <Edit sx={{ fontSize: "1rem" }} />
-                                    </IconButton>
+                                    {project &&
+                                        (checkUserRole(project.role, USER_ROLES.OWNER) ? (
+                                            <ProjectActionsMenu
+                                                project={project}
+                                                onClickEditProject={handleEditProject}
+                                                onClickDeleteProject={handleDeleteProject}
+                                                testIdPrefix="project-header_action-menu"
+                                                triggerSize="medium"
+                                                triggerSx={{ ml: 1, color: "text.primary" }}
+                                                triggerIconSx={{ fontSize: "1rem" }}
+                                            />
+                                        ) : (
+                                            <IconButton
+                                                onClick={(event) => handleEditProject(event, project)}
+                                                sx={{
+                                                    ml: 1,
+                                                    "&:hover": {
+                                                        color: "secondary.main",
+                                                    },
+                                                    color: "text.primary",
+                                                    fontSize: "1rem",
+                                                }}
+                                            >
+                                                <Edit sx={{ fontSize: "1rem" }} />
+                                            </IconButton>
+                                        ))}
                                 </Box>
                             </Box>
                         )}

--- a/apps/frontend/src/view/components/project-actions-menu.component.test.tsx
+++ b/apps/frontend/src/view/components/project-actions-menu.component.test.tsx
@@ -1,0 +1,130 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createProject } from "#test-utils/builders.ts";
+import { mockUseProjectExport } from "#test-utils/mock-hooks.ts";
+import { ProjectActionsMenu } from "./project-actions-menu.component";
+
+const TEST_ID_PREFIX = "test-menu";
+const triggerId = `${TEST_ID_PREFIX}-button`;
+const editItemId = `${TEST_ID_PREFIX}_edit-project-button`;
+const exportItemId = `${TEST_ID_PREFIX}_export-project-button`;
+const deleteItemId = `${TEST_ID_PREFIX}_delete-project-button`;
+
+const exportProject = vi.fn();
+mockUseProjectExport({ exportProject });
+
+const setup = (props: Partial<React.ComponentProps<typeof ProjectActionsMenu>> = {}) => {
+    const project = createProject({ id: 7, name: "Test Project" });
+    const onClickEditProject = vi.fn();
+    const onClickDeleteProject = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+        <ProjectActionsMenu
+            project={project}
+            onClickEditProject={onClickEditProject}
+            onClickDeleteProject={onClickDeleteProject}
+            testIdPrefix={TEST_ID_PREFIX}
+            {...props}
+        />
+    );
+
+    return { project, onClickEditProject, onClickDeleteProject, user };
+};
+
+const openMenu = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByTestId(triggerId));
+    await screen.findByTestId(editItemId);
+};
+
+describe("ProjectActionsMenu", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders the trigger button with the composed test id", () => {
+        setup();
+        expect(screen.getByTestId(triggerId)).toBeInTheDocument();
+    });
+
+    it("keeps the menu closed until the trigger is clicked", () => {
+        setup();
+        expect(screen.queryByTestId(editItemId)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(exportItemId)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(deleteItemId)).not.toBeInTheDocument();
+    });
+
+    it("opens a menu with edit, export and delete items when the trigger is clicked", async () => {
+        const { user } = setup();
+
+        await openMenu(user);
+
+        expect(screen.getByTestId(editItemId)).toBeInTheDocument();
+        expect(screen.getByTestId(exportItemId)).toBeInTheDocument();
+        expect(screen.getByTestId(deleteItemId)).toBeInTheDocument();
+        expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+    });
+
+    it("composes the test id prefix into every menu item id", async () => {
+        const { user } = setup({ testIdPrefix: "custom-prefix" });
+
+        await user.click(screen.getByTestId("custom-prefix-button"));
+
+        expect(await screen.findByTestId("custom-prefix_edit-project-button")).toBeInTheDocument();
+        expect(screen.getByTestId("custom-prefix_export-project-button")).toBeInTheDocument();
+        expect(screen.getByTestId("custom-prefix_delete-project-button")).toBeInTheDocument();
+    });
+
+    it("calls onClickEditProject with the project and closes the menu when edit is clicked", async () => {
+        const { user, project, onClickEditProject } = setup();
+        await openMenu(user);
+
+        await user.click(screen.getByTestId(editItemId));
+
+        expect(onClickEditProject).toHaveBeenCalledTimes(1);
+        expect(onClickEditProject).toHaveBeenCalledWith(expect.anything(), project);
+        await waitFor(() => expect(screen.queryByTestId(editItemId)).not.toBeInTheDocument());
+    });
+
+    it("calls onClickDeleteProject with the project and closes the menu when delete is clicked", async () => {
+        const { user, project, onClickDeleteProject } = setup();
+        await openMenu(user);
+
+        await user.click(screen.getByTestId(deleteItemId));
+
+        expect(onClickDeleteProject).toHaveBeenCalledTimes(1);
+        expect(onClickDeleteProject).toHaveBeenCalledWith(expect.anything(), project);
+        await waitFor(() => expect(screen.queryByTestId(deleteItemId)).not.toBeInTheDocument());
+    });
+
+    it("exports the project and closes the menu when export is clicked", async () => {
+        const { user, project } = setup();
+        await openMenu(user);
+
+        await user.click(screen.getByTestId(exportItemId));
+
+        expect(exportProject).toHaveBeenCalledTimes(1);
+        expect(exportProject).toHaveBeenCalledWith(project);
+        await waitFor(() => expect(screen.queryByTestId(exportItemId)).not.toBeInTheDocument());
+    });
+
+    it("does not invoke the edit or delete callbacks when only exporting", async () => {
+        const { user, onClickEditProject, onClickDeleteProject } = setup();
+        await openMenu(user);
+
+        await user.click(screen.getByTestId(exportItemId));
+
+        expect(onClickEditProject).not.toHaveBeenCalled();
+        expect(onClickDeleteProject).not.toHaveBeenCalled();
+    });
+
+    it("still renders and opens the menu when used with the header variant", async () => {
+        const { user } = setup({ variant: "header" });
+
+        expect(screen.getByTestId(triggerId)).toBeInTheDocument();
+        await openMenu(user);
+
+        expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+    });
+});

--- a/apps/frontend/src/view/components/project-actions-menu.component.tsx
+++ b/apps/frontend/src/view/components/project-actions-menu.component.tsx
@@ -1,5 +1,5 @@
 import { Delete, Edit, MoreVert } from "@mui/icons-material";
-import { Menu, MenuItem, type SxProps, type Theme } from "@mui/material";
+import { Menu, MenuItem } from "@mui/material";
 import { useState, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useProjectExport } from "#application/hooks/use-export.hook.ts";
@@ -12,9 +12,7 @@ interface ProjectActionsMenuProps {
     onClickEditProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
     onClickDeleteProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
     testIdPrefix: string;
-    triggerSx?: SxProps<Theme>;
-    triggerIconSx?: SxProps<Theme>;
-    triggerSize?: "small" | "medium" | "large";
+    variant?: "card" | "header";
 }
 
 export const ProjectActionsMenu = ({
@@ -22,10 +20,9 @@ export const ProjectActionsMenu = ({
     onClickEditProject,
     onClickDeleteProject,
     testIdPrefix,
-    triggerSx,
-    triggerIconSx = { fontSize: 18 },
-    triggerSize = "small",
+    variant = "card",
 }: ProjectActionsMenuProps) => {
+    const isHeader = variant === "header";
     const { t } = useTranslation("projectsPage");
     const [anchorElement, setAnchorElement] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorElement);
@@ -57,8 +54,13 @@ export const ProjectActionsMenu = ({
 
     return (
         <>
-            <IconButton size={triggerSize} onClick={handleClick} sx={triggerSx} data-testid={`${testIdPrefix}-button`}>
-                <MoreVert sx={triggerIconSx} />
+            <IconButton
+                size={isHeader ? "medium" : "small"}
+                onClick={handleClick}
+                sx={isHeader ? { ml: 1, color: "text.primary" } : undefined}
+                data-testid={`${testIdPrefix}-button`}
+            >
+                <MoreVert sx={{ fontSize: isHeader ? "1rem" : 18 }} />
             </IconButton>
             <Menu
                 anchorEl={anchorElement}

--- a/apps/frontend/src/view/components/project-actions-menu.component.tsx
+++ b/apps/frontend/src/view/components/project-actions-menu.component.tsx
@@ -1,0 +1,130 @@
+import { Delete, Edit, MoreVert } from "@mui/icons-material";
+import { Menu, MenuItem, type SxProps, type Theme } from "@mui/material";
+import { useState, type MouseEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { useProjectExport } from "#application/hooks/use-export.hook.ts";
+import type { ExtendedProject } from "#api/types/project.types.ts";
+import { ExportIconButton } from "./export-icon-button.component";
+import { IconButton } from "./icon-button.component";
+
+interface ProjectActionsMenuProps {
+    project: ExtendedProject;
+    onClickEditProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
+    onClickDeleteProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
+    testIdPrefix: string;
+    triggerSx?: SxProps<Theme>;
+    triggerIconSx?: SxProps<Theme>;
+    triggerSize?: "small" | "medium" | "large";
+}
+
+export const ProjectActionsMenu = ({
+    project,
+    onClickEditProject,
+    onClickDeleteProject,
+    testIdPrefix,
+    triggerSx,
+    triggerIconSx = { fontSize: 18 },
+    triggerSize = "small",
+}: ProjectActionsMenuProps) => {
+    const { t } = useTranslation("projectsPage");
+    const [anchorElement, setAnchorElement] = useState<null | HTMLElement>(null);
+    const open = Boolean(anchorElement);
+
+    const { exportProject } = useProjectExport();
+
+    const handleClick = (event: MouseEvent<HTMLElement>) => {
+        setAnchorElement(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorElement(null);
+    };
+
+    const handleEditProject = (event: MouseEvent<HTMLElement>) => {
+        onClickEditProject(event, project);
+        handleClose();
+    };
+
+    const handleDeleteProject = (event: MouseEvent<HTMLElement>) => {
+        onClickDeleteProject(event, project);
+        handleClose();
+    };
+
+    const handleExport = () => {
+        exportProject(project);
+        handleClose();
+    };
+
+    return (
+        <>
+            <IconButton size={triggerSize} onClick={handleClick} sx={triggerSx} data-testid={`${testIdPrefix}-button`}>
+                <MoreVert sx={triggerIconSx} />
+            </IconButton>
+            <Menu
+                anchorEl={anchorElement}
+                open={open}
+                onClose={handleClose}
+                slotProps={{
+                    list: {
+                        sx: { bgcolor: "background.mainIntransparent" },
+                    },
+                    paper: {
+                        sx: {
+                            borderRadius: 5,
+                        },
+                    },
+                }}
+            >
+                <MenuItem
+                    title={t("edit")}
+                    onClick={handleEditProject}
+                    sx={{
+                        "&:hover": {
+                            backgroundColor: "background.mainIntransparent",
+                            color: "secondary.light",
+                        },
+                    }}
+                    data-testid={`${testIdPrefix}_edit-project-button`}
+                >
+                    <IconButton>
+                        <Edit />
+                    </IconButton>
+                </MenuItem>
+                <MenuItem
+                    title={t("exportProject")}
+                    onClick={handleExport}
+                    sx={{
+                        "&:hover": {
+                            backgroundColor: "background.mainIntransparent",
+                            color: "secondary.light",
+                        },
+                    }}
+                    data-testid={`${testIdPrefix}_export-project-button`}
+                >
+                    <ExportIconButton />
+                </MenuItem>
+                <MenuItem
+                    title={t("delete")}
+                    onClick={handleDeleteProject}
+                    sx={{
+                        "&:hover": {
+                            backgroundColor: "background.mainIntransparent",
+                        },
+                    }}
+                    data-testid={`${testIdPrefix}_delete-project-button`}
+                >
+                    <IconButton
+                        sx={{
+                            "&:hover": {
+                                color: "error.light",
+                                backgroundColor: "background.paperIntransparent",
+                            },
+                        }}
+                    >
+                        <Delete />
+                    </IconButton>
+                </MenuItem>
+            </Menu>
+        </>
+    );
+};

--- a/apps/frontend/src/view/components/project-card.component.test.tsx
+++ b/apps/frontend/src/view/components/project-card.component.test.tsx
@@ -1,0 +1,100 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { MouseEvent } from "react";
+import type { ExtendedProject } from "#api/types/project.types.ts";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createProject } from "#test-utils/builders.ts";
+
+const navigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react-router")>();
+    return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock("./project-actions-menu.component", () => ({
+    ProjectActionsMenu: ({
+        project,
+        onClickEditProject,
+        onClickDeleteProject,
+        testIdPrefix,
+    }: {
+        project: ExtendedProject;
+        onClickEditProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
+        onClickDeleteProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
+        testIdPrefix: string;
+    }) => (
+        <div data-testid="project-actions-menu-stub" data-prefix={testIdPrefix}>
+            <button onClick={(event) => onClickEditProject(event, project)}>menu-edit</button>
+            <button onClick={(event) => onClickDeleteProject(event, project)}>menu-delete</button>
+        </div>
+    ),
+}));
+
+import { ProjectCard } from "./project-card.component";
+
+const setup = (project: ExtendedProject) => {
+    const onClickEditProject = vi.fn();
+    const onClickDeleteProject = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+        <ProjectCard
+            project={project}
+            onClickEditProject={onClickEditProject}
+            onClickDeleteProject={onClickDeleteProject}
+        />
+    );
+
+    return { onClickEditProject, onClickDeleteProject, user };
+};
+
+describe("ProjectCard — actions menu delegation", () => {
+    it("renders the project name", () => {
+        setup(createProject({ name: "Alpha", role: USER_ROLES.OWNER }));
+        expect(screen.getByText("Alpha")).toBeInTheDocument();
+    });
+
+    it("renders the actions menu for an owner", () => {
+        setup(createProject({ role: USER_ROLES.OWNER }));
+        expect(screen.getByTestId("project-actions-menu-stub")).toBeInTheDocument();
+    });
+
+    it("passes its own test id prefix down to the actions menu", () => {
+        setup(createProject({ role: USER_ROLES.OWNER }));
+        expect(screen.getByTestId("project-actions-menu-stub")).toHaveAttribute(
+            "data-prefix",
+            "projects-page_project-card_action-menu"
+        );
+    });
+
+    it("does not render the actions menu for an editor", () => {
+        setup(createProject({ role: USER_ROLES.EDITOR }));
+        expect(screen.queryByTestId("project-actions-menu-stub")).not.toBeInTheDocument();
+    });
+
+    it("does not render the actions menu for a viewer", () => {
+        setup(createProject({ role: USER_ROLES.VIEWER }));
+        expect(screen.queryByTestId("project-actions-menu-stub")).not.toBeInTheDocument();
+    });
+
+    it("forwards the edit callback with the project", async () => {
+        const project = createProject({ id: 5, role: USER_ROLES.OWNER });
+        const { onClickEditProject, user } = setup(project);
+
+        await user.click(screen.getByRole("button", { name: "menu-edit" }));
+
+        expect(onClickEditProject).toHaveBeenCalledTimes(1);
+        expect(onClickEditProject).toHaveBeenCalledWith(expect.anything(), project);
+    });
+
+    it("forwards the delete callback with the project", async () => {
+        const project = createProject({ id: 8, role: USER_ROLES.OWNER });
+        const { onClickDeleteProject, user } = setup(project);
+
+        await user.click(screen.getByRole("button", { name: "menu-delete" }));
+
+        expect(onClickDeleteProject).toHaveBeenCalledTimes(1);
+        expect(onClickDeleteProject).toHaveBeenCalledWith(expect.anything(), project);
+    });
+});

--- a/apps/frontend/src/view/components/project-card.component.tsx
+++ b/apps/frontend/src/view/components/project-card.component.tsx
@@ -1,28 +1,17 @@
-import { Delete, Edit, ExpandLess, ExpandMore, MoreVert, GppGood } from "@mui/icons-material";
-import {
-    Box,
-    Button as MaterialButton,
-    Collapse,
-    Menu,
-    MenuItem,
-    Typography,
-    type SxProps,
-    type Theme,
-} from "@mui/material";
-import { useState } from "react";
+import { ExpandLess, ExpandMore, GppGood } from "@mui/icons-material";
+import { Box, Button as MaterialButton, Collapse, Typography, type SxProps, type Theme } from "@mui/material";
+import { useState, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { checkUserRole, USER_ROLES } from "#api/types/user-roles.types.ts";
 import { Button } from "./button.component";
-import { IconButton } from "./icon-button.component";
-import { ExportIconButton } from "./export-icon-button.component";
-import { useProjectExport } from "#application/hooks/use-export.hook.ts";
+import { ProjectActionsMenu } from "./project-actions-menu.component";
 import type { ExtendedProject } from "#api/types/project.types.ts";
 
 interface ProjectCardProps {
     project: ExtendedProject;
-    onClickEditProject: (event: React.MouseEvent<HTMLElement, MouseEvent>, project: ExtendedProject) => void;
-    onClickDeleteProject: (event: React.MouseEvent<HTMLElement, MouseEvent>, project: ExtendedProject) => void;
+    onClickEditProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
+    onClickDeleteProject: (event: MouseEvent<HTMLElement>, project: ExtendedProject) => void;
     sx?: SxProps<Theme>;
 }
 
@@ -30,31 +19,9 @@ export const ProjectCard = ({ project, onClickEditProject, onClickDeleteProject,
     const { t } = useTranslation("projectsPage");
     const navigate = useNavigate();
     const { id, name, createdAt, description, image, confidentialityLevel } = project;
-    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [showDescription, setShowDescription] = useState(false);
-    const open = Boolean(anchorEl);
-
-    const { exportProject } = useProjectExport();
 
     const projectCreationDate = new Date(createdAt);
-
-    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        setAnchorEl(event.currentTarget);
-    };
-
-    const handleClose = () => {
-        setAnchorEl(null);
-    };
-
-    const handleEditProject = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-        onClickEditProject(event, project);
-        handleClose();
-    };
-
-    const handleDeleteProject = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-        onClickDeleteProject(event, project);
-        handleClose();
-    };
 
     const handleClickShowDescription = () => {
         setShowDescription(!showDescription);
@@ -88,10 +55,6 @@ export const ProjectCard = ({ project, onClickEditProject, onClickDeleteProject,
 
     const onClickOpenMembers = () => {
         navigate(`/projects/${id}/members`, { state: { project } });
-    };
-
-    const handleExport = () => {
-        exportProject(project);
     };
 
     return (
@@ -129,84 +92,14 @@ export const ProjectCard = ({ project, onClickEditProject, onClickDeleteProject,
                     >
                         {name}
                     </Typography>
-                    {checkUserRole(project.role, USER_ROLES.OWNER) && [
-                        <IconButton
-                            key={"iconbutton" + project.id}
-                            size="small"
-                            onClick={handleClick}
-                            data-testid="projects-page_project-card_action-menu-button"
-                        >
-                            <MoreVert sx={{ fontSize: 18 }} />
-                        </IconButton>,
-
-                        <Menu
-                            key={"menu" + project.id}
-                            anchorEl={anchorEl}
-                            open={open}
-                            onClose={handleClose}
-                            slotProps={{
-                                list: {
-                                    sx: { bgcolor: "background.mainIntransparent" },
-                                },
-                                paper: {
-                                    sx: {
-                                        borderRadius: 5,
-                                    },
-                                },
-                            }}
-                        >
-                            <MenuItem
-                                title={t("edit")}
-                                onClick={handleEditProject}
-                                sx={{
-                                    "&:hover": {
-                                        backgroundColor: "background.mainIntransparent",
-                                        color: "secondary.light",
-                                    },
-                                }}
-                                data-testid="projects-page_project-card_action-menu_edit-project-button"
-                            >
-                                {" "}
-                                <IconButton>
-                                    <Edit />
-                                </IconButton>{" "}
-                            </MenuItem>
-                            <MenuItem
-                                title={t("exportProject")}
-                                onClick={handleExport}
-                                sx={{
-                                    "&:hover": {
-                                        backgroundColor: "background.mainIntransparent",
-                                        color: "secondary.light",
-                                    },
-                                }}
-                                data-testid="projects-page_project-card_action-menu_export-project-button"
-                            >
-                                <ExportIconButton />
-                            </MenuItem>
-                            <MenuItem
-                                title={t("delete")}
-                                onClick={handleDeleteProject}
-                                sx={{
-                                    "&:hover": {
-                                        backgroundColor: "background.mainIntransparent",
-                                    },
-                                }}
-                                data-testid="projects-page_project-card_action-menu_delete-project-button"
-                            >
-                                <IconButton
-                                    sx={{
-                                        "&:hover": {
-                                            color: "error.light",
-                                            backgroundColor: "background.paperIntransparent",
-                                        },
-                                    }}
-                                >
-                                    <Delete />
-                                </IconButton>{" "}
-                            </MenuItem>
-                        </Menu>,
-                    ]}
+                    {checkUserRole(project.role, USER_ROLES.OWNER) && (
+                        <ProjectActionsMenu
+                            project={project}
+                            onClickEditProject={onClickEditProject}
+                            onClickDeleteProject={onClickDeleteProject}
+                            testIdPrefix="projects-page_project-card_action-menu"
+                        />
+                    )}
                 </Box>
                 <Typography
                     variant="body2"

--- a/apps/frontend/src/view/pages/asset-dialog.page.test.tsx
+++ b/apps/frontend/src/view/pages/asset-dialog.page.test.tsx
@@ -38,7 +38,7 @@ describe("AssetDialogPage", () => {
             url: "/projects/1/assets/5/edit",
             preloadedState: {
                 assets: { ids: [], entities: {}, isPending: true },
-                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined, deletingProjectId: undefined },
             },
         });
 
@@ -53,7 +53,7 @@ describe("AssetDialogPage", () => {
             url: "/projects/1/assets/999/edit",
             preloadedState: {
                 assets: { ids: [10], entities: { 10: otherAsset }, isPending: false },
-                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined, deletingProjectId: undefined },
             },
         });
 
@@ -69,7 +69,7 @@ describe("AssetDialogPage", () => {
             url: "/projects/1/assets/5/edit",
             preloadedState: {
                 assets: { ids: [5], entities: { 5: asset }, isPending: false },
-                projects: { ids: [], entities: {}, isPending: false, current: project },
+                projects: { ids: [], entities: {}, isPending: false, current: project, deletingProjectId: undefined },
             },
         });
 
@@ -85,7 +85,7 @@ describe("AssetDialogPage", () => {
             url: { pathname: "/projects/1/assets/edit", state: { asset: { name: "New Asset" } } },
             preloadedState: {
                 assets: { ids: [], entities: {}, isPending: false },
-                projects: { ids: [], entities: {}, isPending: false, current: undefined },
+                projects: { ids: [], entities: {}, isPending: false, current: undefined, deletingProjectId: undefined },
             },
         });
 

--- a/apps/frontend/src/view/pages/projects.page.tsx
+++ b/apps/frontend/src/view/pages/projects.page.tsx
@@ -2,7 +2,7 @@ import { Add, ArrowDownward, ArrowUpward } from "@mui/icons-material";
 import { LinearProgress, useMediaQuery } from "@mui/material";
 import { Box } from "@mui/system";
 import { useTheme } from "@mui/material/styles";
-import { useLayoutEffect, type ChangeEvent, type SyntheticEvent } from "react";
+import { useLayoutEffect, type ChangeEvent, type MouseEvent, type SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { Route, Routes } from "react-router-dom";
@@ -85,7 +85,7 @@ export const ProjectsPage = CreatePage(HeaderUtilityControls, () => {
         navigate("/projects/add");
     };
 
-    const onClickDeleteProject = (_event: React.MouseEvent<HTMLElement>, project: ExtendedProject) => {
+    const onClickDeleteProject = (_event: MouseEvent<HTMLElement>, project: ExtendedProject) => {
         openConfirm({
             state: project,
             message: t("deleteMessage", { projectName: project.name }),
@@ -97,7 +97,7 @@ export const ProjectsPage = CreatePage(HeaderUtilityControls, () => {
         });
     };
 
-    const onClickEditProject = (_event: React.MouseEvent<HTMLElement>, project: ExtendedProject) => {
+    const onClickEditProject = (_event: MouseEvent<HTMLElement>, project: ExtendedProject) => {
         navigate(`/projects/${project.id}`, { state: { project } });
     };
 


### PR DESCRIPTION
## Summary

  Resolves #700
  
   - Adds a shared ProjectActionsMenu (Edit / Export as JSON / Delete)
  - Owners get the full ⋮ dropdown in the header; non-owners keep the existing Edit pencil. The card is refactored onto the same shared component
  - Fixes the delete-from-within flow
  
  ### Screenshots
  
<img width="1334" height="517" alt="dropdown-in-project-header" src="https://github.com/user-attachments/assets/e7930185-289b-4bc6-b1b7-3e8875b9719f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project actions menu providing edit, export, and delete functionality
  * Introduced confirmation dialog before deleting projects

* **Improvements**
  * Enhanced project deletion reliability by preventing background operations during deletion
  * Implemented role-based visibility of project actions (owners see full menu; non-owners see edit option)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->