### PR TITLE
test(e2e): add report page playwright tests

### DIFF
--- a/apps/frontend/playwright/pages/report.page.ts
+++ b/apps/frontend/playwright/pages/report.page.ts
@@ -1,0 +1,37 @@
+import type { Page, Locator } from "@playwright/test";
+import { BasePage } from "./base.page.ts";
+
+export class ReportPage extends BasePage {
+    readonly createPdfButton: Locator;
+    readonly downloadPdfButton: Locator;
+    readonly openPdfButton: Locator;
+    readonly excelExportButton: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.createPdfButton = page.getByRole("button", { name: "Create PDF Document" });
+        this.downloadPdfButton = page.getByRole("link", { name: "Download PDF" });
+        this.openPdfButton = page.getByRole("link", { name: "Open PDF in Browser" });
+        this.excelExportButton = page.getByRole("button", { name: "Click to Download Export" });
+    }
+
+    async goto(projectId: number): Promise<void> {
+        await this.page.goto(`/projects/${projectId}/report`);
+    }
+
+    pageSection(label: string): Locator {
+        return this.page.getByRole("switch", { name: label });
+    }
+
+    languageButton(lang: string): Locator {
+        return this.page.getByRole("main").getByRole("button", { name: lang, exact: true });
+    }
+
+    sortByButton(name: string): Locator {
+        return this.page.getByRole("button", { name, exact: true });
+    }
+
+    get scheduledFromInput(): Locator {
+        return this.page.getByLabel("From");
+    }
+}

