### PR TITLE
refactor(editor): extract and test pure logic from the useEditor hook

### DIFF
--- a/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
@@ -1,0 +1,502 @@
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { I18nextProvider } from "react-i18next";
+import type { ReactNode } from "react";
+import { useEditor } from "./use-editor.hook";
+import { createStore } from "#application/store.ts";
+import { translationUtil } from "#utils/translations.ts";
+import { EditorActions } from "#application/actions/editor.actions.ts";
+import { SystemActions } from "#application/actions/system.actions.ts";
+import { PointsOfAttackActions } from "#application/actions/points-of-attack.actions.ts";
+import {
+    createAsset,
+    createCommunicationInterface,
+    createComponentPayload,
+    createConnection,
+    createConnectionAnchor,
+    createConnectionPoint,
+    createPointOfAttack,
+} from "#test-utils/builders.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+
+type EditorStore = ReturnType<typeof createStore>;
+
+// we seed by dispatching the same actions the app dispatches
+// and assert on the resulting store state — behaviour, not internals.
+const renderUseEditor = (seed?: (store: EditorStore) => void) => {
+    const store = createStore();
+    seed?.(store);
+
+    const showErrorMessage = vi.fn();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <Provider store={store}>
+            <I18nextProvider i18n={translationUtil}>{children}</I18nextProvider>
+        </Provider>
+    );
+
+    const view = renderHook(() => useEditor({ projectId: 1, showErrorMessage }), { wrapper });
+    return { ...view, store, showErrorMessage };
+};
+
+const seedComponentWithInterface = (store: EditorStore, interfaceId: string, interfaceName: string) => {
+    store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-1", name: "Server" })));
+    store.dispatch(
+        SystemActions.setComponent({
+            id: "comp-1",
+            changes: {
+                communicationInterfaces: [createCommunicationInterface({ id: interfaceId, name: interfaceName })],
+            },
+        })
+    );
+    store.dispatch(
+        PointsOfAttackActions.createPointOfAttack(
+            createPointOfAttack({
+                id: interfaceId,
+                componentId: "comp-1",
+                name: interfaceName,
+                type: POINTS_OF_ATTACK.COMMUNICATION_INTERFACES,
+            })
+        )
+    );
+    store.dispatch(
+        SystemActions.createConnectionPoint(
+            createConnectionPoint({ id: interfaceId, name: interfaceName, connectionId: "" })
+        )
+    );
+};
+
+describe("useEditor", () => {
+    describe("selectConnector", () => {
+        const seedConnectorComponents = (store: EditorStore) => {
+            const componentsByType: [string, STANDARD_COMPONENT_TYPES][] = [
+                ["users-1", STANDARD_COMPONENT_TYPES.USERS],
+                ["users-2", STANDARD_COMPONENT_TYPES.USERS],
+                ["client-1", STANDARD_COMPONENT_TYPES.CLIENT],
+                ["server-1", STANDARD_COMPONENT_TYPES.SERVER],
+                ["infra-1", STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE],
+                ["infra-2", STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE],
+            ];
+            componentsByType.forEach(([id, type]) => {
+                store.dispatch(SystemActions.createComponent(createComponentPayload({ id, type })));
+            });
+        };
+
+        const connect = (
+            result: ReturnType<typeof renderUseEditor>["result"],
+            from: ReturnType<typeof createConnectionAnchor>,
+            to: ReturnType<typeof createConnectionAnchor>
+        ) => {
+            act(() => result.current.selectConnector(from));
+            act(() => result.current.selectConnector(to));
+        };
+
+        type ConnectorCase = [
+            label: string,
+            from: ReturnType<typeof createConnectionAnchor>,
+            to: ReturnType<typeof createConnectionAnchor>,
+        ];
+
+        // Each row is an allowed pairing: the second click creates exactly one
+        // connection wired from→to, with no error surfaced.
+        const allowedPairings: ConnectorCase[] = [
+            [
+                "users → system component",
+                createConnectionAnchor({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS }),
+                createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT }),
+            ],
+            [
+                "system component → users",
+                createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT }),
+                createConnectionAnchor({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS }),
+            ],
+            [
+                "system component with interface → communication infrastructure",
+                createConnectionAnchor({
+                    id: "client-1",
+                    type: STANDARD_COMPONENT_TYPES.CLIENT,
+                    communicationInterfaceId: "ci-1",
+                }),
+                createConnectionAnchor({ id: "infra-1", type: STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE }),
+            ],
+            [
+                "communication infrastructure → system component with interface",
+                createConnectionAnchor({ id: "infra-1", type: STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE }),
+                createConnectionAnchor({
+                    id: "client-1",
+                    type: STANDARD_COMPONENT_TYPES.CLIENT,
+                    communicationInterfaceId: "ci-1",
+                }),
+            ],
+        ];
+
+        it.each(allowedPairings)("creates a connection for an allowed pairing: %s", (_label, from, to) => {
+            const { result, store, showErrorMessage } = renderUseEditor(seedConnectorComponents);
+
+            connect(result, from, to);
+
+            expect(showErrorMessage).not.toHaveBeenCalled();
+            const connections = store.getState().system.connections;
+            expect(connections.ids).toHaveLength(1);
+            const created = Object.values(connections.entities)[0];
+            expect(created?.from.id).toBe(from.id);
+            expect(created?.to.id).toBe(to.id);
+        });
+
+        // Each row is a disallowed pairing: the second click surfaces exactly one
+        // error and creates nothing.
+        const disallowedPairings: ConnectorCase[] = [
+            [
+                "users → users",
+                createConnectionAnchor({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS }),
+                createConnectionAnchor({ id: "users-2", type: STANDARD_COMPONENT_TYPES.USERS }),
+            ],
+            [
+                "users → communication infrastructure",
+                createConnectionAnchor({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS }),
+                createConnectionAnchor({ id: "infra-1", type: STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE }),
+            ],
+            [
+                "system component → system component",
+                createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT }),
+                createConnectionAnchor({ id: "server-1", type: STANDARD_COMPONENT_TYPES.SERVER }),
+            ],
+            [
+                "system component without interface → communication infrastructure",
+                createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT }),
+                createConnectionAnchor({ id: "infra-1", type: STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE }),
+            ],
+            [
+                "communication infrastructure → system component without interface",
+                createConnectionAnchor({ id: "infra-1", type: STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE }),
+                createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT }),
+            ],
+            [
+                "communication infrastructure → communication infrastructure",
+                createConnectionAnchor({ id: "infra-1", type: STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE }),
+                createConnectionAnchor({ id: "infra-2", type: STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE }),
+            ],
+        ];
+
+        it.each(disallowedPairings)("rejects a disallowed pairing and creates nothing: %s", (_label, from, to) => {
+            const { result, store, showErrorMessage } = renderUseEditor(seedConnectorComponents);
+
+            connect(result, from, to);
+
+            expect(showErrorMessage).toHaveBeenCalledTimes(1);
+            expect(store.getState().system.connections.ids).toHaveLength(0);
+        });
+
+        it("opens a preview on the first click without creating a connection", () => {
+            const { result, store, showErrorMessage } = renderUseEditor(seedConnectorComponents);
+
+            act(() => {
+                result.current.selectConnector(
+                    createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT })
+                );
+            });
+
+            expect(store.getState().editor.connection?.from?.id).toBe("client-1");
+            expect(store.getState().system.connections.ids).toHaveLength(0);
+            expect(showErrorMessage).not.toHaveBeenCalled();
+        });
+
+        it("clicking the same anchor twice creates nothing", () => {
+            const { result, store, showErrorMessage } = renderUseEditor(seedConnectorComponents);
+            const sameAnchor = createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT });
+
+            connect(result, sameAnchor, sameAnchor);
+
+            expect(store.getState().system.connections.ids).toHaveLength(0);
+            expect(showErrorMessage).not.toHaveBeenCalled();
+        });
+    });
+
+    // cascade delete — removeComponent must also drop the
+    // component's connections and points of attack.
+    describe("removeComponent", () => {
+        it("removes the selected component together with its connections and points of attack", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-1" })));
+                store.dispatch(
+                    PointsOfAttackActions.createPointOfAttack(
+                        createPointOfAttack({ id: "poa-1", componentId: "comp-1" })
+                    )
+                );
+                store.dispatch(SystemActions.createConnection(createConnection({ id: "conn-1" })));
+                store.dispatch(EditorActions.selectComponent("comp-1"));
+            });
+
+            const seeded = store.getState().system;
+            expect(seeded.components.ids).toHaveLength(1);
+            expect(seeded.pointsOfAttack.ids).toHaveLength(1);
+            expect(seeded.connections.ids).toHaveLength(1);
+
+            act(() => {
+                result.current.removeComponent();
+            });
+
+            const state = store.getState().system;
+            expect(state.components.ids).toHaveLength(0);
+            expect(state.pointsOfAttack.ids).toHaveLength(0);
+            expect(state.connections.ids).toHaveLength(0);
+        });
+    });
+
+    // addComponent creates the component plus one
+    // point of attack per attack-point type on its component type.
+    describe("addComponent", () => {
+        it("creates a component and one point of attack per attack-point type", () => {
+            const { result, store } = renderUseEditor();
+
+            act(() => {
+                result.current.addComponent({
+                    componentType: {
+                        id: STANDARD_COMPONENT_TYPES.CLIENT,
+                        name: "Client",
+                        symbol: null,
+                        standardIcon: null,
+                        pointsOfAttack: [POINTS_OF_ATTACK.USER_INTERFACE, POINTS_OF_ATTACK.PROCESSING_INFRASTRUCTURE],
+                    },
+                    x: 10,
+                    y: 20,
+                    gridX: 1,
+                    gridY: 2,
+                });
+            });
+
+            const state = store.getState().system;
+            expect(state.components.ids).toHaveLength(1);
+
+            const componentId = state.components.ids[0];
+            const pointsOfAttack = state.pointsOfAttack.ids.map((id) => state.pointsOfAttack.entities[id]);
+            expect(pointsOfAttack).toHaveLength(2);
+            expect(pointsOfAttack.every((pointOfAttack) => pointOfAttack?.componentId === componentId)).toBe(true);
+        });
+    });
+
+    // setSelectedComponentName ignores a
+    // blank name instead of writing it.
+    describe("setSelectedComponentName", () => {
+        it("ignores a blank name", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-1", name: "Original" }))
+                );
+                store.dispatch(EditorActions.selectComponent("comp-1"));
+            });
+
+            act(() => {
+                result.current.setSelectedComponentName("   ");
+            });
+
+            expect(store.getState().system.components.entities["comp-1"]?.name).toBe("Original");
+        });
+    });
+
+    // removeConnection drops the connection and any
+    // points of attack tied to it, and falls back to the selected connection.
+    describe("removeConnection", () => {
+        it("removes a passed connection together with its points of attack", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(SystemActions.createConnection(createConnection({ id: "conn-1" })));
+                store.dispatch(
+                    PointsOfAttackActions.createPointOfAttack(
+                        createPointOfAttack({ id: "poa-1", connectionId: "conn-1" })
+                    )
+                );
+            });
+
+            expect(store.getState().system.connections.ids).toHaveLength(1);
+            expect(store.getState().system.pointsOfAttack.ids).toHaveLength(1);
+
+            act(() => {
+                result.current.removeConnection(createConnection({ id: "conn-1" }));
+            });
+
+            const state = store.getState().system;
+            expect(state.connections.ids).toHaveLength(0);
+            expect(state.pointsOfAttack.ids).toHaveLength(0);
+        });
+
+        it("falls back to the selected connection when called without an argument", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(SystemActions.createConnection(createConnection({ id: "conn-1" })));
+                store.dispatch(EditorActions.selectConnection("conn-1"));
+            });
+
+            act(() => {
+                result.current.removeConnection();
+            });
+
+            expect(store.getState().system.connections.ids).toHaveLength(0);
+        });
+
+        it("does nothing when no connection is passed and none is selected", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(SystemActions.createConnection(createConnection({ id: "conn-1" })));
+            });
+
+            act(() => {
+                result.current.removeConnection();
+            });
+
+            expect(store.getState().system.connections.ids).toHaveLength(1);
+        });
+    });
+
+    // addCommunicationInterface adds the interface to
+    // the component and creates a point of attack and connection point sharing its id.
+    describe("addCommunicationInterface", () => {
+        it("adds the interface to the component and creates its point of attack and connection point", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-1", name: "Server" })));
+            });
+
+            act(() => {
+                result.current.addCommunicationInterface("comp-1", "REST API", "icon-name");
+            });
+
+            const state = store.getState().system;
+            const createdInterface = state.components.entities["comp-1"]?.communicationInterfaces?.[0];
+            expect(state.components.entities["comp-1"]?.communicationInterfaces).toHaveLength(1);
+            expect(createdInterface?.name).toBe("REST API");
+            expect(createdInterface?.icon).toBe("icon-name");
+            expect(createdInterface?.type).toBe(POINTS_OF_ATTACK.COMMUNICATION_INTERFACES);
+
+            const interfaceId = createdInterface?.id;
+            const pointsOfAttack = Object.values(state.pointsOfAttack.entities);
+            expect(pointsOfAttack).toHaveLength(1);
+            expect(pointsOfAttack[0]?.id).toBe(interfaceId);
+            expect(pointsOfAttack[0]?.type).toBe(POINTS_OF_ATTACK.COMMUNICATION_INTERFACES);
+            expect(pointsOfAttack[0]?.componentId).toBe("comp-1");
+
+            const connectionPoints = Object.values(state.connectionPoints.entities);
+            expect(connectionPoints).toHaveLength(1);
+            expect(connectionPoints[0]?.id).toBe(interfaceId);
+        });
+
+        it("does nothing for an unknown component", () => {
+            const { result, store } = renderUseEditor();
+
+            act(() => {
+                result.current.addCommunicationInterface("does-not-exist", "REST API", null);
+            });
+
+            const state = store.getState().system;
+            expect(state.pointsOfAttack.ids).toHaveLength(0);
+            expect(state.connectionPoints.ids).toHaveLength(0);
+        });
+    });
+
+    // handleDeleteCommunicationInterface removes the interface, its point of attack,
+    // its connection point, and any connection that uses it.
+    describe("handleDeleteCommunicationInterface", () => {
+        it("removes the interface and everything tied to it", () => {
+            const interfaceId = "ci-1";
+            const { result, store } = renderUseEditor((store) => {
+                seedComponentWithInterface(store, interfaceId, "REST API");
+                store.dispatch(
+                    SystemActions.createConnection(
+                        createConnection({
+                            id: "conn-1",
+                            from: createConnectionAnchor({ id: "comp-1", communicationInterfaceId: interfaceId }),
+                        })
+                    )
+                );
+            });
+
+            // all four are present up front.
+            const seeded = store.getState().system;
+            expect(seeded.components.entities["comp-1"]?.communicationInterfaces).toHaveLength(1);
+            expect(seeded.pointsOfAttack.ids).toContain(interfaceId);
+            expect(seeded.connectionPoints.ids).toContain(interfaceId);
+            expect(seeded.connections.ids).toContain("conn-1");
+
+            act(() => {
+                result.current.handleDeleteCommunicationInterface("comp-1", interfaceId);
+            });
+
+            const state = store.getState().system;
+            expect(state.components.entities["comp-1"]?.communicationInterfaces).toHaveLength(0);
+            expect(state.pointsOfAttack.ids).not.toContain(interfaceId);
+            expect(state.connectionPoints.ids).not.toContain(interfaceId);
+            expect(state.connections.ids).not.toContain("conn-1");
+        });
+    });
+
+    // handleChangeCommunicationInterfaceName renames the interface on the component,
+    // its connection point, and its point of attack together.
+    //
+    describe("handleChangeCommunicationInterfaceName", () => {
+        it("renames the interface, its connection point, and its point of attack", () => {
+            const interfaceId = "ci-1";
+            const { result, store } = renderUseEditor((store) => {
+                seedComponentWithInterface(store, interfaceId, "Old name");
+            });
+
+            act(() => {
+                result.current.handleChangeCommunicationInterfaceName("comp-1", interfaceId, "New name");
+            });
+
+            const state = store.getState().system;
+            expect(state.components.entities["comp-1"]?.communicationInterfaces?.[0]?.name).toBe("New name");
+            expect(state.connectionPoints.entities[interfaceId]?.name).toBe("New name");
+            expect(state.pointsOfAttack.entities[interfaceId]?.name).toBe("New name");
+        });
+    });
+
+    // addAssetToPointOfAttack adds an asset once and ignores a repeat
+    describe("addAssetToPointOfAttack", () => {
+        it("adds an asset and ignores a duplicate", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(PointsOfAttackActions.createPointOfAttack(createPointOfAttack({ id: "poa-1" })));
+            });
+
+            act(() => {
+                result.current.addAssetToPointOfAttack(
+                    createAsset({ id: 5 }),
+                    createPointOfAttack({ id: "poa-1", assets: [] })
+                );
+            });
+            expect(store.getState().system.pointsOfAttack.entities["poa-1"]?.assets).toEqual([5]);
+
+            // Same asset again: the existing entry must not be duplicated.
+            act(() => {
+                result.current.addAssetToPointOfAttack(
+                    createAsset({ id: 5 }),
+                    createPointOfAttack({ id: "poa-1", assets: [5] })
+                );
+            });
+            expect(store.getState().system.pointsOfAttack.entities["poa-1"]?.assets).toEqual([5]);
+        });
+    });
+
+    // removeAssetFromPointOfAttack only removes an asset that is actually attached
+    describe("removeAssetFromPointOfAttack", () => {
+        it("removes an attached asset and ignores an unattached one", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(PointsOfAttackActions.createPointOfAttack(createPointOfAttack({ id: "poa-1" })));
+                store.dispatch(PointsOfAttackActions.setPointOfAttack({ id: "poa-1", changes: { assets: [5] } }));
+            });
+
+            // Unattached asset: no change.
+            act(() => {
+                result.current.removeAssetFromPointOfAttack(
+                    createAsset({ id: 7 }),
+                    createPointOfAttack({ id: "poa-1", assets: [5] })
+                );
+            });
+            expect(store.getState().system.pointsOfAttack.entities["poa-1"]?.assets).toEqual([5]);
+
+            // Attached asset: removed.
+            act(() => {
+                result.current.removeAssetFromPointOfAttack(
+                    createAsset({ id: 5 }),
+                    createPointOfAttack({ id: "poa-1", assets: [5] })
+                );
+            });
+            expect(store.getState().system.pointsOfAttack.entities["poa-1"]?.assets).toEqual([]);
+        });
+    });
+});

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -27,6 +27,8 @@ import { useSystem } from "./use-system.hook";
 import type { EditorComponentType } from "#application/adapters/editor-component-type.adapter.ts";
 import { validateConnection } from "#utils/connection-rules.ts";
 import { enhanceComponents } from "#utils/enhance-components.ts";
