### PR TITLE
fix(assets): block save with invalid CIA values

### DIFF
--- a/apps/frontend/src/view/dialogs/add-asset.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/add-asset.dialog.test.tsx
@@ -5,6 +5,8 @@ import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { createAsset } from "#test-utils/builders.ts";
 import { mockUseDialog } from "#test-utils/mock-hooks.ts";
 import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { translationUtil } from "#utils/translations.ts";
+import { MIN_CIA_VALUE, MAX_CIA_VALUE } from "./validation-constants";
 
 mockUseDialog();
 
@@ -78,5 +80,124 @@ describe("AddAssetDialog — onDialogClose prop", () => {
             expect(navigate).toHaveBeenCalledOnce();
         });
         expect(navigate).toHaveBeenCalledWith(-1);
+    });
+});
+
+describe("AddAssetDialog — CIA value validation", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const fields = [
+        {
+            label: translationUtil.t("confidentiality"),
+            maxErrorKey: "errorMessages.confidentialityMax",
+            minErrorKey: "errorMessages.confidentialityMin",
+        },
+        {
+            label: translationUtil.t("integrity"),
+            maxErrorKey: "errorMessages.integrityMax",
+            minErrorKey: "errorMessages.integrityMin",
+        },
+        {
+            label: translationUtil.t("availability"),
+            maxErrorKey: "errorMessages.availabilityMax",
+            minErrorKey: "errorMessages.availabilityMin",
+        },
+    ] as const;
+
+    it.each(fields)(
+        "blocks submit and shows max-value error when $label exceeds MAX_CIA_VALUE",
+        async ({ label, maxErrorKey }) => {
+            const { user } = setup();
+            const input = screen.getByLabelText(label);
+
+            await user.clear(input);
+            await user.type(input, String(MAX_CIA_VALUE + 1));
+            await user.click(screen.getByTestId("save-button"));
+
+            expect(await screen.findByText(translationUtil.t(maxErrorKey))).toBeInTheDocument();
+            expect(navigate).not.toHaveBeenCalled();
+        }
+    );
+
+    it.each(fields)(
+        "blocks submit and shows min-value error when $label is below MIN_CIA_VALUE",
+        async ({ label, minErrorKey }) => {
+            const { user } = setup();
+            const input = screen.getByLabelText(label);
+
+            await user.clear(input);
+            await user.type(input, String(MIN_CIA_VALUE - 1));
+            await user.click(screen.getByTestId("save-button"));
+
+            expect(await screen.findByText(translationUtil.t(minErrorKey))).toBeInTheDocument();
+            expect(navigate).not.toHaveBeenCalled();
+        }
+    );
+
+    it.each(fields)("constrains the $label input via min/max HTML attributes", ({ label }) => {
+        setup();
+        const input = screen.getByLabelText(label);
+
+        expect(input).toHaveAttribute("min", String(MIN_CIA_VALUE));
+        expect(input).toHaveAttribute("max", String(MAX_CIA_VALUE));
+    });
+
+    it("submits when all CIA values are within range", async () => {
+        const { user } = setup();
+
+        await user.click(screen.getByTestId("save-button"));
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith(-1);
+        });
+    });
+});
+
+describe("AddAssetDialog — save button disabled state", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("disables save when the user lacks the editor role", () => {
+        setup({ userRole: USER_ROLES.VIEWER });
+
+        expect(screen.getByTestId("save-button")).toBeDisabled();
+    });
+
+    it("disables save after a CIA value becomes invalid", async () => {
+        const { user } = setup();
+        expect(screen.getByTestId("save-button")).toBeEnabled();
+
+        const input = screen.getByLabelText(translationUtil.t("confidentiality"));
+        await user.clear(input);
+        await user.type(input, String(MAX_CIA_VALUE + 1));
+        await user.tab();
+
+        await waitFor(() => {
+            expect(screen.getByTestId("save-button")).toBeDisabled();
+        });
+    });
+
+    it("re-enables save once the invalid CIA value is corrected", async () => {
+        const { user } = setup();
+        const input = screen.getByLabelText(translationUtil.t("confidentiality"));
+
+        await user.clear(input);
+        await user.type(input, String(MAX_CIA_VALUE + 1));
+        await user.tab();
+
+        await waitFor(() => {
+            expect(screen.getByTestId("save-button")).toBeDisabled();
+        });
+
+        await user.clear(input);
+        await user.type(input, String(MAX_CIA_VALUE));
+        await user.tab();
+
+        await waitFor(() => {
+            expect(screen.getByTestId("save-button")).toBeEnabled();
+        });
     });
 });