--- a/apps/frontend/playwright/tests/report.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/report.page.e2e.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import type { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { getProjects, importProject, deleteProject } from "../utils/project.api.ts";
+import { deleteCatalog } from "../utils/catalog.api.ts";
+import { buildTestId } from "../builder/test-data.builder.ts";
+import { ReportPage } from "../pages/report.page.ts";
+import threatsFixture from "../fixtures/threats.json" with { type: "json" };
+
+type ExportedProject = typeof threatsFixture.project;
+let exportedProject: ExportedProject;
+let projectId: number | undefined;
+let catalogId: number | undefined;
+let projectName: string | undefined;
+
+test.beforeAll(() => {
+    exportedProject = {
+        ...threatsFixture.project,
+        project: {
+            ...threatsFixture.project.project,
+            role: threatsFixture.project.project.role as USER_ROLES,
+        },
+    };
+});
+
+test.beforeEach(async ({ page, request, browserName }, { testId }) => {
+    projectId = undefined;
+    catalogId = undefined;
+    projectName = undefined;
+
+    const pg = new ReportPage(page);
+    await page.goto("/projects");
+    const token = await pg.getCsrfToken();
+    const tid = buildTestId(browserName, testId);
+    const projectData = structuredClone(exportedProject);
+    projectName = `${exportedProject.project.name} ${tid}`;
+    projectData.project.name = projectName;
+    projectData.catalog.name = `${exportedProject.catalog.name} ${tid}`;
+    await importProject(request, token, projectData);
+    const projects = await getProjects(request, token);
+    const project = projects.find((p) => p.name === projectName);
+    if (!project) {
+        throw new Error(`Project "${projectName}" not found after import`);
+    }
+    projectId = project.id;
+    catalogId = project.catalogId;
+    await pg.goto(projectId);
+});
+
+test.afterEach(async ({ page, request }) => {
+    const token = await new ReportPage(page).getCsrfToken();
+    const projects = await getProjects(request, token);
+    const project = projects.find((p) => p.id === projectId || p.name === projectName);
+    if (project) {
+        await deleteProject(request, token, project.id);
+    }
+    const remaining = await getProjects(request, token);
+    const stillUsed = remaining.some((p) => p.catalogId === catalogId);
+    if (catalogId && !stillUsed) {
+        await deleteCatalog(request, token, catalogId);
+    }
+});
+
+test.describe("Report Page Tests", () => {
+    test("Should load the report page with settings panel visible", async ({ page }) => {
+        const pg = new ReportPage(page);
+        await expect(pg.pageSection("Show Cover Page")).toBeVisible();
+        await expect(pg.createPdfButton).toBeVisible();
+    });
+
+    test("Should toggle a page section switch and show create PDF button", async ({ page }) => {
+        const pg = new ReportPage(page);
+        await pg.createPdfButton.click();
+        await expect(pg.downloadPdfButton).toBeVisible({ timeout: 30000 });
+
+        const coverSwitch = pg.pageSection("Show Cover Page");
+        await coverSwitch.click();
+        await expect(pg.createPdfButton).toBeVisible();
+    });
+
+    test("Should generate PDF and show download buttons", async ({ page }) => {
+        const pg = new ReportPage(page);
+        await pg.createPdfButton.click();
+        await expect(pg.downloadPdfButton).toBeVisible({ timeout: 30000 });
+        await expect(pg.openPdfButton).toBeVisible();
+    });
+
+    test("Should download PDF file", async ({ page }) => {
+        const pg = new ReportPage(page);
+        await pg.createPdfButton.click();
+        await expect(pg.downloadPdfButton).toBeVisible({ timeout: 30000 });
+
+        const downloadPromise = page.waitForEvent("download");
+        await pg.downloadPdfButton.click();
+        const download = await downloadPromise;
+        expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+    });
+
+    test("Should switch report language to DE", async ({ page }) => {
+        const pg = new ReportPage(page);
+        const deButton = pg.languageButton("DE");
+        await deButton.click();
+        await expect(deButton).toHaveAttribute("aria-pressed", "true");
+        await expect(pg.languageButton("EN")).toHaveAttribute("aria-pressed", "false");
+    });
+
+    test("Should switch sort to Risk (gross)", async ({ page }) => {
+        const pg = new ReportPage(page);
+        const grossButton = pg.sortByButton("Risk (gross)");
+        await grossButton.click();
+        await expect(grossButton).toHaveAttribute("aria-pressed", "true");
+        await expect(pg.sortByButton("Risk (net)")).toHaveAttribute("aria-pressed", "false");
+    });
+
+    test("Should download Excel export file", async ({ page }) => {
+        const pg = new ReportPage(page);
+        await expect(pg.excelExportButton).toBeVisible();
+
+        const downloadPromise = page.waitForEvent("download");
+        await pg.excelExportButton.click();
+        const download = await downloadPromise;
+        expect(download.suggestedFilename()).toMatch(/\.xlsx$/);
+    });
+
+    test("Should mark report as changed when scheduled at date is set", async ({ page }) => {
+        const pg = new ReportPage(page);
+        await pg.createPdfButton.click();
+        await expect(pg.downloadPdfButton).toBeVisible({ timeout: 30000 });
+
+        await pg.scheduledFromInput.fill("2026-01-01");
+        await expect(pg.createPdfButton).toBeVisible();
+    });
+});

--- a/apps/frontend/playwright/tests/report.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/report.page.e2e.spec.ts
@@ -121,10 +121,17 @@ test.describe("Report Page Tests", () => {
         expect(download.suggestedFilename()).toMatch(/\.xlsx$/);
     });
 
+    test("Should not show download buttons before PDF is generated", async ({ page }) => {
+        const pg = new ReportPage(page);
+        await expect(pg.downloadPdfButton).toBeHidden();
+        await expect(pg.openPdfButton).toBeHidden();
+    });
+
     test("Should mark report as changed when scheduled at date is set", async ({ page }) => {
         const pg = new ReportPage(page);
         await pg.createPdfButton.click();
         await expect(pg.downloadPdfButton).toBeVisible({ timeout: 30000 });
+        await expect(pg.createPdfButton).toBeHidden();
 
         await pg.scheduledFromInput.fill("2026-01-01");
         await expect(pg.createPdfButton).toBeVisible();

--- a/apps/frontend/playwright/tests/report.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/report.page.e2e.spec.ts
@@ -127,6 +127,18 @@ test.describe("Report Page Tests", () => {
         await expect(pg.openPdfButton).toBeHidden();
     });
 
+    test("Should mark report as changed when scheduled at date is cleared", async ({ page }) => {
+        const pg = new ReportPage(page);
+        await pg.scheduledFromInput.fill("2026-01-01");
+        await expect(pg.createPdfButton).toBeVisible();
+        await pg.createPdfButton.click();
+        await expect(pg.downloadPdfButton).toBeVisible({ timeout: 30000 });
+        await expect(pg.createPdfButton).toBeHidden();
+
+        await pg.scheduledFromInput.fill("");
+        await expect(pg.createPdfButton).toBeVisible();
+    });
+
     test("Should mark report as changed when scheduled at date is set", async ({ page }) => {
         const pg = new ReportPage(page);
         await pg.createPdfButton.click();


### PR DESCRIPTION
### Description:

  Adds a new ReportPage Page Object and E2E test suite covering the Report page.

  Tests (9, all passing locally):
  - Page loads with settings panel visible
  - Toggle page section switch → "Create PDF Document" appears
  - Generate PDF → download buttons become visible
  - Download PDF → .pdf file download
  - Switch language to DE
  - Switch sort to Risk (gross)
  - Set Scheduled at date → report marked as changed
  - Excel export → .xlsx file download

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the report page, including generating, downloading, and opening PDFs, plus exporting to Excel.
  * Added UI behavior checks for language and sort selections, cover page toggle behavior, and scheduled “from” date input effects.

* **Tests**
  * Introduced a reusable Playwright page object for the report page to improve locator stability and navigation.
  * Enhanced E2E setup/teardown by cleaning up created project and catalog data after each run, and asserting download filenames (.pdf/.xlsx).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->