+import { buildPointOfAttackPayload } from "#utils/build-point-of-attack-payload.ts";
+import type { CreatePointOfAttackArgs } from "#utils/build-point-of-attack-payload.ts";
 
 let lastMousePointerUpdate = 0;
 
@@ -39,9 +41,6 @@ export type EditorConnectionAnchor = ConnectionAnchor & {
     communicationInterfaceId?: string | null;
     component?: SystemComponent;
 };
-
-type CreatePointOfAttackArgs = Pick<SystemPointOfAttack, "id" | "type" | "projectId" | "componentId"> &
-    Partial<Omit<SystemPointOfAttack, "id" | "type" | "projectId" | "componentId">>;
 
 export const useEditor = ({
     projectId,
@@ -789,19 +788,7 @@ export const useEditor = ({
     }, [projectId, dispatch]);
 
     const createPointOfAttack = (data: CreatePointOfAttackArgs): void => {
-        const payload: SystemPointOfAttack = {
-            id: data.id,
-            type: data.type,
-            projectId: data.projectId,
-            componentId: data.componentId,
-            connectionId: data.connectionId ?? null,
-            connectionPointId: data.connectionPointId ?? null,
-            name: data.name ?? null,
-            componentName: data.componentName ?? null,
-            assets: data.assets ?? [],
-        };
-
-        dispatch(PointsOfAttackActions.createPointOfAttack(payload));
+        dispatch(PointsOfAttackActions.createPointOfAttack(buildPointOfAttackPayload(data)));
     };
 
     const addComponentConnectionLine = (

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -26,6 +26,7 @@ import { useAppDispatch, useAppSelector } from "./use-app-redux.hook";
 import { useSystem } from "./use-system.hook";
 import type { EditorComponentType } from "#application/adapters/editor-component-type.adapter.ts";
 import { validateConnection } from "#utils/connection-rules.ts";
+import { enhanceComponents } from "#utils/enhance-components.ts";
 
 let lastMousePointerUpdate = 0;
 
@@ -724,18 +725,7 @@ export const useEditor = ({
     const standardComponents = useAppSelector(editorSelectors.selectStandardComponents);
 
     const enhancedComponents = useMemo(() => {
-        return components.map((c) => {
-            // Finde die Standardkomponente, die dem Typ von c entspricht
-            const standardComponent = standardComponents.find((sc) => sc.id === c.type);
-
-            return {
-                ...c,
-                selected: selectedComponentId === c.id,
-                startAnchor,
-                // Setze das Symbol basierend auf der gefundenen Standardkomponente
-                symbol: standardComponent ? standardComponent.symbol : c.symbol,
-            };
-        });
+        return enhanceComponents(components, standardComponents, selectedComponentId, startAnchor);
     }, [components, standardComponents, selectedComponentId, startAnchor]);
 
     const selectConnectionPoint = (connectionId: string): void => {

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -24,8 +24,8 @@ import { editorSelectors } from "#application/selectors/editor.selectors.ts";
 import { systemSelectors } from "#application/selectors/system.selectors.ts";
 import { useAppDispatch, useAppSelector } from "./use-app-redux.hook";
 import { useSystem } from "./use-system.hook";
-import type { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
 import type { EditorComponentType } from "#application/adapters/editor-component-type.adapter.ts";
+import { validateConnection } from "#utils/connection-rules.ts";
 
 let lastMousePointerUpdate = 0;
 
@@ -538,10 +538,6 @@ export const useEditor = ({
         dispatch(EditorActions.deselectComponent());
     };
 
-    const isSystemOrCustomComponent = (type: EditorConnectionAnchor["type"]): boolean => {
-        return ["CLIENT", "SERVER", "DATABASE"].includes(type as STANDARD_COMPONENT_TYPES) || typeof type === "number";
-    };
-
     const selectConnector = (connector: EditorConnectionAnchor): void => {
         // First connection, set the from, start connection preview
         if (!isConnectionPreview(newConnection)) {
@@ -569,37 +565,10 @@ export const useEditor = ({
             }
 
             // Check connection rules
-            if (from.type === "USERS") {
-                if (!isSystemOrCustomComponent(to.type)) {
-                    showErrorMessage?.({
-                        message: t("errors.userConnectionInvalid"),
-                    });
-                    return;
-                }
-            } else if (to.type === "USERS") {
-                if (!isSystemOrCustomComponent(from.type)) {
-                    showErrorMessage?.({
-                        message: t("errors.componentToUserInvalid"),
-                    });
-                    return;
-                }
-            } else if (isSystemOrCustomComponent(from.type)) {
-                if (to.type !== "COMMUNICATION_INFRASTRUCTURE" || !from.communicationInterfaceId) {
-                    showErrorMessage?.({
-                        message: t("errors.componentToCommunicationInfraInvalid"),
-                    });
-                    return;
-                }
-            } else if (from.type === "COMMUNICATION_INFRASTRUCTURE") {
-                if (!isSystemOrCustomComponent(to.type) || !to.communicationInterfaceId) {
-                    showErrorMessage?.({
-                        message: t("errors.communicationInfraToComponentInvalid"),
-                    });
-                    return;
-                }
-            } else {
+            const validation = validateConnection(from, to);
+            if (!validation.ok) {
                 showErrorMessage?.({
-                    message: t("errors.invalidConnection"),
+                    message: t(validation.messageKey),
                 });
                 return;
             }

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -489,7 +489,7 @@ export const useEditor = ({
 
     const handleDeleteCommunicationInterface = (componentId: string, interfaceId: string): void => {
         const selectedComponent = components.find((component) => component.id === componentId);
-        if (!selectedComponent || !selectedComponent.communicationInterfaces) {
+        if (!selectedComponent?.communicationInterfaces) {
             return;
         }
 

--- a/apps/frontend/src/application/selectors/editor.selectors.ts
+++ b/apps/frontend/src/application/selectors/editor.selectors.ts
@@ -1,18 +1,12 @@
 import { createSelector } from "reselect";
 import type { RootState } from "#application/store.ts";
 import type { EditorState } from "#application/reducers/editor.reducer.ts";
-import {
-    editorComponentConnectionLinesAdapter,
-    type EditorComponentConnectionLine,
-} from "#application/adapters/editor-component-connection-lines.adapter.ts";
+import { editorComponentConnectionLinesAdapter } from "#application/adapters/editor-component-connection-lines.adapter.ts";
 import {
     editorComponentTypeAdapter,
     type EditorComponentType,
 } from "#application/adapters/editor-component-type.adapter.ts";
-import {
-    editorMousePointersAdapter,
-    type EditorMousePointer,
-} from "#application/adapters/editor-mouse-pointers.adapter.ts";
+import { editorMousePointersAdapter } from "#application/adapters/editor-mouse-pointers.adapter.ts";
 
 type ExtendedEditorState = EditorState & {
     startAnchor?: unknown;
@@ -92,13 +86,11 @@ export const editorSelectors = {
     ),
 
     /**
-     * Reduces the entities to an array.
+     * The adapter's `selectAll` is already memoized, so we expose it directly
+     * rather than wrapping it in an identity selector.
      * @returns An array of mouse cursors.
      */
-    selectMousePointers: createSelector(
-        [selectAllMousePointers],
-        (mousePointers): EditorMousePointer[] => mousePointers
-    ),
+    selectMousePointers: selectAllMousePointers,
 
     /**
      * Gets the standard components.
@@ -122,13 +114,11 @@ export const editorSelectors = {
     ),
 
     /**
-     * Converts the connection entities to an array.
+     * The adapter's `selectAll` is already memoized, so we expose it directly
+     * rather than wrapping it in an identity selector.
      * @returns An array of connection lines.
      */
-    selectComponentConnectionLines: createSelector(
-        [selectAllComponentConnectionLines],
-        (componentConnectionLines): EditorComponentConnectionLine[] => componentConnectionLines
-    ),
+    selectComponentConnectionLines: selectAllComponentConnectionLines,
 
     /**
      * Filters whether a component is in use.

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -9,7 +9,9 @@ import {
     type Annotation,
     type AnnotationType,
     type AugmentedSystemComponent,
+    type Component,
     type ConnectionAnchor,
+    type SystemCommunicationInterface,
     type SystemConnection,
     type SystemPointOfAttack,
 } from "#api/types/system.types.ts";
@@ -78,6 +80,21 @@ export const createSystemComponent = (overrides: Partial<AugmentedSystemComponen
     ...overrides,
 });
 
+export const createComponentPayload = (
+    overrides: Partial<Omit<Component, "width" | "height" | "selected">> = {}
+): Omit<Component, "width" | "height" | "selected"> => ({
+    id: "comp-1",
+    name: "Test Component",
+    type: STANDARD_COMPONENT_TYPES.CLIENT,
+    x: 0,
+    y: 0,
+    gridX: 0,
+    gridY: 0,
+    projectId: 1,
+    symbol: null,
+    ...overrides,
+});
+
 export const createPointOfAttack = (overrides: Partial<SystemPointOfAttack> = {}): SystemPointOfAttack => ({
     id: "poa-1",
     name: null,
@@ -102,6 +119,19 @@ export const createConnectionPoint = (overrides: Partial<SystemConnectionPoint> 
     ...overrides,
 });
 
+export const createCommunicationInterface = (
+    overrides: Partial<SystemCommunicationInterface> = {}
+): SystemCommunicationInterface => ({
+    id: "ci-1",
+    name: "REST API",
+    icon: null,
+    type: POINTS_OF_ATTACK.COMMUNICATION_INTERFACES,
+    projectId: 1,
+    componentId: "comp-1",
+    componentName: "Test Component",
+    ...overrides,
+});
+
 export const createProject = (overrides: Partial<ExtendedProject> = {}): ExtendedProject => ({
     id: 1,
     catalogId: 1,
@@ -116,11 +146,12 @@ export const createProject = (overrides: Partial<ExtendedProject> = {}): Extende
     ...overrides,
 });
 
-export const createConnectionAnchor = (overrides: Partial<ConnectionAnchor> = {}) => ({
+export const createConnectionAnchor = (
+    overrides: Partial<ConnectionAnchor> & { communicationInterfaceId?: string | null } = {}
+) => ({
     id: "comp-1",
     anchor: AnchorOrientation.right,
     type: STANDARD_COMPONENT_TYPES.CLIENT,
-    component: undefined,
     ...overrides,
 });
 

--- a/apps/frontend/src/utils/build-point-of-attack-payload.test.ts
+++ b/apps/frontend/src/utils/build-point-of-attack-payload.test.ts
@@ -1,0 +1,58 @@
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { buildPointOfAttackPayload } from "./build-point-of-attack-payload";
+
+const requiredArgs = {
+    id: "poa-1",
+    type: POINTS_OF_ATTACK.USER_INTERFACE,
+    projectId: 1,
+    componentId: "comp-1",
+};
+
+describe("buildPointOfAttackPayload", () => {
+    it("keeps the required identity fields", () => {
+        const payload = buildPointOfAttackPayload(requiredArgs);
+
+        expect(payload).toMatchObject(requiredArgs);
+    });
+
+    it("defaults every optional field when none are provided", () => {
+        const payload = buildPointOfAttackPayload(requiredArgs);
+
+        expect(payload).toEqual({
+            ...requiredArgs,
+            connectionId: null,
+            connectionPointId: null,
+            name: null,
+            componentName: null,
+            assets: [],
+        });
+    });
+
+    it("keeps the optional fields when they are provided", () => {
+        const payload = buildPointOfAttackPayload({
+            ...requiredArgs,
+            connectionId: "conn-1",
+            connectionPointId: "cp-1",
+            name: "My Point",
+            componentName: "My Component",
+            assets: [7, 8],
+        });
+
+        expect(payload).toEqual({
+            ...requiredArgs,
+            connectionId: "conn-1",
+            connectionPointId: "cp-1",
+            name: "My Point",
+            componentName: "My Component",
+            assets: [7, 8],
+        });
+    });
+
+    it("defaults assets to an empty array rather than sharing one reference", () => {
+        const first = buildPointOfAttackPayload(requiredArgs);
+        const second = buildPointOfAttackPayload(requiredArgs);
+
+        expect(first.assets).toEqual([]);
+        expect(first.assets).not.toBe(second.assets);
+    });
+});

--- a/apps/frontend/src/utils/build-point-of-attack-payload.ts
+++ b/apps/frontend/src/utils/build-point-of-attack-payload.ts
@@ -1,0 +1,21 @@
+import type { SystemPointOfAttack } from "#api/types/system.types.ts";
+
+export type CreatePointOfAttackArgs = Pick<SystemPointOfAttack, "id" | "type" | "projectId" | "componentId"> &
+    Partial<Omit<SystemPointOfAttack, "id" | "type" | "projectId" | "componentId">>;
+
+/**
+ * Pure: it derives output from input only and dispatches nothing.
+ */
+export const buildPointOfAttackPayload = (data: CreatePointOfAttackArgs): SystemPointOfAttack => {
+    return {
+        id: data.id,
+        type: data.type,
+        projectId: data.projectId,
+        componentId: data.componentId,
+        connectionId: data.connectionId ?? null,
+        connectionPointId: data.connectionPointId ?? null,
+        name: data.name ?? null,
+        componentName: data.componentName ?? null,
+        assets: data.assets ?? [],
+    };
+};

--- a/apps/frontend/src/utils/connection-rules.test.ts
+++ b/apps/frontend/src/utils/connection-rules.test.ts
@@ -1,0 +1,110 @@
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { createConnectionAnchor } from "#test-utils/builders.ts";
+import { isSystemOrCustomComponent, validateConnection } from "./connection-rules";
+
+const { USERS, CLIENT, SERVER, DATABASE, COMMUNICATION_INFRASTRUCTURE } = STANDARD_COMPONENT_TYPES;
+
+const CUSTOM_TYPE = 42;
+
+describe("isSystemOrCustomComponent", () => {
+    it.each([CLIENT, SERVER, DATABASE])("treats the standard component %s as a system component", (type) => {
+        expect(isSystemOrCustomComponent(type)).toBe(true);
+    });
+
+    it("treats a numeric (custom) type as a system component", () => {
+        expect(isSystemOrCustomComponent(CUSTOM_TYPE)).toBe(true);
+    });
+
+    it.each([USERS, COMMUNICATION_INFRASTRUCTURE])("does not treat %s as a system component", (type) => {
+        expect(isSystemOrCustomComponent(type)).toBe(false);
+    });
+});
+
+describe("validateConnection", () => {
+    describe("allowed connections", () => {
+        it.each([
+            ["users to a system component", USERS, CLIENT],
+            ["a system component to users", SERVER, USERS],
+            ["users to a custom component", USERS, CUSTOM_TYPE],
+            ["a custom component to users", CUSTOM_TYPE, USERS],
+        ])("allows %s", (_label, fromType, toType) => {
+            const from = createConnectionAnchor({ id: "from", type: fromType });
+            const to = createConnectionAnchor({ id: "to", type: toType });
+
+            expect(validateConnection(from, to)).toEqual({ ok: true });
+        });
+
+        it("allows a system component to communication infrastructure when it carries an interface", () => {
+            const from = createConnectionAnchor({ id: "client-1", type: CLIENT, communicationInterfaceId: "iface-1" });
+            const to = createConnectionAnchor({ id: "infra-1", type: COMMUNICATION_INFRASTRUCTURE });
+
+            expect(validateConnection(from, to)).toEqual({ ok: true });
+        });
+
+        it("allows communication infrastructure to a system component when the target carries an interface", () => {
+            const from = createConnectionAnchor({ id: "infra-1", type: COMMUNICATION_INFRASTRUCTURE });
+            const to = createConnectionAnchor({ id: "client-1", type: CLIENT, communicationInterfaceId: "iface-1" });
+
+            expect(validateConnection(from, to)).toEqual({ ok: true });
+        });
+    });
+
+    describe("disallowed connections", () => {
+        it.each([
+            [
+                "users to communication infrastructure",
+                USERS,
+                COMMUNICATION_INFRASTRUCTURE,
+                "errors.userConnectionInvalid",
+            ],
+            ["users to users", USERS, USERS, "errors.userConnectionInvalid"],
+            [
+                "communication infrastructure to users",
+                COMMUNICATION_INFRASTRUCTURE,
+                USERS,
+                "errors.componentToUserInvalid",
+            ],
+            [
+                "a system component to a non-infrastructure component",
+                CLIENT,
+                SERVER,
+                "errors.componentToCommunicationInfraInvalid",
+            ],
+        ])("rejects %s", (_label, fromType, toType, messageKey) => {
+            const from = createConnectionAnchor({ id: "from", type: fromType });
+            const to = createConnectionAnchor({ id: "to", type: toType });
+
+            expect(validateConnection(from, to)).toEqual({ ok: false, messageKey });
+        });
+
+        it("rejects a system component to communication infrastructure without an interface", () => {
+            const from = createConnectionAnchor({ id: "client-1", type: CLIENT });
+            const to = createConnectionAnchor({ id: "infra-1", type: COMMUNICATION_INFRASTRUCTURE });
+
+            expect(validateConnection(from, to)).toEqual({
+                ok: false,
+                messageKey: "errors.componentToCommunicationInfraInvalid",
+            });
+        });
+
+        it("rejects communication infrastructure to a system component without an interface", () => {
+            const from = createConnectionAnchor({ id: "infra-1", type: COMMUNICATION_INFRASTRUCTURE });
+            const to = createConnectionAnchor({ id: "client-1", type: CLIENT });
+
+            expect(validateConnection(from, to)).toEqual({
+                ok: false,
+                messageKey: "errors.communicationInfraToComponentInvalid",
+            });
+        });
+
+        it("rejects communication infrastructure to communication infrastructure", () => {
+            const from = createConnectionAnchor({ id: "infra-1", type: COMMUNICATION_INFRASTRUCTURE });
+            const to = createConnectionAnchor({ id: "infra-2", type: COMMUNICATION_INFRASTRUCTURE });
+
+            expect(validateConnection(from, to)).toEqual({
+                ok: false,
+                messageKey: "errors.communicationInfraToComponentInvalid",
+            });
+        });
+    });
+});

--- a/apps/frontend/src/utils/connection-rules.ts
+++ b/apps/frontend/src/utils/connection-rules.ts
@@ -1,0 +1,38 @@
+import type { ConnectionAnchor } from "#api/types/system.types.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+
+type ConnectionEndpoint = Pick<ConnectionAnchor, "type" | "communicationInterfaceId">;
+
+export type ValidateConnectionResult = { ok: true } | { ok: false; messageKey: string };
+
+export const isSystemOrCustomComponent = (type: ConnectionEndpoint["type"]): boolean => {
+    return (
+        [STANDARD_COMPONENT_TYPES.CLIENT, STANDARD_COMPONENT_TYPES.SERVER, STANDARD_COMPONENT_TYPES.DATABASE].includes(
+            type as STANDARD_COMPONENT_TYPES
+        ) || typeof type === "number"
+    );
+};
+
+export const validateConnection = (from: ConnectionEndpoint, to: ConnectionEndpoint): ValidateConnectionResult => {
+    if (from.type === STANDARD_COMPONENT_TYPES.USERS) {
+        if (!isSystemOrCustomComponent(to.type)) {
+            return { ok: false, messageKey: "errors.userConnectionInvalid" };
+        }
+    } else if (to.type === STANDARD_COMPONENT_TYPES.USERS) {
+        if (!isSystemOrCustomComponent(from.type)) {
+            return { ok: false, messageKey: "errors.componentToUserInvalid" };
+        }
+    } else if (isSystemOrCustomComponent(from.type)) {
+        if (to.type !== STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE || !from.communicationInterfaceId) {
+            return { ok: false, messageKey: "errors.componentToCommunicationInfraInvalid" };
+        }
+    } else if (from.type === STANDARD_COMPONENT_TYPES.COMMUNICATION_INFRASTRUCTURE) {
+        if (!isSystemOrCustomComponent(to.type) || !to.communicationInterfaceId) {
+            return { ok: false, messageKey: "errors.communicationInfraToComponentInvalid" };
+        }
+    } else {
+        return { ok: false, messageKey: "errors.invalidConnection" };
+    }
+
+    return { ok: true };
+};

--- a/apps/frontend/src/utils/enhance-components.test.ts
+++ b/apps/frontend/src/utils/enhance-components.test.ts
@@ -45,7 +45,7 @@ describe("enhanceComponents", () => {
 
         const result = enhanceComponents(components, standardComponents, null, START_ANCHOR);
 
-        expect(result[0].symbol).toBe("server-symbol");
+        expect(result[0]?.symbol).toBe("server-symbol");
     });
 
     it("keeps the component's own symbol when no standard component matches the type", () => {
@@ -54,7 +54,7 @@ describe("enhanceComponents", () => {
 
         const result = enhanceComponents(components, standardComponents, null, START_ANCHOR);
 
-        expect(result[0].symbol).toBe("own-symbol");
+        expect(result[0]?.symbol).toBe("own-symbol");
     });
 
     it("attaches the start anchor to every component", () => {

--- a/apps/frontend/src/utils/enhance-components.test.ts
+++ b/apps/frontend/src/utils/enhance-components.test.ts
@@ -1,0 +1,75 @@
+import type { EditorComponentType } from "#application/adapters/editor-component-type.adapter.ts";
+import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import { createSystemComponent } from "#test-utils/builders.ts";
+import { enhanceComponents } from "./enhance-components";
+
+const createStandardComponent = (overrides: Partial<EditorComponentType> = {}): EditorComponentType => ({
+    id: STANDARD_COMPONENT_TYPES.CLIENT,
+    name: "Client",
+    pointsOfAttack: [],
+    symbol: "client-symbol",
+    standardIcon: null,
+    ...overrides,
+});
+
+const START_ANCHOR = { id: "anchor-1" };
+
+describe("enhanceComponents", () => {
+    it("returns an empty array when there are no components", () => {
+        expect(enhanceComponents([], [createStandardComponent()], null, START_ANCHOR)).toEqual([]);
+    });
+
+    it("flags only the component whose id matches the selected id", () => {
+        const components = [createSystemComponent({ id: "comp-1" }), createSystemComponent({ id: "comp-2" })];
+
+        const result = enhanceComponents(components, [], "comp-2", START_ANCHOR);
+
+        expect(result.map((c) => c.selected)).toEqual([false, true]);
+    });
+
+    it("flags no component as selected when the selected id is null", () => {
+        const components = [createSystemComponent({ id: "comp-1" }), createSystemComponent({ id: "comp-2" })];
+
+        const result = enhanceComponents(components, [], null, START_ANCHOR);
+
+        expect(result.every((c) => c.selected === false)).toBe(true);
+    });
+
+    it("overrides the symbol with the matching standard component's symbol", () => {
+        const components = [
+            createSystemComponent({ id: "comp-1", type: STANDARD_COMPONENT_TYPES.SERVER, symbol: "own" }),
+        ];
+        const standardComponents = [
+            createStandardComponent({ id: STANDARD_COMPONENT_TYPES.SERVER, symbol: "server-symbol" }),
+        ];
+
+        const result = enhanceComponents(components, standardComponents, null, START_ANCHOR);
+
+        expect(result[0].symbol).toBe("server-symbol");
+    });
+
+    it("keeps the component's own symbol when no standard component matches the type", () => {
+        const components = [createSystemComponent({ id: "comp-1", type: 42, symbol: "own-symbol" })];
+        const standardComponents = [createStandardComponent({ id: STANDARD_COMPONENT_TYPES.CLIENT })];
+
+        const result = enhanceComponents(components, standardComponents, null, START_ANCHOR);
+
+        expect(result[0].symbol).toBe("own-symbol");
+    });
+
+    it("attaches the start anchor to every component", () => {
+        const components = [createSystemComponent({ id: "comp-1" }), createSystemComponent({ id: "comp-2" })];
+
+        const result = enhanceComponents(components, [], null, START_ANCHOR);
+
+        expect(result.every((c) => c.startAnchor === START_ANCHOR)).toBe(true);
+    });
+
+    it("preserves the other component fields", () => {
+        const component = createSystemComponent({ id: "comp-1", name: "My Component", x: 10, y: 20 });
+
+        const [result] = enhanceComponents([component], [], null, START_ANCHOR);
+
+        expect(result).toMatchObject({ id: "comp-1", name: "My Component", x: 10, y: 20 });
+    });
+});

--- a/apps/frontend/src/utils/enhance-components.ts
+++ b/apps/frontend/src/utils/enhance-components.ts
@@ -1,0 +1,34 @@
+import type { AugmentedSystemComponent } from "#api/types/system.types.ts";
+import type { EditorComponentType } from "#application/adapters/editor-component-type.adapter.ts";
+
+export type EnhancedComponent = AugmentedSystemComponent & {
+    selected: boolean;
+    startAnchor: unknown;
+    symbol: string | null;
+};
+
+/**
+ * Merges each system component with its standard symbol and a `selected` flag
+ * for rendering on the canvas. The component's own `symbol` is overridden by the
+ * matching standard component's symbol when one exists. Pure: it derives output
+ * from input only and dispatches nothing.
+ */
+export const enhanceComponents = (
+    components: AugmentedSystemComponent[],
+    standardComponents: EditorComponentType[],
+    selectedComponentId: string | null,
+    startAnchor: unknown
+): EnhancedComponent[] => {
+    return components.map((c) => {
+        // Find the standard component that matches the type of c.
+        const standardComponent = standardComponents.find((sc) => sc.id === c.type);
+
+        return {
+            ...c,
+            selected: selectedComponentId === c.id,
+            startAnchor,
+            // Set the symbol based on the matching standard component.
+            symbol: standardComponent ? standardComponent.symbol : c.symbol,
+        };
+    });
+};

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
@@ -9,6 +9,13 @@ import { SystemComponentConnection } from "./system-component-connection.compone
 
 const defaultEditorState = editorReducer(undefined, { type: "@@INIT" });
 
+// The connection component types each endpoint as a ConnectionAnchor that also
+// carries its resolved component, so the anchors need that field present.
+const connectionAnchor = (overrides: Parameters<typeof createConnectionAnchor>[0] = {}) => ({
+    ...createConnectionAnchor(overrides),
+    component: undefined,
+});
+
 const defaultProps = {
     id: "connection-1",
     name: "Connection 1",
@@ -33,8 +40,8 @@ describe("SystemComponentConnection", () => {
             renderWithProviders(
                 <SystemComponentConnection
                     {...defaultProps}
-                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
-                    to={createConnectionAnchor({ id: "comp-2" })}
+                    from={connectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    to={connectionAnchor({ id: "comp-2" })}
                     fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
                     toComponent={createSystemComponent({ id: "comp-2" })}
                 />
@@ -48,8 +55,8 @@ describe("SystemComponentConnection", () => {
             renderWithProviders(
                 <SystemComponentConnection
                     {...defaultProps}
-                    from={createConnectionAnchor()}
-                    to={createConnectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
+                    from={connectionAnchor()}
+                    to={connectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
                     fromComponent={createSystemComponent()}
                     toComponent={createSystemComponent({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
                 />
@@ -63,8 +70,8 @@ describe("SystemComponentConnection", () => {
             renderWithProviders(
                 <SystemComponentConnection
                     {...defaultProps}
-                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.SERVER })}
-                    to={createConnectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
+                    from={connectionAnchor({ type: STANDARD_COMPONENT_TYPES.SERVER })}
+                    to={connectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
                     fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.SERVER })}
                     toComponent={createSystemComponent({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
                 />
@@ -84,8 +91,8 @@ describe("SystemComponentConnection", () => {
                 <SystemComponentConnection
                     {...defaultProps}
                     waypoints={waypoints}
-                    from={createConnectionAnchor()}
-                    to={createConnectionAnchor({ id: "comp-2" })}
+                    from={connectionAnchor()}
+                    to={connectionAnchor({ id: "comp-2" })}
                     fromComponent={createSystemComponent()}
                     toComponent={createSystemComponent({ id: "comp-2" })}
                 />
@@ -101,8 +108,8 @@ describe("SystemComponentConnection", () => {
                 <SystemComponentConnection
                     {...defaultProps}
                     selected={true}
-                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
-                    to={createConnectionAnchor({ id: "comp-2" })}
+                    from={connectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    to={connectionAnchor({ id: "comp-2" })}
                     fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
                     toComponent={createSystemComponent({ id: "comp-2" })}
                 />
@@ -117,8 +124,8 @@ describe("SystemComponentConnection", () => {
                 <SystemComponentConnection
                     {...defaultProps}
                     selected={true}
-                    from={createConnectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
-                    to={createConnectionAnchor({ id: "comp-2" })}
+                    from={connectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
+                    to={connectionAnchor({ id: "comp-2" })}
                     fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
                     toComponent={createSystemComponent({ id: "comp-2" })}
                 />,


### PR DESCRIPTION
`useEditor` is a ~970-line "god hook". Its richest logic (connection rules,
component enhancement, point-of-attack defaulting) was buried inside it and
hard to test. This PR pins the behaviour down with tests, then extracts the
pure pieces into small, directly-testable utils — without changing behaviour.

## What changed

- **Safety net first** — added characterization tests for the risky behaviour
  of the hook (every `selectConnector` rule, cascade deletes, the three
  communication-interface handlers, asset/precondition guards) using a real
  store and asserting on resulting state.
- **Extracted three pure functions** into `src/utils/`, each with its own
  fast `input → expected` tests (no `renderHook`, no store):
  - `validateConnection` — the connection-rule branches
  - `enhanceComponents` — the `enhancedComponents` merge logic
  - `buildPointOfAttackPayload` — the `createPointOfAttack` defaulting
- Minor cleanup: removed redundant identity wrappers from the editor
  selectors and simplified a communication-interface guard.

The hook keeps owning all dispatch / translation / error handling and shrinks
from **969 → 915 lines**.

## Behaviour & public surface

No behaviour change. The object `useEditor` returns keeps the exact same shape,
so no page, component, or `mockUseEditor` had to change.

## Testing

- Full frontend suite green: **537 tests** (54 files).
- Extracted utils at **94–100 %** coverage; type-check, lint, and format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added extensive coverage for editor hook behaviors: connector selection, connection preview, component/interface mutation flows, and asset attachment rules.
  * Added unit tests for connection validation, component enhancement, and point-of-attack payload building.
  * Updated existing connection-related tests to match the revised anchor shape.

* **Refactor**
  * Centralized connection validation and point-of-attack payload construction into reusable utilities.
  * Simplified editor selectors to expose memoized adapter selectors directly.
  * Refactored the editor hook to rely on shared utilities for enhanced component derivation and validation.

* **Chores**
  * Extended frontend test builders with new component/interface helpers and updated connection-anchor fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->