--- a/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-asset.dialog.tsx
@@ -76,6 +76,7 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
         handleSubmit,
         formState: { errors },
     } = useForm<AssetDialogFormValues>({
+        mode: "onTouched",
         defaultValues: {
             ...asset,
             id: asset?.id ?? undefined,
@@ -221,8 +222,6 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             }}
                             type="number"
                             label={t("confidentiality")}
-                            min={MIN_CIA_VALUE}
-                            max={MIN_CIA_VALUE}
                             margin="normal"
                             {...register("confidentiality", {
                                 required: t("errorMessages.confidentialityValue"),
@@ -240,6 +239,10 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             helperText={errors?.confidentiality?.message}
                             data-testid="asset-creation-modal_confidentiality-input"
                             slotProps={{
+                                htmlInput: {
+                                    min: MIN_CIA_VALUE,
+                                    max: MAX_CIA_VALUE,
+                                },
                                 input: {
                                     endAdornment: (
                                         <InputAdornment position="end">
@@ -308,8 +311,6 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             type="number"
                             label={t("integrity")}
                             margin="normal"
-                            min={1}
-                            max={5}
                             sx={{
                                 marginLeft: 1,
                                 "& .info-adornment": {
@@ -326,11 +327,11 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                                 required: t("errorMessages.integrityValue"),
                                 valueAsNumber: true,
                                 min: {
-                                    value: 1,
+                                    value: MIN_CIA_VALUE,
                                     message: t("errorMessages.integrityMin"),
                                 },
                                 max: {
-                                    value: 5,
+                                    value: MAX_CIA_VALUE,
                                     message: t("errorMessages.integrityMax"),
                                 },
                             })}
@@ -338,6 +339,10 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             helperText={errors?.integrity?.message}
                             data-testid="asset-creation-modal_integrity-input"
                             slotProps={{
+                                htmlInput: {
+                                    min: MIN_CIA_VALUE,
+                                    max: MAX_CIA_VALUE,
+                                },
                                 input: {
                                     endAdornment: (
                                         <InputAdornment position="end">
@@ -402,8 +407,6 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             type="number"
                             label={t("availability")}
                             margin="normal"
-                            min={1}
-                            max={5}
                             sx={{
                                 marginLeft: 1,
                                 "& .info-adornment": {
@@ -420,11 +423,11 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                                 required: t("errorMessages.availabilityValue"),
                                 valueAsNumber: true,
                                 min: {
-                                    value: 1,
+                                    value: MIN_CIA_VALUE,
                                     message: t("errorMessages.availabilityMin"),
                                 },
                                 max: {
-                                    value: 5,
+                                    value: MAX_CIA_VALUE,
                                     message: t("errorMessages.availabilityMax"),
                                 },
                             })}
@@ -432,6 +435,10 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                             helperText={errors?.availability?.message}
                             data-testid="asset-creation-modal_availability-input"
                             slotProps={{
+                                htmlInput: {
+                                    min: MIN_CIA_VALUE,
+                                    max: MAX_CIA_VALUE,
+                                },
                                 input: {
                                     endAdornment: (
                                         <InputAdornment position="end">
@@ -551,7 +558,7 @@ const AddAssetDialog = ({ projectId, asset, userRole, onDialogClose, ...props }:
                         color="success"
                         sx={{ marginRight: 0 }}
                         data-testid="save-button"
-                        disabled={!checkUserRole(userRole, USER_ROLES.EDITOR)}
+                        disabled={!checkUserRole(userRole, USER_ROLES.EDITOR) || Object.keys(errors).length > 0}
                     >
                         {t("saveBtn")}
                     </Button>


### PR DESCRIPTION
# fix(assets): block save with invalid CIA values

References issue: #<add number>

## What does this PR do

In the asset dialog ("Add/Edit Asset") it was possible to save assets
with invalid CIA values (Confidentiality, Integrity, Availability
outside the 1–5 range). The HTML `min`/`max` constraints did not apply
reliably, and the Save button stayed enabled even when the form had
validation errors.

This PR fixes that:

- **Save button is disabled when validation errors exist** — the core of
  the fix (`disabled` now also gated on `Object.keys(errors).length > 0`).
- **Form validates `onTouched`**, so errors are detected as soon as a
  field is left and the button locks in time.
- **`min`/`max` set correctly via `slotProps.htmlInput`** for all three
  CIA fields (previously included a copy-paste bug: Confidentiality had
  `max = MIN_CIA_VALUE`).
- **Hard-coded bounds (1/5) replaced with `MIN_CIA_VALUE` /
  `MAX_CIA_VALUE`** for consistency and maintainability.

## Definition of Done

- [x] A test for the issue exists and confirms the absence of the issue
- [ ] If necessary - A (negative) e2e-test has been implemented to protect from regressions of this issue
- [x] The Architectural Decision Record was taken into account
- [x] Functional tests and integration tests / e2e-tests have passed successfully
- [ ] If necessary - new config parameters have been described
- [ ] If necessary - Required documentation has been written or updated
- [ ] If necessary - User manual has been updated
