### PR TITLE
refactor(editor): rewrite connection routing to avoid crossings and false merges

### DIFF
--- a/apps/frontend/src/api/types/system.types.ts
+++ b/apps/frontend/src/api/types/system.types.ts
@@ -111,6 +111,9 @@ export interface Connection {
     connectionPoints: string[];
     connectionPointsMeta: ConnectionPointMeta[];
     waypoints: number[];
+    // TODO: since routing moved to use-editor.hook — only the load-time fallback still
+    // reads it. Retire end-to-end (reducer, middleware comparator, builders, backend payload) once no
+    // persisted project relies on it.
     recalculate: boolean;
     projectId: number;
 }

--- a/apps/frontend/src/application/hooks/use-app-redux.hook.ts
+++ b/apps/frontend/src/application/hooks/use-app-redux.hook.ts
@@ -1,5 +1,9 @@
-import { useDispatch, useSelector, type TypedUseSelectorHook } from "react-redux";
+import { useDispatch, useSelector, useStore, type TypedUseSelectorHook } from "react-redux";
+import type { Store } from "@reduxjs/toolkit";
 import type { AppDispatch, RootState } from "#application/store.ts";
+
+type AppStore = Store<RootState> & { dispatch: AppDispatch };
 
 export const useAppDispatch = (): AppDispatch => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useAppStore = (): AppStore => useStore<RootState>() as AppStore;

--- a/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
@@ -772,6 +772,40 @@ describe("useEditor", () => {
                 { gridX: 40, gridY: 0 }
             );
         });
+
+        it("keeps the stored line when no route is possible", () => {
+            // Both endpoints sit on the same grid cell, so the router returns no route.
+            const storedWaypoints = [40, 90, 240, 90];
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-1", gridX: 0, gridY: 0 }))
+                );
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-2", gridX: 0, gridY: 0 }))
+                );
+                store.dispatch(
+                    SystemActions.createConnection(
+                        createConnection({
+                            id: "conn-1",
+                            from: createConnectionAnchor({ id: "comp-1" }),
+                            to: createConnectionAnchor({ id: "comp-2" }),
+                            waypoints: storedWaypoints,
+                            recalculate: true,
+                        })
+                    )
+                );
+                store.dispatch(EditorActions.selectComponent("comp-1"));
+            });
+
+            act(() => {
+                result.current.updateConnectionsOfComponent();
+            });
+
+            // No route found: the stored line stays and the recalculate flag is left as-is.
+            const connection = connectionFromStore(store, "conn-1");
+            expect(connection?.waypoints).toEqual(storedWaypoints);
+            expect(connection?.recalculate).toBe(true);
+        });
     });
 
     // removeAssetFromPointOfAttack only removes an asset that is actually attached

--- a/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
@@ -472,6 +472,95 @@ describe("useEditor", () => {
         });
     });
 
+    // A batch of connections recalculated together only sees each other's old lines, so once the
+    // whole batch has reported, it is flagged one more time (and only one more time) — in that
+    // second pass every member routes against its siblings' fresh lines.
+    describe("connection recalculation second pass", () => {
+        const seedHubWithTwoConnections = (store: EditorStore): void => {
+            store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-1" })));
+            store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-2" })));
+            store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-3" })));
+            store.dispatch(
+                SystemActions.createConnection(
+                    createConnection({
+                        id: "conn-1",
+                        from: createConnectionAnchor({ id: "comp-1" }),
+                        to: createConnectionAnchor({ id: "comp-2" }),
+                    })
+                )
+            );
+            store.dispatch(
+                SystemActions.createConnection(
+                    createConnection({
+                        id: "conn-2",
+                        from: createConnectionAnchor({ id: "comp-1" }),
+                        to: createConnectionAnchor({ id: "comp-3" }),
+                    })
+                )
+            );
+            store.dispatch(EditorActions.selectComponent("comp-1"));
+        };
+
+        const recalculateFlags = (store: EditorStore): (boolean | undefined)[] => [
+            store.getState().system.connections.entities["conn-1"]?.recalculate,
+            store.getState().system.connections.entities["conn-2"]?.recalculate,
+        ];
+
+        it("re-flags the whole batch once after every member reported, then stops", () => {
+            const { result, store } = renderUseEditor(seedHubWithTwoConnections);
+
+            act(() => {
+                result.current.updateConnectionsOfComponent();
+            });
+            expect(recalculateFlags(store)).toEqual([true, true]);
+
+            // First pass: nothing re-flags until the last member reports.
+            act(() => {
+                result.current.connectionRecalculated("conn-1", [0, 0, 10, 0], []);
+            });
+            expect(recalculateFlags(store)).toEqual([false, true]);
+
+            act(() => {
+                result.current.connectionRecalculated("conn-2", [0, 5, 10, 5], []);
+            });
+            expect(recalculateFlags(store)).toEqual([true, true]);
+
+            // Second pass: reporting clears the flags for good — no third pass.
+            act(() => {
+                result.current.connectionRecalculated("conn-1", [0, 0, 10, 0], []);
+                result.current.connectionRecalculated("conn-2", [0, 5, 10, 5], []);
+            });
+            expect(recalculateFlags(store)).toEqual([false, false]);
+        });
+
+        it("does not re-flag a single-connection batch", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-1" })));
+                store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-2" })));
+                store.dispatch(
+                    SystemActions.createConnection(
+                        createConnection({
+                            id: "conn-1",
+                            from: createConnectionAnchor({ id: "comp-1" }),
+                            to: createConnectionAnchor({ id: "comp-2" }),
+                        })
+                    )
+                );
+                store.dispatch(EditorActions.selectComponent("comp-1"));
+            });
+
+            act(() => {
+                result.current.updateConnectionsOfComponent();
+            });
+            expect(store.getState().system.connections.entities["conn-1"]?.recalculate).toBe(true);
+
+            act(() => {
+                result.current.connectionRecalculated("conn-1", [0, 0, 10, 0], []);
+            });
+            expect(store.getState().system.connections.entities["conn-1"]?.recalculate).toBe(false);
+        });
+    });
+
     // removeAssetFromPointOfAttack only removes an asset that is actually attached
     describe("removeAssetFromPointOfAttack", () => {
         it("removes an attached asset and ignores an unattached one", () => {

--- a/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
@@ -547,6 +547,53 @@ describe("useEditor", () => {
             expect(second?.recalculate).toBe(false);
         });
 
+        it("keeps a neighbour's established line and routes the moved component's connection last", () => {
+            const storedStableWaypoints = [240, 80, 240, 100];
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-1", gridX: 0, gridY: 0 }))
+                );
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-2", gridX: 40, gridY: 0 }))
+                );
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-3", gridX: 40, gridY: 20 }))
+                );
+                // conn-stable does not touch the moved component and already has its line.
+                store.dispatch(
+                    SystemActions.createConnection(
+                        createConnection({
+                            id: "conn-stable",
+                            from: createConnectionAnchor({ id: "comp-2" }),
+                            to: createConnectionAnchor({ id: "comp-3" }),
+                            waypoints: storedStableWaypoints,
+                        })
+                    )
+                );
+                store.dispatch(
+                    SystemActions.createConnection(
+                        createConnection({
+                            id: "conn-moved",
+                            from: createConnectionAnchor({ id: "comp-1" }),
+                            to: createConnectionAnchor({ id: "comp-2" }),
+                        })
+                    )
+                );
+                store.dispatch(EditorActions.selectComponent("comp-1"));
+            });
+
+            act(() => {
+                result.current.updateConnectionsOfComponent();
+            });
+
+            expect(connectionFromStore(store, "conn-stable")?.waypoints).toEqual(storedStableWaypoints);
+            expectRoutedBetween(
+                connectionFromStore(store, "conn-moved")!.waypoints,
+                { gridX: 0, gridY: 0 },
+                { gridX: 40, gridY: 0 }
+            );
+        });
+
         it("routes sibling connections without transversal crossings", () => {
             const { result, store } = renderUseEditor(seedHubWithTwoConnections);
 
@@ -588,6 +635,50 @@ describe("useEditor", () => {
             const created = Object.values(store.getState().system.connections.entities)[0];
             expectRoutedBetween(created!.waypoints, { gridX: 0, gridY: 0 }, { gridX: 40, gridY: 0 });
             expect(created?.recalculate).toBe(false);
+        });
+
+        it("routes a duplicate connection between the same pair off the first one's line", () => {
+            const firstWaypoints = [80, 40, 200, 40];
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(
+                    SystemActions.createComponent(
+                        createComponentPayload({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS, gridX: 0 })
+                    )
+                );
+                store.dispatch(
+                    SystemActions.createComponent(
+                        createComponentPayload({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT, gridX: 40 })
+                    )
+                );
+                store.dispatch(
+                    SystemActions.createConnection(
+                        createConnection({
+                            id: "conn-first",
+                            from: createConnectionAnchor({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS }),
+                            to: createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT }),
+                            waypoints: firstWaypoints,
+                        })
+                    )
+                );
+            });
+
+            act(() =>
+                result.current.selectConnector(
+                    createConnectionAnchor({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS })
+                )
+            );
+            act(() =>
+                result.current.selectConnector(
+                    createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT })
+                )
+            );
+
+            const { entities } = store.getState().system.connections;
+            expect(Object.keys(entities)).toHaveLength(2);
+            const duplicate = Object.values(entities).find((connection) => connection?.id !== "conn-first");
+            expect(connectionFromStore(store, "conn-first")?.waypoints).toEqual(firstWaypoints);
+            expectRoutedBetween(duplicate!.waypoints, { gridX: 0, gridY: 0 }, { gridX: 40, gridY: 0 });
+            expect(duplicate!.waypoints).not.toEqual(firstWaypoints);
         });
 
         it("re-routes the surviving connections when one is removed", () => {

--- a/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-editor.hook.test.tsx
@@ -17,6 +17,12 @@ import {
     createConnectionPoint,
     createPointOfAttack,
 } from "#test-utils/builders.ts";
+import {
+    expectNoTransversalCrossings,
+    isOnComponentPerimeter,
+    routeCoversPoint,
+    toPoints,
+} from "#test-utils/connection-routing-helpers.ts";
 import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
 import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 
@@ -472,14 +478,17 @@ describe("useEditor", () => {
         });
     });
 
-    // A batch of connections recalculated together only sees each other's old lines, so once the
-    // whole batch has reported, it is flagged one more time (and only one more time) — in that
-    // second pass every member routes against its siblings' fresh lines.
-    describe("connection recalculation second pass", () => {
+    describe("sequential connection routing", () => {
+        // comp-1 connected to two others on separate grid cells — smallest layout
+        // where sibling routes can interact.
         const seedHubWithTwoConnections = (store: EditorStore): void => {
-            store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-1" })));
-            store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-2" })));
-            store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-3" })));
+            store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-1", gridX: 0, gridY: 0 })));
+            store.dispatch(
+                SystemActions.createComponent(createComponentPayload({ id: "comp-2", gridX: 40, gridY: 0 }))
+            );
+            store.dispatch(
+                SystemActions.createComponent(createComponentPayload({ id: "comp-3", gridX: 40, gridY: 20 }))
+            );
             store.dispatch(
                 SystemActions.createConnection(
                     createConnection({
@@ -501,63 +510,176 @@ describe("useEditor", () => {
             store.dispatch(EditorActions.selectComponent("comp-1"));
         };
 
-        const recalculateFlags = (store: EditorStore): (boolean | undefined)[] => [
-            store.getState().system.connections.entities["conn-1"]?.recalculate,
-            store.getState().system.connections.entities["conn-2"]?.recalculate,
-        ];
+        const connectionFromStore = (store: EditorStore, connectionId: string) =>
+            store.getState().system.connections.entities[connectionId];
 
-        it("re-flags the whole batch once after every member reported, then stops", () => {
+        // A routed connection has one end on each component's box (waypoint order is not
+        // guaranteed to follow the from/to direction).
+        const expectRoutedBetween = (
+            waypoints: number[],
+            first: { gridX: number; gridY: number },
+            second: { gridX: number; gridY: number }
+        ): void => {
+            const points = toPoints(waypoints);
+            expect(points.length).toBeGreaterThanOrEqual(2);
+            const start = points[0]!;
+            const end = points[points.length - 1]!;
+            const connectsBoth =
+                (isOnComponentPerimeter(first.gridX, first.gridY, start) &&
+                    isOnComponentPerimeter(second.gridX, second.gridY, end)) ||
+                (isOnComponentPerimeter(second.gridX, second.gridY, start) &&
+                    isOnComponentPerimeter(first.gridX, first.gridY, end));
+            expect(connectsBoth).toBe(true);
+        };
+
+        it("routes every connection of the moved component and clears the recalculate flags", () => {
             const { result, store } = renderUseEditor(seedHubWithTwoConnections);
 
             act(() => {
                 result.current.updateConnectionsOfComponent();
             });
-            expect(recalculateFlags(store)).toEqual([true, true]);
 
-            // First pass: nothing re-flags until the last member reports.
-            act(() => {
-                result.current.connectionRecalculated("conn-1", [0, 0, 10, 0], []);
-            });
-            expect(recalculateFlags(store)).toEqual([false, true]);
-
-            act(() => {
-                result.current.connectionRecalculated("conn-2", [0, 5, 10, 5], []);
-            });
-            expect(recalculateFlags(store)).toEqual([true, true]);
-
-            // Second pass: reporting clears the flags for good — no third pass.
-            act(() => {
-                result.current.connectionRecalculated("conn-1", [0, 0, 10, 0], []);
-                result.current.connectionRecalculated("conn-2", [0, 5, 10, 5], []);
-            });
-            expect(recalculateFlags(store)).toEqual([false, false]);
+            const first = connectionFromStore(store, "conn-1");
+            expectRoutedBetween(first!.waypoints, { gridX: 0, gridY: 0 }, { gridX: 40, gridY: 0 });
+            expect(first?.recalculate).toBe(false);
+            const second = connectionFromStore(store, "conn-2");
+            expectRoutedBetween(second!.waypoints, { gridX: 0, gridY: 0 }, { gridX: 40, gridY: 20 });
+            expect(second?.recalculate).toBe(false);
         });
 
-        it("does not re-flag a single-connection batch", () => {
-            const { result, store } = renderUseEditor((store) => {
-                store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-1" })));
-                store.dispatch(SystemActions.createComponent(createComponentPayload({ id: "comp-2" })));
-                store.dispatch(
-                    SystemActions.createConnection(
-                        createConnection({
-                            id: "conn-1",
-                            from: createConnectionAnchor({ id: "comp-1" }),
-                            to: createConnectionAnchor({ id: "comp-2" }),
-                        })
-                    )
-                );
-                store.dispatch(EditorActions.selectComponent("comp-1"));
-            });
+        it("routes sibling connections without transversal crossings", () => {
+            const { result, store } = renderUseEditor(seedHubWithTwoConnections);
 
             act(() => {
                 result.current.updateConnectionsOfComponent();
             });
-            expect(store.getState().system.connections.entities["conn-1"]?.recalculate).toBe(true);
+
+            expectNoTransversalCrossings(
+                connectionFromStore(store, "conn-1")!.waypoints,
+                connectionFromStore(store, "conn-2")!.waypoints
+            );
+        });
+
+        it("routes a connection immediately when it is created", () => {
+            const { result, store } = renderUseEditor((store) => {
+                store.dispatch(
+                    SystemActions.createComponent(
+                        createComponentPayload({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS, gridX: 0 })
+                    )
+                );
+                store.dispatch(
+                    SystemActions.createComponent(
+                        createComponentPayload({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT, gridX: 40 })
+                    )
+                );
+            });
+
+            act(() =>
+                result.current.selectConnector(
+                    createConnectionAnchor({ id: "users-1", type: STANDARD_COMPONENT_TYPES.USERS })
+                )
+            );
+            act(() =>
+                result.current.selectConnector(
+                    createConnectionAnchor({ id: "client-1", type: STANDARD_COMPONENT_TYPES.CLIENT })
+                )
+            );
+
+            const created = Object.values(store.getState().system.connections.entities)[0];
+            expectRoutedBetween(created!.waypoints, { gridX: 0, gridY: 0 }, { gridX: 40, gridY: 0 });
+            expect(created?.recalculate).toBe(false);
+        });
+
+        it("re-routes the surviving connections when one is removed", () => {
+            const { result, store } = renderUseEditor(seedHubWithTwoConnections);
 
             act(() => {
-                result.current.connectionRecalculated("conn-1", [0, 0, 10, 0], []);
+                result.current.removeConnection(connectionFromStore(store, "conn-1"));
             });
-            expect(store.getState().system.connections.entities["conn-1"]?.recalculate).toBe(false);
+
+            expect(connectionFromStore(store, "conn-1")).toBeUndefined();
+            const survivor = connectionFromStore(store, "conn-2");
+            expectRoutedBetween(survivor!.waypoints, { gridX: 0, gridY: 0 }, { gridX: 40, gridY: 20 });
+            expect(survivor?.recalculate).toBe(false);
+        });
+
+        it("routes the neighbours' remaining connections through the removed component's space", () => {
+            const { result, store } = renderUseEditor((store) => {
+                // comp-middle sits directly between comp-left and comp-right, which are connected.
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-left", gridX: 0, gridY: 0 }))
+                );
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-middle", gridX: 40, gridY: 0 }))
+                );
+                store.dispatch(
+                    SystemActions.createComponent(createComponentPayload({ id: "comp-right", gridX: 80, gridY: 0 }))
+                );
+                store.dispatch(
+                    SystemActions.createConnection(
+                        createConnection({
+                            id: "conn-across",
+                            from: createConnectionAnchor({ id: "comp-left" }),
+                            to: createConnectionAnchor({ id: "comp-right" }),
+                        })
+                    )
+                );
+                store.dispatch(
+                    SystemActions.createConnection(
+                        createConnection({
+                            id: "conn-doomed",
+                            from: createConnectionAnchor({ id: "comp-left" }),
+                            to: createConnectionAnchor({ id: "comp-middle" }),
+                        })
+                    )
+                );
+                store.dispatch(EditorActions.selectComponent("comp-middle"));
+            });
+
+            act(() => {
+                result.current.removeComponent();
+            });
+
+            expect(store.getState().system.components.entities["comp-middle"]).toBeUndefined();
+            expect(connectionFromStore(store, "conn-doomed")).toBeUndefined();
+            // The surviving route must ignore the removed component: the straight line between
+            // comp-left and comp-right runs through comp-middle's old cell.
+            const survivor = connectionFromStore(store, "conn-across");
+            expect(routeCoversPoint(survivor!.waypoints, { x: 240, y: 40 })).toBe(true);
+        });
+
+        it("routes connections that load without a line and leaves stored routes untouched", () => {
+            const storedWaypoints = [40, 90, 40, 300, 500, 300];
+            const { store } = renderUseEditor((store) => {
+                seedHubWithTwoConnections(store);
+                store.dispatch(SystemActions.setConnection({ id: "conn-2", changes: { waypoints: storedWaypoints } }));
+                store.dispatch(SystemActions.setLoadedProjectId(1));
+            });
+
+            // Only conn-1 loaded without waypoints, so only conn-1 gets routed.
+            expectRoutedBetween(
+                connectionFromStore(store, "conn-1")!.waypoints,
+                { gridX: 0, gridY: 0 },
+                { gridX: 40, gridY: 0 }
+            );
+            expect(connectionFromStore(store, "conn-2")?.waypoints).toEqual(storedWaypoints);
+        });
+
+        it("routes loaded connections even when the system data arrives after mount", () => {
+            // Simulates switching projects: the hook is already mounted when the new
+            // project's connections land in the store.
+            const { store } = renderUseEditor();
+
+            act(() => {
+                seedHubWithTwoConnections(store);
+                store.dispatch(SystemActions.setLoadedProjectId(1));
+            });
+
+            expectRoutedBetween(
+                connectionFromStore(store, "conn-1")!.waypoints,
+                { gridX: 0, gridY: 0 },
+                { gridX: 40, gridY: 0 }
+            );
         });
     });
 

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -320,16 +320,22 @@ export const useEditor = ({
      * from the store because callers dispatch the change that made routes stale right before.
      */
     const routeConnectionsSequentially = useCallback(
-        (connectionIds: Set<string>): void => {
+        (connectionIds: Set<string>, connectionIdsToRouteLast = new Set<string>()): void => {
             const state = store.getState();
             const freshComponents = systemSelectors.selectComponents(state, projectId);
             const freshConnections = systemSelectors.selectConnections(state, projectId);
             const componentById = new Map(freshComponents.map((component) => [component.id, component]));
 
-            // Fixed order, so the same edit always produces the same layout.
+            // Connections whose geometry the edit did not touch route first, so they keep their
+            // established lines; the edited ones route last and adapt around them. Id order breaks
+            // ties, so the same edit always produces the same layout.
             const connectionsToRoute = freshConnections
                 .filter((connection) => connectionIds.has(connection.id))
-                .sort((first, second) => first.id.localeCompare(second.id));
+                .sort((first, second) => {
+                    const firstRoutesLast = connectionIdsToRouteLast.has(first.id) ? 1 : 0;
+                    const secondRoutesLast = connectionIdsToRouteLast.has(second.id) ? 1 : 0;
+                    return firstRoutesLast - secondRoutesLast || first.id.localeCompare(second.id);
+                });
 
             let workingConnections = freshConnections;
             connectionsToRoute.forEach((connection) => {
@@ -340,6 +346,7 @@ export const useEditor = ({
                 }
 
                 const routing = computeConnectionRouting({
+                    connectionId: connection.id,
                     fromComponent,
                     toComponent,
                     components: freshComponents,
@@ -380,7 +387,10 @@ export const useEditor = ({
         [store, dispatch, projectId]
     );
 
-    const recalculateConnectionsOfComponents = (componentIds: string[]): void => {
+    const recalculateConnectionsOfComponents = (
+        componentIds: string[],
+        connectionIdsToRouteLast?: Set<string>
+    ): void => {
         const state = store.getState();
         const freshConnections = systemSelectors.selectConnections(state, projectId);
         const affectedComponents = new Set(componentIds);
@@ -392,7 +402,7 @@ export const useEditor = ({
                 )
                 .map((connection) => connection.id)
         );
-        routeConnectionsSequentially(affectedConnectionIds);
+        routeConnectionsSequentially(affectedConnectionIds, connectionIdsToRouteLast);
     };
 
     const loadedProjectId = useAppSelector((state) => state.system.loadedProjectId);
@@ -711,7 +721,8 @@ export const useEditor = ({
                 })
             );
 
-            recalculateConnectionsOfComponents([from.id, to.id]);
+            // The new connection routes last, adapting around its siblings' established lines.
+            recalculateConnectionsOfComponents([from.id, to.id], new Set([connectionId]));
 
             dispatch(EditorActions.resetConnection());
         }
@@ -822,13 +833,17 @@ export const useEditor = ({
         // Read the store, not the render snapshot — connections may have changed in this same tick.
         const freshConnections = systemSelectors.selectConnections(store.getState(), projectId);
         const affectedComponents = new Set<string>();
+        const movedConnectionIds = new Set<string>();
         freshConnections.forEach((connection) => {
             if (connection.from.id === selectedComponentId || connection.to.id === selectedComponentId) {
                 affectedComponents.add(connection.from.id);
                 affectedComponents.add(connection.to.id);
+                movedConnectionIds.add(connection.id);
             }
         });
-        recalculateConnectionsOfComponents([...affectedComponents]);
+        // The moved component's own connections route last: the neighbours' other connections keep
+        // their established lines and the moved ones adapt around them.
+        recalculateConnectionsOfComponents([...affectedComponents], movedConnectionIds);
     };
 
     const standardComponents = useAppSelector(editorSelectors.selectStandardComponents);

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -299,16 +299,19 @@ export const useEditor = ({
         dispatch(SystemActions.removeComponent({ id: selectedComponentId }));
     };
 
-    const flagAllConnectionsForRecalculation = (): void => {
+    const flagConnectionsForRecalculation = (componentIds: string[]): void => {
+        const affectedComponents = new Set(componentIds);
         connections.forEach((connection) => {
-            dispatch(
-                SystemActions.setConnection({
-                    id: connection.id,
-                    changes: {
-                        recalculate: true,
-                    },
-                })
-            );
+            if (affectedComponents.has(connection.from.id) || affectedComponents.has(connection.to.id)) {
+                dispatch(
+                    SystemActions.setConnection({
+                        id: connection.id,
+                        changes: {
+                            recalculate: true,
+                        },
+                    })
+                );
+            }
         });
     };
 
@@ -334,7 +337,7 @@ export const useEditor = ({
             })
         );
 
-        flagAllConnectionsForRecalculation();
+        flagConnectionsForRecalculation([targetConnection.from.id, targetConnection.to.id]);
     };
 
     const removeConnectionById = (connectionId: string): void => {
@@ -604,7 +607,7 @@ export const useEditor = ({
                 })
             );
 
-            flagAllConnectionsForRecalculation();
+            flagConnectionsForRecalculation([from.id, to.id]);
 
             dispatch(EditorActions.resetConnection());
         }
@@ -709,16 +712,12 @@ export const useEditor = ({
     };
 
     const updateConnectionsOfComponent = (): void => {
+        const affectedComponents = new Set<string>();
         connectionsOfComponent.forEach((connection) => {
-            dispatch(
-                SystemActions.setConnection({
-                    id: connection.id,
-                    changes: {
-                        recalculate: true,
-                    },
-                })
-            );
+            affectedComponents.add(connection.from.id);
+            affectedComponents.add(connection.to.id);
         });
+        flagConnectionsForRecalculation([...affectedComponents]);
     };
 
     const connectionRecalculated = (

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -299,6 +299,19 @@ export const useEditor = ({
         dispatch(SystemActions.removeComponent({ id: selectedComponentId }));
     };
 
+    const flagAllConnectionsForRecalculation = (): void => {
+        connections.forEach((connection) => {
+            dispatch(
+                SystemActions.setConnection({
+                    id: connection.id,
+                    changes: {
+                        recalculate: true,
+                    },
+                })
+            );
+        });
+    };
+
     const removeConnection = (connection?: SystemConnection | null): void => {
         const targetConnection = connection ?? selectedConnection;
         if (!targetConnection) {
@@ -320,6 +333,8 @@ export const useEditor = ({
                 connectionPoints: targetConnection.connectionPoints,
             })
         );
+
+        flagAllConnectionsForRecalculation();
     };
 
     const removeConnectionById = (connectionId: string): void => {
@@ -588,6 +603,8 @@ export const useEditor = ({
                     communicationInterface: null,
                 })
             );
+
+            flagAllConnectionsForRecalculation();
 
             dispatch(EditorActions.resetConnection());
         }

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "@reduxjs/toolkit";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { Asset } from "#api/types/asset.types.ts";
 import type { ComponentType } from "#api/types/component-types.types.ts";
@@ -22,7 +22,11 @@ import { PointsOfAttackActions } from "#application/actions/points-of-attack.act
 import { SystemActions } from "#application/actions/system.actions.ts";
 import { editorSelectors } from "#application/selectors/editor.selectors.ts";
 import { systemSelectors } from "#application/selectors/system.selectors.ts";
-import { useAppDispatch, useAppSelector } from "./use-app-redux.hook";
+import { useAppDispatch, useAppSelector, useAppStore } from "./use-app-redux.hook";
+import {
+    computeConnectionRouting,
+    hasDrawableLine,
+} from "#view/components/editor-components/connection-routing/index.ts";
 import { useSystem } from "./use-system.hook";
 import type { EditorComponentType } from "#application/adapters/editor-component-type.adapter.ts";
 import { validateConnection } from "#utils/connection-rules.ts";
@@ -50,6 +54,7 @@ export const useEditor = ({
     showErrorMessage?: (payload: { message: string }) => void;
 }) => {
     const dispatch = useAppDispatch();
+    const store = useAppStore();
     const { t, i18n } = useTranslation("editorPage");
     const {
         loadSystem,
@@ -284,9 +289,16 @@ export const useEditor = ({
             return;
         }
 
+        // Remove the component and everything attached to it first, then re-route the neighbours'
+        // remaining connections in one go — otherwise they would route around the not-yet-removed
+        // component and its doomed connections.
+        const neighbourComponentIds = new Set<string>();
         connectionsOfComponent.forEach((connection) => {
-            removeConnection(connection);
+            neighbourComponentIds.add(connection.from.id);
+            neighbourComponentIds.add(connection.to.id);
+            removeConnectionWithoutRerouting(connection);
         });
+        neighbourComponentIds.delete(selectedComponentId);
 
         pointsOfAttackOfSelectedComponent.forEach((pointOfAttack) => {
             dispatch(
@@ -297,52 +309,115 @@ export const useEditor = ({
         });
 
         dispatch(SystemActions.removeComponent({ id: selectedComponentId }));
+
+        recalculateConnectionsOfComponents([...neighbourComponentIds]);
     };
 
-    // One batch of connections flagged for recalculation together (see flagConnectionsForRecalculation).
-    const recalculationBatchRef = useRef<{
-        connectionIds: string[];
-        remaining: Set<string>;
-        isSecondPass: boolean;
-    } | null>(null);
+    /**
+     * Routes the given connections one at a time: each route already sees the final lines of the
+     * ones routed before it, so two fresh routes cannot cross by accident (which happens when all
+     * routes are computed at once, each seeing only the others' old lines). Reads state straight
+     * from the store because callers dispatch the change that made routes stale right before.
+     */
+    const routeConnectionsSequentially = useCallback(
+        (connectionIds: Set<string>): void => {
+            const state = store.getState();
+            const freshComponents = systemSelectors.selectComponents(state, projectId);
+            const freshConnections = systemSelectors.selectConnections(state, projectId);
+            const componentById = new Map(freshComponents.map((component) => [component.id, component]));
 
-    const flagConnectionsForRecalculation = (componentIds: string[]): void => {
-        const affectedComponents = new Set(componentIds);
-        const affectedConnectionIds: string[] = [];
-        connections.forEach((connection) => {
-            if (affectedComponents.has(connection.from.id) || affectedComponents.has(connection.to.id)) {
-                affectedConnectionIds.push(connection.id);
+            // Fixed order, so the same edit always produces the same layout.
+            const connectionsToRoute = freshConnections
+                .filter((connection) => connectionIds.has(connection.id))
+                .sort((first, second) => first.id.localeCompare(second.id));
+
+            let workingConnections = freshConnections;
+            connectionsToRoute.forEach((connection) => {
+                const fromComponent = componentById.get(connection.from.id);
+                const toComponent = componentById.get(connection.to.id);
+                if (!fromComponent || !toComponent) {
+                    return;
+                }
+
+                const routing = computeConnectionRouting({
+                    fromComponent,
+                    toComponent,
+                    components: freshComponents,
+                    connections: workingConnections,
+                    from: connection.from,
+                    to: connection.to,
+                    pointsOfAttack: connection.pointsOfAttack,
+                });
+                if (!routing) {
+                    // No route possible (e.g. both endpoints on one grid cell) — keep the stored line.
+                    return;
+                }
+
+                const waypointsUnchanged =
+                    routing.waypoints.length === connection.waypoints.length &&
+                    routing.waypoints.every((value, index) => value === connection.waypoints[index]);
+                if (waypointsUnchanged && connection.recalculate === false) {
+                    // Same line as before — skip the dispatch so untouched connections don't mark
+                    // the project as changed.
+                    return;
+                }
+
+                workingConnections = workingConnections.map((other) =>
+                    other.id === connection.id ? { ...other, waypoints: routing.waypoints } : other
+                );
                 dispatch(
                     SystemActions.setConnection({
                         id: connection.id,
                         changes: {
-                            recalculate: true,
+                            waypoints: routing.waypoints,
+                            connectionPointsMeta: routing.connectionPointsMeta,
+                            recalculate: false,
                         },
                     })
                 );
-            }
-        });
-        // Connections recalculated in the same batch only see each other's OLD lines, so two fresh
-        // routes can cross without either noticing. Remember the batch; once every member has
-        // reported back, connectionRecalculated flags them all a second time — in that pass each one
-        // sees its siblings' fresh lines. A single connection has no sibling to be stale against.
-        recalculationBatchRef.current =
-            affectedConnectionIds.length >= 2
-                ? {
-                      connectionIds: affectedConnectionIds,
-                      remaining: new Set(affectedConnectionIds),
-                      isSecondPass: false,
-                  }
-                : null;
+            });
+        },
+        [store, dispatch, projectId]
+    );
+
+    const recalculateConnectionsOfComponents = (componentIds: string[]): void => {
+        const state = store.getState();
+        const freshConnections = systemSelectors.selectConnections(state, projectId);
+        const affectedComponents = new Set(componentIds);
+        const affectedConnectionIds = new Set(
+            freshConnections
+                .filter(
+                    (connection) =>
+                        affectedComponents.has(connection.from.id) || affectedComponents.has(connection.to.id)
+                )
+                .map((connection) => connection.id)
+        );
+        routeConnectionsSequentially(affectedConnectionIds);
     };
 
-    const removeConnection = (connection?: SystemConnection | null): void => {
-        const targetConnection = connection ?? selectedConnection;
-        if (!targetConnection) {
+    const loadedProjectId = useAppSelector((state) => state.system.loadedProjectId);
+
+    // On load, route only the connections that have no usable line yet; stored routes stay untouched.
+    // Keyed on loadedProjectId (set after the system data landed in the store), not on `initialized` —
+    // that flag stays true across project switches, so an effect keyed on it would fire before the
+    // new project's connections arrive and never again.
+    useEffect(() => {
+        if (loadedProjectId !== projectId) {
             return;
         }
+        const freshConnections = systemSelectors.selectConnections(store.getState(), projectId);
+        const connectionIdsWithoutRoute = new Set(
+            freshConnections
+                .filter((connection) => connection.recalculate || !hasDrawableLine(connection.waypoints))
+                .map((connection) => connection.id)
+        );
+        if (connectionIdsWithoutRoute.size > 0) {
+            routeConnectionsSequentially(connectionIdsWithoutRoute);
+        }
+    }, [loadedProjectId, store, projectId, routeConnectionsSequentially]);
 
-        const pointsOfAttackOfConnection = pointsOfAttack.filter((item) => item.connectionId === targetConnection.id);
+    const removeConnectionWithoutRerouting = (connection: SystemConnection): void => {
+        const pointsOfAttackOfConnection = pointsOfAttack.filter((item) => item.connectionId === connection.id);
         pointsOfAttackOfConnection.forEach((pointOfAttack) => {
             dispatch(
                 PointsOfAttackActions.removePointOfAttack({
@@ -353,12 +428,20 @@ export const useEditor = ({
 
         dispatch(
             SystemActions.removeConnection({
-                id: targetConnection.id,
-                connectionPoints: targetConnection.connectionPoints,
+                id: connection.id,
+                connectionPoints: connection.connectionPoints,
             })
         );
+    };
 
-        flagConnectionsForRecalculation([targetConnection.from.id, targetConnection.to.id]);
+    const removeConnection = (connection?: SystemConnection | null): void => {
+        const targetConnection = connection ?? selectedConnection;
+        if (!targetConnection) {
+            return;
+        }
+
+        removeConnectionWithoutRerouting(targetConnection);
+        recalculateConnectionsOfComponents([targetConnection.from.id, targetConnection.to.id]);
     };
 
     const removeConnectionById = (connectionId: string): void => {
@@ -628,7 +711,7 @@ export const useEditor = ({
                 })
             );
 
-            flagConnectionsForRecalculation([from.id, to.id]);
+            recalculateConnectionsOfComponents([from.id, to.id]);
 
             dispatch(EditorActions.resetConnection());
         }
@@ -733,56 +816,19 @@ export const useEditor = ({
     };
 
     const updateConnectionsOfComponent = (): void => {
+        if (!selectedComponentId) {
+            return;
+        }
+        // Read the store, not the render snapshot — connections may have changed in this same tick.
+        const freshConnections = systemSelectors.selectConnections(store.getState(), projectId);
         const affectedComponents = new Set<string>();
-        connectionsOfComponent.forEach((connection) => {
-            affectedComponents.add(connection.from.id);
-            affectedComponents.add(connection.to.id);
+        freshConnections.forEach((connection) => {
+            if (connection.from.id === selectedComponentId || connection.to.id === selectedComponentId) {
+                affectedComponents.add(connection.from.id);
+                affectedComponents.add(connection.to.id);
+            }
         });
-        flagConnectionsForRecalculation([...affectedComponents]);
-    };
-
-    const connectionRecalculated = (
-        connectionId: string,
-        waypoints: number[],
-        connectionPointsMeta: ConnectionPointMeta[]
-    ): void => {
-        dispatch(
-            SystemActions.setConnection({
-                id: connectionId,
-                changes: {
-                    waypoints,
-                    connectionPointsMeta,
-                    recalculate: false,
-                },
-            })
-        );
-
-        // Second recalculation pass (see flagConnectionsForRecalculation): once the whole batch has
-        // reported its first-pass route, flag it once more so every member re-routes against the
-        // others' fresh lines. The second pass ends here — no third one.
-        const batch = recalculationBatchRef.current;
-        if (!batch?.remaining.delete(connectionId) || batch.remaining.size > 0) {
-            return;
-        }
-        if (batch.isSecondPass) {
-            recalculationBatchRef.current = null;
-            return;
-        }
-        recalculationBatchRef.current = {
-            connectionIds: batch.connectionIds,
-            remaining: new Set(batch.connectionIds),
-            isSecondPass: true,
-        };
-        batch.connectionIds.forEach((id) => {
-            dispatch(
-                SystemActions.setConnection({
-                    id,
-                    changes: {
-                        recalculate: true,
-                    },
-                })
-            );
-        });
+        recalculateConnectionsOfComponents([...affectedComponents]);
     };
 
     const standardComponents = useAppSelector(editorSelectors.selectStandardComponents);
@@ -928,7 +974,6 @@ export const useEditor = ({
         addAssetToSelectedPointOfAttack,
         removeAssetToSelectedPointOfAttack,
         updateConnectionsOfComponent,
-        connectionRecalculated,
         selectConnectionPoint,
         deselectConnectionPoint,
         setMousePointers,

--- a/apps/frontend/src/application/hooks/use-editor.hook.ts
+++ b/apps/frontend/src/application/hooks/use-editor.hook.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "@reduxjs/toolkit";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { Asset } from "#api/types/asset.types.ts";
 import type { ComponentType } from "#api/types/component-types.types.ts";
@@ -299,10 +299,19 @@ export const useEditor = ({
         dispatch(SystemActions.removeComponent({ id: selectedComponentId }));
     };
 
+    // One batch of connections flagged for recalculation together (see flagConnectionsForRecalculation).
+    const recalculationBatchRef = useRef<{
+        connectionIds: string[];
+        remaining: Set<string>;
+        isSecondPass: boolean;
+    } | null>(null);
+
     const flagConnectionsForRecalculation = (componentIds: string[]): void => {
         const affectedComponents = new Set(componentIds);
+        const affectedConnectionIds: string[] = [];
         connections.forEach((connection) => {
             if (affectedComponents.has(connection.from.id) || affectedComponents.has(connection.to.id)) {
+                affectedConnectionIds.push(connection.id);
                 dispatch(
                     SystemActions.setConnection({
                         id: connection.id,
@@ -313,6 +322,18 @@ export const useEditor = ({
                 );
             }
         });
+        // Connections recalculated in the same batch only see each other's OLD lines, so two fresh
+        // routes can cross without either noticing. Remember the batch; once every member has
+        // reported back, connectionRecalculated flags them all a second time — in that pass each one
+        // sees its siblings' fresh lines. A single connection has no sibling to be stale against.
+        recalculationBatchRef.current =
+            affectedConnectionIds.length >= 2
+                ? {
+                      connectionIds: affectedConnectionIds,
+                      remaining: new Set(affectedConnectionIds),
+                      isSecondPass: false,
+                  }
+                : null;
     };
 
     const removeConnection = (connection?: SystemConnection | null): void => {
@@ -735,6 +756,33 @@ export const useEditor = ({
                 },
             })
         );
+
+        // Second recalculation pass (see flagConnectionsForRecalculation): once the whole batch has
+        // reported its first-pass route, flag it once more so every member re-routes against the
+        // others' fresh lines. The second pass ends here — no third one.
+        const batch = recalculationBatchRef.current;
+        if (!batch?.remaining.delete(connectionId) || batch.remaining.size > 0) {
+            return;
+        }
+        if (batch.isSecondPass) {
+            recalculationBatchRef.current = null;
+            return;
+        }
+        recalculationBatchRef.current = {
+            connectionIds: batch.connectionIds,
+            remaining: new Set(batch.connectionIds),
+            isSecondPass: true,
+        };
+        batch.connectionIds.forEach((id) => {
+            dispatch(
+                SystemActions.setConnection({
+                    id,
+                    changes: {
+                        recalculate: true,
+                    },
+                })
+            );
+        });
     };
 
     const standardComponents = useAppSelector(editorSelectors.selectStandardComponents);

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -16,6 +16,7 @@ import {
     type SystemPointOfAttack,
 } from "#api/types/system.types.ts";
 import type { SystemConnectionPoint } from "#application/adapters/system-connection-point.adapter.ts";
+import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
 import { ATTACKERS } from "#api/types/attackers.types.ts";
 import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
@@ -239,3 +240,28 @@ export const createConnection = (overrides: Partial<SystemConnection> = {}): Sys
     communicationInterface: null,
     ...overrides,
 });
+
+export const createAugmentedConnection = (
+    overrides: {
+        id?: string;
+        fromComponent?: AugmentedSystemComponent;
+        toComponent?: AugmentedSystemComponent;
+        pointsOfAttack?: SystemPointOfAttack[];
+        waypoints?: number[];
+    } = {}
+): AugmentedSystemConnection => {
+    const fromComponent = overrides.fromComponent ?? createSystemComponent({ id: "comp-1" });
+    const toComponent = overrides.toComponent ?? createSystemComponent({ id: "comp-2" });
+    const base = createConnection({
+        ...(overrides.id !== undefined ? { id: overrides.id } : {}),
+        from: { id: fromComponent.id, anchor: AnchorOrientation.right, type: fromComponent.type },
+        to: { id: toComponent.id, anchor: AnchorOrientation.left, type: toComponent.type },
+        ...(overrides.waypoints !== undefined ? { waypoints: overrides.waypoints } : {}),
+    });
+    return {
+        ...base,
+        from: { ...base.from, component: fromComponent },
+        to: { ...base.to, component: toComponent },
+        pointsOfAttack: overrides.pointsOfAttack ?? [],
+    };
+};

--- a/apps/frontend/src/test-utils/connection-routing-helpers.ts
+++ b/apps/frontend/src/test-utils/connection-routing-helpers.ts
@@ -69,6 +69,25 @@ export const routeCoversPoint = (waypoints: number[], point: Point): boolean =>
         return onVertical || onHorizontal;
     });
 
+/** True when the point sits on the perimeter of the component box at the given grid cell. */
+export const isOnComponentPerimeter = (gridX: number, gridY: number, point: Point): boolean => {
+    const minX = gridX * 5;
+    const minY = gridY * 5;
+    const maxX = minX + 80;
+    const maxY = minY + 80;
+    const withinBox = point.x >= minX && point.x <= maxX && point.y >= minY && point.y <= maxY;
+    return withinBox && (point.x === minX || point.x === maxX || point.y === minY || point.y === maxY);
+};
+
+/** Asserts no segment of one route X-crosses a segment of the other. */
+export const expectNoTransversalCrossings = (waypointsA: number[], waypointsB: number[]): void => {
+    for (const [firstStart, firstEnd] of segmentsOf(waypointsA)) {
+        for (const [secondStart, secondEnd] of segmentsOf(waypointsB)) {
+            expect(crossesTransversally(firstStart, firstEnd, secondStart, secondEnd)).toBe(false);
+        }
+    }
+};
+
 /**
  * True when a horizontal and a vertical segment cross at a point strictly interior to BOTH (an
  * X-crossing). Shared endpoints and T-junctions (an endpoint of one touching the other) are allowed.

--- a/apps/frontend/src/test-utils/connection-routing-helpers.ts
+++ b/apps/frontend/src/test-utils/connection-routing-helpers.ts
@@ -92,9 +92,24 @@ export const expectNoTransversalCrossings = (waypointsA: number[], waypointsB: n
  * True when a horizontal and a vertical segment cross at a point strictly interior to BOTH (an
  * X-crossing). Shared endpoints and T-junctions (an endpoint of one touching the other) are allowed.
  */
-export const crossesTransversally = (a1: Point, a2: Point, b1: Point, b2: Point): boolean => {
-    const horizontal = a1.y === a2.y ? [a1, a2] : b1.y === b2.y ? [b1, b2] : null;
-    const vertical = a1.x === a2.x ? [a1, a2] : b1.x === b2.x ? [b1, b2] : null;
+export const crossesTransversally = (
+    firstStart: Point,
+    firstEnd: Point,
+    secondStart: Point,
+    secondEnd: Point
+): boolean => {
+    const horizontal =
+        firstStart.y === firstEnd.y
+            ? [firstStart, firstEnd]
+            : secondStart.y === secondEnd.y
+              ? [secondStart, secondEnd]
+              : null;
+    const vertical =
+        firstStart.x === firstEnd.x
+            ? [firstStart, firstEnd]
+            : secondStart.x === secondEnd.x
+              ? [secondStart, secondEnd]
+              : null;
     if (!horizontal || !vertical || horizontal === vertical) {
         return false; // parallel segments — collinear overlap is allowed, not a crossing
     }

--- a/apps/frontend/src/test-utils/connection-routing-helpers.ts
+++ b/apps/frontend/src/test-utils/connection-routing-helpers.ts
@@ -1,0 +1,88 @@
+// Shared assertions/conversions for the connection-routing tests. Lives in test-utils (not a test
+// file) so the per-module test files don't duplicate it; imports `expect` explicitly, like mock-hooks.
+import { expect } from "vitest";
+
+interface Point {
+    x: number;
+    y: number;
+}
+
+/** Splits a flat [x, y, x, y, …] waypoint array into points. */
+export const toPoints = (waypoints: number[]): Point[] => {
+    const points: Point[] = [];
+    for (let index = 0; index < waypoints.length; index += 2) {
+        points.push({ x: waypoints[index] ?? 0, y: waypoints[index + 1] ?? 0 });
+    }
+    return points;
+};
+
+/** The straight segments of a flat waypoint array, as point pairs. */
+export function segmentsOf(waypoints: number[]): [Point, Point][] {
+    const points = toPoints(waypoints);
+    const segments: [Point, Point][] = [];
+    for (let index = 1; index < points.length; index++) {
+        segments.push([points[index - 1]!, points[index]!]);
+    }
+    return segments;
+}
+
+/** The router already simplifies, so each interior point is one direction change. */
+export const bendCountOf = (waypoints: number[]): number => Math.max(0, toPoints(waypoints).length - 2);
+
+/** Asserts every segment of a routed connection runs along a single axis (horizontal or vertical). */
+export const expectOrthogonal = (waypoints: number[]): void => {
+    for (const [previous, current] of segmentsOf(waypoints)) {
+        expect(current.x === previous.x || current.y === previous.y).toBe(true);
+    }
+};
+
+/**
+ * Asserts an endpoint sits on a component's face midpoint and the adjoining segment leaves perpendicular
+ * to that face (outward) — the radial guarantee, whichever face the router picked.
+ */
+export const expectRadialEnd = (gridX: number, gridY: number, endPoint: Point, nextPoint: Point): void => {
+    const minX = gridX * 5;
+    const minY = gridY * 5;
+    const maxX = minX + 80;
+    const maxY = minY + 80;
+    const centerX = (minX + maxX) / 2;
+    const centerY = (minY + maxY) / 2;
+    const faces = [
+        { x: minX, y: centerY, outX: -1, outY: 0 },
+        { x: maxX, y: centerY, outX: 1, outY: 0 },
+        { x: centerX, y: minY, outX: 0, outY: -1 },
+        { x: centerX, y: maxY, outX: 0, outY: 1 },
+    ];
+    const face = faces.find((candidate) => candidate.x === endPoint.x && candidate.y === endPoint.y);
+    expect(face).toBeDefined();
+    expect(Math.sign(nextPoint.x - endPoint.x)).toBe(face!.outX);
+    expect(Math.sign(nextPoint.y - endPoint.y)).toBe(face!.outY);
+};
+
+/** True when `point` lies on one of the route's axis-aligned segments. */
+export const routeCoversPoint = (waypoints: number[], point: Point): boolean =>
+    segmentsOf(waypoints).some(([a, b]) => {
+        const onVertical =
+            a.x === b.x && a.x === point.x && point.y >= Math.min(a.y, b.y) && point.y <= Math.max(a.y, b.y);
+        const onHorizontal =
+            a.y === b.y && a.y === point.y && point.x >= Math.min(a.x, b.x) && point.x <= Math.max(a.x, b.x);
+        return onVertical || onHorizontal;
+    });
+
+/**
+ * True when a horizontal and a vertical segment cross at a point strictly interior to BOTH (an
+ * X-crossing). Shared endpoints and T-junctions (an endpoint of one touching the other) are allowed.
+ */
+export const crossesTransversally = (a1: Point, a2: Point, b1: Point, b2: Point): boolean => {
+    const horizontal = a1.y === a2.y ? [a1, a2] : b1.y === b2.y ? [b1, b2] : null;
+    const vertical = a1.x === a2.x ? [a1, a2] : b1.x === b2.x ? [b1, b2] : null;
+    if (!horizontal || !vertical || horizontal === vertical) {
+        return false; // parallel segments — collinear overlap is allowed, not a crossing
+    }
+    const strictlyBetween = (value: number, bound1: number, bound2: number) =>
+        value > Math.min(bound1, bound2) && value < Math.max(bound1, bound2);
+    return (
+        strictlyBetween(vertical[0]!.x, horizontal[0]!.x, horizontal[1]!.x) &&
+        strictlyBetween(horizontal[0]!.y, vertical[0]!.y, vertical[1]!.y)
+    );
+};

--- a/apps/frontend/src/test-utils/mock-hooks.ts
+++ b/apps/frontend/src/test-utils/mock-hooks.ts
@@ -103,7 +103,6 @@ export const mockUseEditor = (config?: Partial<UseEditorResult>): MockInstance =
         addAssetToSelectedPointOfAttack: vi.fn(),
         removeAssetToSelectedPointOfAttack: vi.fn(),
         updateConnectionsOfComponent: vi.fn(),
-        connectionRecalculated: vi.fn(),
         selectConnectionPoint: vi.fn(),
         deselectConnectionPoint: vi.fn(),
         setMousePointers: vi.fn(),

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
@@ -207,6 +207,41 @@ describe("routeDeterministic line-crossing avoidance", () => {
     });
 });
 
+describe("routeDeterministic duplicate connections between the same pair", () => {
+    it("routes a second connection off its sibling's line instead of on top of it", () => {
+        const fromComponent = createSystemComponent({ id: "from", gridX: 0, gridY: 0 });
+        const toComponent = createSystemComponent({ id: "to", gridX: 60, gridY: 0 });
+        // The first connection's straight line between the facing faces.
+        const siblingWaypoints = [80, 40, 300, 40];
+        const sibling = createAugmentedConnection({
+            id: "sibling",
+            fromComponent,
+            toComponent,
+            waypoints: siblingWaypoints,
+        });
+
+        const routing = routeDeterministic({
+            connectionId: "duplicate",
+            fromComponent,
+            toComponent,
+            components: [fromComponent, toComponent],
+            connections: [sibling],
+            from: { ...createConnectionAnchor({ id: "from" }), component: fromComponent },
+            to: { ...createConnectionAnchor({ id: "to" }), component: toComponent },
+            pointsOfAttack: [],
+        });
+
+        expect(routing).not.toBeNull();
+        expectOrthogonal(routing!.waypoints);
+        // The duplicate must not fuse with the sibling: its mid-section leaves the sibling's y=40 line.
+        expect(routing!.waypoints).not.toEqual(siblingWaypoints);
+        const interiorYs = toPoints(routing!.waypoints)
+            .slice(1, -1)
+            .map((point) => point.y);
+        expect(interiorYs.some((y) => y !== 40)).toBe(true);
+    });
+});
+
 describe("routeDeterministic radial hub entry", () => {
     it("enters a shared hub on the side facing each leaf, so two lines into it do not cross", () => {
         const hub = createSystemComponent({ id: "hub", gridX: 160, gridY: 120 });

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
@@ -30,6 +30,7 @@ const routeBetween = (
     const fromComponent = createSystemComponent({ id: "from", ...fromGrid });
     const toComponent = createSystemComponent({ id: "to", ...toGrid });
     return routeDeterministic({
+        connectionId: "self",
         fromComponent,
         toComponent,
         components: [fromComponent, toComponent, ...(options.obstacles ?? [])],
@@ -183,6 +184,7 @@ describe("routeDeterministic line-crossing avoidance", () => {
 
         const routeAtoB = (connections: AugmentedSystemConnection[]) =>
             routeDeterministic({
+                connectionId: connection.id,
                 fromComponent: boxA,
                 toComponent: boxB,
                 components,
@@ -255,6 +257,7 @@ describe("routeDeterministic radial hub entry", () => {
 
         const routeOf = (connection: AugmentedSystemConnection, leaf: AugmentedSystemComponent) =>
             routeDeterministic({
+                connectionId: connection.id,
                 fromComponent: leaf,
                 toComponent: hub,
                 components,

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
@@ -1,5 +1,5 @@
 import { routeDeterministic } from "./deterministic.ts";
-import { rectOf, segHitsRect } from "./shared.ts";
+import { rectangleOf, segmentHitsRectangle } from "./shared.ts";
 import {
     bendCountOf,
     crossesTransversally,
@@ -115,9 +115,9 @@ describe("routeDeterministic", () => {
         expectOrthogonal(routing!.waypoints);
 
         const points = toPoints(routing!.waypoints);
-        const obstacleRect = rectOf(obstacle);
+        const obstacleRect = rectangleOf(obstacle);
         for (let index = 1; index < points.length; index++) {
-            expect(segHitsRect(points[index - 1]!, points[index]!, obstacleRect)).toBe(false);
+            expect(segmentHitsRectangle(points[index - 1]!, points[index]!, obstacleRect)).toBe(false);
         }
     });
 

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
@@ -206,3 +206,38 @@ describe("routeDeterministic line-crossing avoidance", () => {
         expect(crossesBlocker(withBlocker!.waypoints)).toBe(false);
     });
 });
+
+describe("routeDeterministic radial hub entry", () => {
+    it("enters a shared hub on the side facing each leaf, so two lines into it do not cross", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 160, gridY: 120 });
+        const leftLeaf = createSystemComponent({ id: "left-leaf", gridX: 50, gridY: 80 });
+        const topLeaf = createSystemComponent({ id: "top-leaf", gridX: 130, gridY: 45 });
+        const components = [hub, leftLeaf, topLeaf];
+
+        const leftConnection = createAugmentedConnection({ id: "left-hub", fromComponent: leftLeaf, toComponent: hub });
+        const topConnection = createAugmentedConnection({ id: "top-hub", fromComponent: topLeaf, toComponent: hub });
+        const connections = [leftConnection, topConnection];
+
+        const routeOf = (connection: AugmentedSystemConnection, leaf: AugmentedSystemComponent) =>
+            routeDeterministic({
+                fromComponent: leaf,
+                toComponent: hub,
+                components,
+                connections,
+                from: connection.from,
+                to: connection.to,
+                pointsOfAttack: [],
+            });
+
+        const leftRoute = routeOf(leftConnection, leftLeaf);
+        const topRoute = routeOf(topConnection, topLeaf);
+
+        expect(leftRoute).not.toBeNull();
+        expect(topRoute).not.toBeNull();
+
+        const leftSegments = segmentsOf(leftRoute!.waypoints);
+        const topSegments = segmentsOf(topRoute!.waypoints);
+        const theyCross = leftSegments.some(([a, b]) => topSegments.some(([c, d]) => crossesTransversally(a, b, c, d)));
+        expect(theyCross).toBe(false);
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.test.ts
@@ -1,0 +1,208 @@
+import { routeDeterministic } from "./deterministic.ts";
+import { rectOf, segHitsRect } from "./shared.ts";
+import {
+    bendCountOf,
+    crossesTransversally,
+    expectOrthogonal,
+    expectRadialEnd,
+    segmentsOf,
+    toPoints,
+} from "#test-utils/connection-routing-helpers.ts";
+import {
+    createAugmentedConnection,
+    createConnectionAnchor,
+    createPointOfAttack,
+    createSystemComponent,
+} from "#test-utils/builders.ts";
+import { AnchorOrientation, type AugmentedSystemComponent, type PointOfAttack } from "#api/types/system.types.ts";
+import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
+
+const routeBetween = (
+    fromGrid: { gridX: number; gridY: number },
+    toGrid: { gridX: number; gridY: number },
+    options: {
+        obstacles?: AugmentedSystemComponent[];
+        pointsOfAttack?: PointOfAttack[];
+        fromAnchor?: AnchorOrientation;
+        toAnchor?: AnchorOrientation;
+    } = {}
+) => {
+    const fromComponent = createSystemComponent({ id: "from", ...fromGrid });
+    const toComponent = createSystemComponent({ id: "to", ...toGrid });
+    return routeDeterministic({
+        fromComponent,
+        toComponent,
+        components: [fromComponent, toComponent, ...(options.obstacles ?? [])],
+        connections: [],
+        from: {
+            ...createConnectionAnchor({ id: "from", anchor: options.fromAnchor ?? AnchorOrientation.right }),
+            component: fromComponent,
+        },
+        to: {
+            ...createConnectionAnchor({ id: "to", anchor: options.toAnchor ?? AnchorOrientation.left }),
+            component: toComponent,
+        },
+        pointsOfAttack: options.pointsOfAttack ?? [],
+    });
+};
+
+describe("routeDeterministic", () => {
+    it("routes a horizontally separated pair as an orthogonal line that spans the gap", () => {
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 60, gridY: 0 });
+
+        expect(routing).not.toBeNull();
+        const waypoints = routing!.waypoints;
+        expect(waypoints.length % 2).toBe(0);
+        expectOrthogonal(waypoints);
+
+        const xs = toPoints(waypoints).map((point) => point.x);
+        expect(Math.max(...xs) - Math.min(...xs)).toBeGreaterThan(80);
+    });
+
+    it("routes a vertically separated pair as an orthogonal line that spans the gap", () => {
+        const routing = routeBetween(
+            { gridX: 0, gridY: 0 },
+            { gridX: 0, gridY: 60 },
+            { fromAnchor: AnchorOrientation.bottom, toAnchor: AnchorOrientation.top }
+        );
+
+        expect(routing).not.toBeNull();
+        expectOrthogonal(routing!.waypoints);
+
+        const ys = toPoints(routing!.waypoints).map((point) => point.y);
+        expect(Math.max(...ys) - Math.min(...ys)).toBeGreaterThan(80);
+    });
+
+    it("introduces at least one and at most two bends for a diagonally separated pair", () => {
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 60, gridY: 60 });
+
+        expect(routing).not.toBeNull();
+        expectOrthogonal(routing!.waypoints);
+        expect(bendCountOf(routing!.waypoints)).toBeGreaterThanOrEqual(1);
+        expect(bendCountOf(routing!.waypoints)).toBeLessThanOrEqual(2);
+    });
+
+    it("leaves and enters perpendicular to the chosen faces (radial), horizontally-dominant offset", () => {
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 60, gridY: 40 });
+
+        expect(routing).not.toBeNull();
+        const points = toPoints(routing!.waypoints);
+        expectRadialEnd(0, 0, points[0]!, points[1]!);
+        expectRadialEnd(60, 40, points[points.length - 1]!, points[points.length - 2]!);
+    });
+
+    it("leaves and enters perpendicular to the chosen faces (radial), vertically-dominant offset", () => {
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 40, gridY: 60 });
+
+        expect(routing).not.toBeNull();
+        const points = toPoints(routing!.waypoints);
+        expectRadialEnd(0, 0, points[0]!, points[1]!);
+        expectRadialEnd(40, 60, points[points.length - 1]!, points[points.length - 2]!);
+    });
+
+    it("uses a straight line (no bends) for directly facing, aligned components", () => {
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 60, gridY: 0 });
+
+        expect(routing).not.toBeNull();
+        expect(bendCountOf(routing!.waypoints)).toBe(0);
+    });
+
+    it("chooses a route whose segments clear a component sitting directly between the endpoints", () => {
+        const obstacle = createSystemComponent({ id: "obstacle", gridX: 50, gridY: 0 });
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 100, gridY: 0 }, { obstacles: [obstacle] });
+
+        expect(routing).not.toBeNull();
+        expectOrthogonal(routing!.waypoints);
+
+        const points = toPoints(routing!.waypoints);
+        const obstacleRect = rectOf(obstacle);
+        for (let index = 1; index < points.length; index++) {
+            expect(segHitsRect(points[index - 1]!, points[index]!, obstacleRect)).toBe(false);
+        }
+    });
+
+    it("returns two connection-point meta entries mapped to the provided points of attack", () => {
+        const pointsOfAttack = [createPointOfAttack({ id: "poa-a" }), createPointOfAttack({ id: "poa-b" })];
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 60, gridY: 0 }, { pointsOfAttack });
+
+        expect(routing).not.toBeNull();
+        const meta = routing!.connectionPointsMeta;
+        expect(meta).toHaveLength(2);
+        expect(meta[0]!.pointOfAttack?.id).toBe("poa-a");
+        expect(meta[1]!.pointOfAttack?.id).toBe("poa-b");
+        expect(Number.isFinite(meta[0]!.position.x)).toBe(true);
+        expect(Number.isFinite(meta[0]!.position.y)).toBe(true);
+        // both endpoints use left/right anchors here, so both connection points go horizontally
+        expect(meta[0]!.goesHorizontal).toBe(true);
+        expect(meta[1]!.goesHorizontal).toBe(true);
+    });
+
+    it("sets pointOfAttack to null on meta entries when no points of attack are provided", () => {
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 60, gridY: 0 }, { pointsOfAttack: [] });
+
+        expect(routing).not.toBeNull();
+        expect(routing!.connectionPointsMeta[0]!.pointOfAttack).toBeNull();
+        expect(routing!.connectionPointsMeta[1]!.pointOfAttack).toBeNull();
+    });
+
+    it("returns null for two components at the same position", () => {
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 0, gridY: 0 });
+
+        expect(routing).toBeNull();
+    });
+
+    it("still produces an orthogonal route for closely spaced components", () => {
+        const routing = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 20, gridY: 0 });
+
+        expect(routing).not.toBeNull();
+        expectOrthogonal(routing!.waypoints);
+    });
+
+    it("is deterministic for identical input", () => {
+        const first = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 60, gridY: 40 });
+        const second = routeBetween({ gridX: 0, gridY: 0 }, { gridX: 60, gridY: 40 });
+
+        expect(first).toEqual(second);
+    });
+});
+
+describe("routeDeterministic line-crossing avoidance", () => {
+    it("breaks an equal-cost tie toward the route that does not cross another connection's line", () => {
+        // A symmetric diagonal pair has two equally cheap routes (down-then-right and right-then-down).
+        const boxA = createSystemComponent({ id: "a", gridX: 0, gridY: 0 });
+        const boxB = createSystemComponent({ id: "b", gridX: 20, gridY: 20 });
+        const components = [boxA, boxB];
+        const connection = createAugmentedConnection({ id: "a-b", fromComponent: boxA, toComponent: boxB });
+        // An existing line at x=60 — on the route the router would otherwise pick, not on the alternative.
+        const blocker = createAugmentedConnection({
+            id: "blocker",
+            fromComponent: createSystemComponent({ id: "c", gridX: 100, gridY: 0 }),
+            toComponent: createSystemComponent({ id: "d", gridX: 100, gridY: 40 }),
+            waypoints: [60, 0, 60, 200],
+        });
+
+        const routeAtoB = (connections: AugmentedSystemConnection[]) =>
+            routeDeterministic({
+                fromComponent: boxA,
+                toComponent: boxB,
+                components,
+                connections,
+                from: connection.from,
+                to: connection.to,
+                pointsOfAttack: [],
+            });
+
+        const blockerStart = { x: 60, y: 0 };
+        const blockerEnd = { x: 60, y: 200 };
+        const crossesBlocker = (waypoints: number[]): boolean =>
+            segmentsOf(waypoints).some(([a, b]) => crossesTransversally(a, b, blockerStart, blockerEnd));
+
+        // With no other line in the way, the default tiebreak picks the route that crosses x=60...
+        const withoutBlocker = routeAtoB([connection]);
+        expect(crossesBlocker(withoutBlocker!.waypoints)).toBe(true);
+
+        // ...and once that line exists, the router switches to the equally-cheap route that avoids it.
+        const withBlocker = routeAtoB([connection, blocker]);
+        expect(crossesBlocker(withBlocker!.waypoints)).toBe(false);
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
@@ -1,0 +1,297 @@
+/**
+ * Deterministic router: one straight-out line per connection — fewest turns, avoids boxes and other
+ * lines where it can. This is the fallback used whenever connections don't form a fishbone.
+ */
+import { AnchorOrientation, type AugmentedSystemComponent, type ConnectionPointMeta } from "#api/types/system.types.ts";
+import {
+    type ConnectionRoutingInput,
+    type ConnectionRoutingResult,
+    type Face,
+    type Point,
+    type Rectangle,
+    GEOMETRY_TOLERANCE,
+    allFinite,
+    buildAnchorMeta,
+    countObstacleHits,
+    faceMidpoint,
+    findBestAnchor,
+    flattenPoints,
+    isHorizontalFace,
+    isOrthogonal,
+    outwardUnit,
+    rectOf,
+    routeLength,
+    sameDirection,
+    simplifyPolyline,
+    stepDirection,
+} from "./shared.ts";
+
+const WRAP_CLEARANCE = 20; // how far outside the boxes a wrap-around line routes, in pixels
+
+interface ScoredRoute {
+    points: Point[];
+    sourceFace: Face;
+    targetFace: Face;
+    obstacleHits: number;
+    crossings: number;
+    bendCount: number;
+    length: number;
+    facePairRank: number;
+    candidateRank: number;
+}
+
+// ----- face selection -----
+
+/** A backup face turned 90° from the primary, still leaning toward the other component — lets a connection route around a blocked side. */
+const alternateFace = (face: Face, self: AugmentedSystemComponent, other: AugmentedSystemComponent): Face => {
+    if (isHorizontalFace(face)) {
+        return other.gridY > self.gridY ? AnchorOrientation.bottom : AnchorOrientation.top;
+    }
+    return other.gridX > self.gridX ? AnchorOrientation.right : AnchorOrientation.left;
+};
+
+const candidateFaces = (self: AugmentedSystemComponent, other: AugmentedSystemComponent): Face[] => {
+    const primary = findBestAnchor(self, other) as Face;
+    const alternate = alternateFace(primary, self, other);
+    return primary === alternate ? [primary] : [primary, alternate];
+};
+
+// ----- connector between the two attach points -----
+
+/**
+ * Lists the possible right-angled line shapes between the two attach points: straight, the two
+ * L-shapes, two Z-shapes, and wrap-around paths that go outside both boxes (for when the faces point
+ * away from each other). Each entry is just the corner points in between — the two ends are added by
+ * the caller, which then checks and ranks them.
+ */
+const buildConnectorCandidates = (p: Point, q: Point, fromRectangle: Rectangle, toRectangle: Rectangle): Point[][] => {
+    const candidates: Point[][] = [];
+
+    if (Math.abs(p.x - q.x) < GEOMETRY_TOLERANCE || Math.abs(p.y - q.y) < GEOMETRY_TOLERANCE) {
+        candidates.push([]); // straight
+    }
+
+    candidates.push([{ x: q.x, y: p.y }]); // L, horizontal first
+    candidates.push([{ x: p.x, y: q.y }]); // L, vertical first
+
+    const midX = (p.x + q.x) / 2;
+    const midY = (p.y + q.y) / 2;
+    candidates.push([
+        { x: midX, y: p.y },
+        { x: midX, y: q.y },
+    ]); // Z, vertical channel at mid-x
+    candidates.push([
+        { x: p.x, y: midY },
+        { x: q.x, y: midY },
+    ]); // Z, horizontal channel at mid-y
+
+    const unionMinX = Math.min(fromRectangle.minX, toRectangle.minX);
+    const unionMaxX = Math.max(fromRectangle.maxX, toRectangle.maxX);
+    const unionMinY = Math.min(fromRectangle.minY, toRectangle.minY);
+    const unionMaxY = Math.max(fromRectangle.maxY, toRectangle.maxY);
+    for (const channelX of [unionMinX - WRAP_CLEARANCE, unionMaxX + WRAP_CLEARANCE]) {
+        candidates.push([
+            { x: channelX, y: p.y },
+            { x: channelX, y: q.y },
+        ]);
+    }
+    for (const channelY of [unionMinY - WRAP_CLEARANCE, unionMaxY + WRAP_CLEARANCE]) {
+        candidates.push([
+            { x: p.x, y: channelY },
+            { x: q.x, y: channelY },
+        ]);
+    }
+
+    return candidates;
+};
+
+// ----- line-crossing avoidance -----
+
+interface Segment {
+    start: Point;
+    end: Point;
+}
+
+/** Reads a flat [x, y, x, y, …] waypoint array back into points. */
+const pointsFromWaypoints = (waypoints: number[]): Point[] => {
+    const points: Point[] = [];
+    for (let index = 0; index + 1 < waypoints.length; index += 2) {
+        points.push({ x: waypoints[index]!, y: waypoints[index + 1]! });
+    }
+    return points;
+};
+
+/** The straight segments of a polyline. */
+const segmentsOfPoints = (points: Point[]): Segment[] => {
+    const segments: Segment[] = [];
+    for (let index = 1; index < points.length; index++) {
+        segments.push({ start: points[index - 1]!, end: points[index]! });
+    }
+    return segments;
+};
+
+const isHorizontalSegment = (segment: Segment): boolean =>
+    segment.start.y === segment.end.y && segment.start.x !== segment.end.x;
+
+const isVerticalSegment = (segment: Segment): boolean =>
+    segment.start.x === segment.end.x && segment.start.y !== segment.end.y;
+
+/**
+ * True when one horizontal and one vertical segment cross at a point inside BOTH. Lines that only
+ * touch at an end (a shared box, a T-junction) don't count — so connections meeting at the same
+ * component aren't mistaken for a crossing.
+ */
+const segmentsCrossTransversally = (first: Segment, second: Segment): boolean => {
+    let horizontal: Segment;
+    let vertical: Segment;
+    if (isHorizontalSegment(first) && isVerticalSegment(second)) {
+        horizontal = first;
+        vertical = second;
+    } else if (isVerticalSegment(first) && isHorizontalSegment(second)) {
+        horizontal = second;
+        vertical = first;
+    } else {
+        return false; // parallel — a side-by-side or collinear overlap is not a crossing
+    }
+    const strictlyBetween = (value: number, bound1: number, bound2: number): boolean =>
+        value > Math.min(bound1, bound2) && value < Math.max(bound1, bound2);
+    return (
+        strictlyBetween(vertical.start.x, horizontal.start.x, horizontal.end.x) &&
+        strictlyBetween(horizontal.start.y, vertical.start.y, vertical.end.y)
+    );
+};
+
+/** How many of the other connections' segments this route crosses (used to prefer non-crossing routes). */
+const countLineCrossings = (points: Point[], otherSegments: Segment[]): number => {
+    let crossings = 0;
+    for (const routeSegment of segmentsOfPoints(points)) {
+        for (const otherSegment of otherSegments) {
+            if (segmentsCrossTransversally(routeSegment, otherSegment)) {
+                crossings++;
+            }
+        }
+    }
+    return crossings;
+};
+
+// Ranks two routes: avoid component boxes first, then keep turns few, then cross fewer other lines,
+// then stay short — with face/candidate order as the final, fully deterministic tiebreak.
+const isBetterRoute = (candidate: ScoredRoute, best: ScoredRoute): boolean => {
+    if (candidate.obstacleHits !== best.obstacleHits) {
+        return candidate.obstacleHits < best.obstacleHits;
+    }
+    if (candidate.bendCount !== best.bendCount) {
+        return candidate.bendCount < best.bendCount;
+    }
+    if (candidate.crossings !== best.crossings) {
+        return candidate.crossings < best.crossings;
+    }
+    const candidateLength = Math.round(candidate.length * 1000);
+    const bestLength = Math.round(best.length * 1000);
+    if (candidateLength !== bestLength) {
+        return candidateLength < bestLength;
+    }
+    if (candidate.facePairRank !== best.facePairRank) {
+        return candidate.facePairRank < best.facePairRank;
+    }
+    return candidate.candidateRank < best.candidateRank;
+};
+
+/**
+ * Works out the waypoints + connection-point info for one connection WITHOUT trunk-merging. Returns
+ * null when no route is possible.
+ */
+export function routeDeterministic({
+    fromComponent,
+    toComponent,
+    components,
+    connections,
+    from,
+    to,
+    pointsOfAttack,
+}: ConnectionRoutingInput): ConnectionRoutingResult | null {
+    // Same spot — nothing to draw.
+    if (fromComponent.gridX === toComponent.gridX && fromComponent.gridY === toComponent.gridY) {
+        return null;
+    }
+
+    const fromRectangle = rectOf(fromComponent);
+    const toRectangle = rectOf(toComponent);
+    const obstacles = components
+        .filter((component) => component.id !== fromComponent.id && component.id !== toComponent.id)
+        .map(rectOf);
+
+    // The other connections' drawn lines (from their cached waypoints), so equal-cost routes can
+    // prefer the one that crosses fewer of them. This connection's own line is left out.
+    const otherSegments: Segment[] = [];
+    for (const connection of connections) {
+        const isThisConnection =
+            (connection.from.id === from.id && connection.to.id === to.id) ||
+            (connection.from.id === to.id && connection.to.id === from.id);
+        if (isThisConnection) {
+            continue;
+        }
+        for (const segment of segmentsOfPoints(pointsFromWaypoints(connection.waypoints))) {
+            otherSegments.push(segment);
+        }
+    }
+
+    const sourceFaces = candidateFaces(fromComponent, toComponent);
+    const targetFaces = candidateFaces(toComponent, fromComponent);
+
+    let best: ScoredRoute | null = null;
+
+    for (const [sourceIndex, sourceFace] of sourceFaces.entries()) {
+        const sourceAttach = faceMidpoint(fromComponent, sourceFace);
+        const sourceOutward = outwardUnit(sourceFace);
+
+        for (const [targetIndex, targetFace] of targetFaces.entries()) {
+            const targetAttach = faceMidpoint(toComponent, targetFace);
+            const targetOutward = outwardUnit(targetFace);
+            // Entering the target means moving inward — the opposite of its outward arrow.
+            const targetInward = { x: -targetOutward.x, y: -targetOutward.y };
+            const facePairRank = sourceIndex * 2 + targetIndex;
+
+            const candidates = buildConnectorCandidates(sourceAttach, targetAttach, fromRectangle, toRectangle);
+            for (const [candidateRank, corners] of candidates.entries()) {
+                const points = simplifyPolyline([sourceAttach, ...corners, targetAttach]);
+                if (points.length < 2 || !isOrthogonal(points) || !allFinite(points)) {
+                    continue;
+                }
+                // Straight-out ends: the first segment must leave the source face outward and the last
+                // must enter the target face inward. Segments run to the real corner, no short stub.
+                const firstStep = stepDirection(points[0]!, points[1]!);
+                const lastStep = stepDirection(points[points.length - 2]!, points[points.length - 1]!);
+                if (!sameDirection(firstStep, sourceOutward) || !sameDirection(lastStep, targetInward)) {
+                    continue;
+                }
+
+                const scored: ScoredRoute = {
+                    points,
+                    sourceFace,
+                    targetFace,
+                    obstacleHits: countObstacleHits(points, obstacles),
+                    crossings: countLineCrossings(points, otherSegments),
+                    bendCount: Math.max(0, points.length - 2),
+                    length: routeLength(points),
+                    facePairRank,
+                    candidateRank,
+                };
+                if (best === null || isBetterRoute(scored, best)) {
+                    best = scored;
+                }
+            }
+        }
+    }
+
+    if (!best) {
+        return null;
+    }
+
+    const connectionPointsMeta: ConnectionPointMeta[] = [
+        buildAnchorMeta(fromComponent, best.sourceFace, from.anchor, pointsOfAttack[0] ?? null),
+        buildAnchorMeta(toComponent, best.targetFace, to.anchor, pointsOfAttack[1] ?? null),
+    ];
+
+    return { waypoints: flattenPoints(best.points), connectionPointsMeta };
+}

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
@@ -23,7 +23,7 @@ import {
     isHorizontalFace,
     isOrthogonal,
     outwardUnit,
-    rectOf,
+    rectangleOf,
     routeLength,
     sameDirection,
     simplifyPolyline,
@@ -73,29 +73,37 @@ const candidateFaces = (self: AugmentedSystemComponent, other: AugmentedSystemCo
  * wrap-arounds outside both boxes. Each entry holds only the corner points — the caller adds the
  * two ends, then checks and ranks.
  */
-const buildConnectorCandidates = (p: Point, q: Point, fromRectangle: Rectangle, toRectangle: Rectangle): Point[][] => {
+const buildConnectorCandidates = (
+    sourceAttach: Point,
+    targetAttach: Point,
+    fromRectangle: Rectangle,
+    toRectangle: Rectangle
+): Point[][] => {
     const candidates: Point[][] = [];
 
-    if (Math.abs(p.x - q.x) < GEOMETRY_TOLERANCE || Math.abs(p.y - q.y) < GEOMETRY_TOLERANCE) {
+    if (
+        Math.abs(sourceAttach.x - targetAttach.x) < GEOMETRY_TOLERANCE ||
+        Math.abs(sourceAttach.y - targetAttach.y) < GEOMETRY_TOLERANCE
+    ) {
         candidates.push([]); // straight
     }
 
-    candidates.push([{ x: q.x, y: p.y }]); // L, horizontal first
-    candidates.push([{ x: p.x, y: q.y }]); // L, vertical first
+    candidates.push([{ x: targetAttach.x, y: sourceAttach.y }]); // L, horizontal first
+    candidates.push([{ x: sourceAttach.x, y: targetAttach.y }]); // L, vertical first
 
-    const midX = (p.x + q.x) / 2;
-    const midY = (p.y + q.y) / 2;
+    const midX = (sourceAttach.x + targetAttach.x) / 2;
+    const midY = (sourceAttach.y + targetAttach.y) / 2;
     // Z-shapes at the middle channel plus nudged ones, so a route can sidestep an occupied channel.
     for (const channelX of [midX, midX - CHANNEL_NUDGE, midX + CHANNEL_NUDGE]) {
         candidates.push([
-            { x: channelX, y: p.y },
-            { x: channelX, y: q.y },
+            { x: channelX, y: sourceAttach.y },
+            { x: channelX, y: targetAttach.y },
         ]);
     }
     for (const channelY of [midY, midY - CHANNEL_NUDGE, midY + CHANNEL_NUDGE]) {
         candidates.push([
-            { x: p.x, y: channelY },
-            { x: q.x, y: channelY },
+            { x: sourceAttach.x, y: channelY },
+            { x: targetAttach.x, y: channelY },
         ]);
     }
 
@@ -105,14 +113,14 @@ const buildConnectorCandidates = (p: Point, q: Point, fromRectangle: Rectangle, 
     const unionMaxY = Math.max(fromRectangle.maxY, toRectangle.maxY);
     for (const channelX of [unionMinX - WRAP_CLEARANCE, unionMaxX + WRAP_CLEARANCE]) {
         candidates.push([
-            { x: channelX, y: p.y },
-            { x: channelX, y: q.y },
+            { x: channelX, y: sourceAttach.y },
+            { x: channelX, y: targetAttach.y },
         ]);
     }
     for (const channelY of [unionMinY - WRAP_CLEARANCE, unionMaxY + WRAP_CLEARANCE]) {
         candidates.push([
-            { x: p.x, y: channelY },
-            { x: q.x, y: channelY },
+            { x: sourceAttach.x, y: channelY },
+            { x: targetAttach.x, y: channelY },
         ]);
     }
 
@@ -151,8 +159,8 @@ export function routeDeterministic(input: ConnectionRoutingInput): ConnectionRou
         return null;
     }
 
-    const fromRectangle = rectOf(fromComponent);
-    const toRectangle = rectOf(toComponent);
+    const fromRectangle = rectangleOf(fromComponent);
+    const toRectangle = rectangleOf(toComponent);
     const scoringContext = buildRouteScoringContext(input);
 
     const degree = buildDegreeMap(connections);

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
@@ -217,6 +217,7 @@ const isBetterRoute = (candidate: ScoredRoute, best: ScoredRoute): boolean => {
 
 /** Computes the waypoints + connection-point info for one connection. Null when no route is possible. */
 export function routeDeterministic({
+    connectionId,
     fromComponent,
     toComponent,
     components,
@@ -242,13 +243,15 @@ export function routeDeterministic({
     const unrelatedSegments: Segment[] = [];
     const ownEndpointIds = new Set([from.id, to.id]);
     for (const connection of connections) {
-        const isThisConnection =
+        const isSamePair =
             (connection.from.id === from.id && connection.to.id === to.id) ||
             (connection.from.id === to.id && connection.to.id === from.id);
+        const isThisConnection = connectionId !== undefined ? connection.id === connectionId : isSamePair;
         if (isThisConnection) {
             continue;
         }
-        const sharesEndpoint = ownEndpointIds.has(connection.from.id) || ownEndpointIds.has(connection.to.id);
+        const sharesEndpoint =
+            !isSamePair && (ownEndpointIds.has(connection.from.id) || ownEndpointIds.has(connection.to.id));
         for (const segment of segmentsOfPoints(pointsFromWaypoints(connection.waypoints))) {
             otherSegments.push(segment);
             if (!sharesEndpoint) {

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
@@ -1,6 +1,6 @@
 /**
- * Deterministic router: one straight-out line per connection — fewest turns, avoids boxes and other
- * lines where it can. This is the fallback used whenever connections don't form a fishbone.
+ * Deterministic router: routes one connection on its own — no trunk merging. Fallback whenever
+ * connections don't form a fishbone.
  */
 import { AnchorOrientation, type AugmentedSystemComponent, type ConnectionPointMeta } from "#api/types/system.types.ts";
 import {
@@ -21,6 +21,7 @@ import {
     isHorizontalFace,
     isOrthogonal,
     outwardUnit,
+    pointsFromWaypoints,
     rectOf,
     routeLength,
     sameDirection,
@@ -29,6 +30,7 @@ import {
 } from "./shared.ts";
 
 const WRAP_CLEARANCE = 20; // how far outside the boxes a wrap-around line routes, in pixels
+const CHANNEL_NUDGE = 20; // sideways offset for the extra Z-channels that dodge an occupied channel
 
 interface ScoredRoute {
     points: Point[];
@@ -36,6 +38,7 @@ interface ScoredRoute {
     targetFace: Face;
     obstacleHits: number;
     crossings: number;
+    overlapLength: number;
     bendCount: number;
     length: number;
     hubFacePenalty: number;
@@ -45,27 +48,32 @@ interface ScoredRoute {
 
 // ----- face selection -----
 
-/** A backup face turned 90° from the primary, still leaning toward the other component — lets a connection route around a blocked side. */
-const alternateFace = (face: Face, self: AugmentedSystemComponent, other: AugmentedSystemComponent): Face => {
-    if (isHorizontalFace(face)) {
-        return other.gridY > self.gridY ? AnchorOrientation.bottom : AnchorOrientation.top;
+/**
+ * The faces to try, best first: the face pointing at the other component, then the 90° turn toward
+ * it, then the 90° turn away from it.
+ */
+const extendedCandidateFaces = (self: AugmentedSystemComponent, other: AugmentedSystemComponent): Face[] => {
+    const primary = findBestAnchor(self, other) as Face;
+    if (isHorizontalFace(primary)) {
+        return other.gridY > self.gridY
+            ? [primary, AnchorOrientation.bottom, AnchorOrientation.top]
+            : [primary, AnchorOrientation.top, AnchorOrientation.bottom];
     }
-    return other.gridX > self.gridX ? AnchorOrientation.right : AnchorOrientation.left;
+    return other.gridX > self.gridX
+        ? [primary, AnchorOrientation.right, AnchorOrientation.left]
+        : [primary, AnchorOrientation.left, AnchorOrientation.right];
 };
 
-const candidateFaces = (self: AugmentedSystemComponent, other: AugmentedSystemComponent): Face[] => {
-    const primary = findBestAnchor(self, other) as Face;
-    const alternate = alternateFace(primary, self, other);
-    return primary === alternate ? [primary] : [primary, alternate];
-};
+/** The normal face set: primary + toward-side turn. The away-side face is escalation-only. */
+const candidateFaces = (self: AugmentedSystemComponent, other: AugmentedSystemComponent): Face[] =>
+    extendedCandidateFaces(self, other).slice(0, 2);
 
 // ----- connector between the two attach points -----
 
 /**
- * Lists the possible right-angled line shapes between the two attach points: straight, the two
- * L-shapes, two Z-shapes, and wrap-around paths that go outside both boxes (for when the faces point
- * away from each other). Each entry is just the corner points in between — the two ends are added by
- * the caller, which then checks and ranks them.
+ * The right-angled line shapes between the two attach points: straight, L-shapes, Z-shapes, and
+ * wrap-arounds outside both boxes. Each entry holds only the corner points — the caller adds the
+ * two ends, then checks and ranks.
  */
 const buildConnectorCandidates = (p: Point, q: Point, fromRectangle: Rectangle, toRectangle: Rectangle): Point[][] => {
     const candidates: Point[][] = [];
@@ -79,14 +87,19 @@ const buildConnectorCandidates = (p: Point, q: Point, fromRectangle: Rectangle, 
 
     const midX = (p.x + q.x) / 2;
     const midY = (p.y + q.y) / 2;
-    candidates.push([
-        { x: midX, y: p.y },
-        { x: midX, y: q.y },
-    ]); // Z, vertical channel at mid-x
-    candidates.push([
-        { x: p.x, y: midY },
-        { x: q.x, y: midY },
-    ]); // Z, horizontal channel at mid-y
+    // Z-shapes at the middle channel plus nudged ones, so a route can sidestep an occupied channel.
+    for (const channelX of [midX, midX - CHANNEL_NUDGE, midX + CHANNEL_NUDGE]) {
+        candidates.push([
+            { x: channelX, y: p.y },
+            { x: channelX, y: q.y },
+        ]);
+    }
+    for (const channelY of [midY, midY - CHANNEL_NUDGE, midY + CHANNEL_NUDGE]) {
+        candidates.push([
+            { x: p.x, y: channelY },
+            { x: q.x, y: channelY },
+        ]);
+    }
 
     const unionMinX = Math.min(fromRectangle.minX, toRectangle.minX);
     const unionMaxX = Math.max(fromRectangle.maxX, toRectangle.maxX);
@@ -115,15 +128,6 @@ interface Segment {
     end: Point;
 }
 
-/** Reads a flat [x, y, x, y, …] waypoint array back into points. */
-const pointsFromWaypoints = (waypoints: number[]): Point[] => {
-    const points: Point[] = [];
-    for (let index = 0; index + 1 < waypoints.length; index += 2) {
-        points.push({ x: waypoints[index]!, y: waypoints[index + 1]! });
-    }
-    return points;
-};
-
 /** The straight segments of a polyline. */
 const segmentsOfPoints = (points: Point[]): Segment[] => {
     const segments: Segment[] = [];
@@ -146,18 +150,56 @@ const countLineCrossings = (points: Point[], otherSegments: Segment[]): number =
     return crossings;
 };
 
-// Ranks two routes: avoid component boxes first, then keep turns few, then cross fewer other lines,
-// then stay short, then enter a hub on the side facing this leaf — with face/candidate order as the
-// final, fully deterministic tiebreak.
+/** How far two 1-D ranges overlap (0 when they don't touch). */
+const rangeOverlap = (start1: number, end1: number, start2: number, end2: number): number =>
+    Math.max(
+        0,
+        Math.min(Math.max(start1, end1), Math.max(start2, end2)) -
+            Math.max(Math.min(start1, end1), Math.min(start2, end2))
+    );
+
+/** The length two parallel collinear segments run on top of each other (0 when they don't). */
+const collinearOverlap = (a: Point, b: Point, c: Point, d: Point): number => {
+    const bothVerticalOnSameX = a.x === b.x && c.x === d.x && a.x === c.x;
+    if (bothVerticalOnSameX) {
+        return rangeOverlap(a.y, b.y, c.y, d.y);
+    }
+    const bothHorizontalOnSameY = a.y === b.y && c.y === d.y && a.y === c.y;
+    if (bothHorizontalOnSameY) {
+        return rangeOverlap(a.x, b.x, c.x, d.x);
+    }
+    return 0;
+};
+
+/**
+ * How many pixels of this route lie on top of unrelated connections' lines — on canvas that reads
+ * as a false merge. (Overlap with lines into a shared component is intended trunk merging and is
+ * not counted here.)
+ */
+const countUnrelatedOverlap = (points: Point[], unrelatedSegments: Segment[]): number => {
+    let overlap = 0;
+    for (const routeSegment of segmentsOfPoints(points)) {
+        for (const otherSegment of unrelatedSegments) {
+            overlap += collinearOverlap(routeSegment.start, routeSegment.end, otherSegment.start, otherSegment.end);
+        }
+    }
+    return overlap;
+};
+
+// Ranking order: boxes avoided > fewer crossings > less overlap > fewer bends > shorter > hub face,
+// with face/candidate order as the final deterministic tiebreak.
 const isBetterRoute = (candidate: ScoredRoute, best: ScoredRoute): boolean => {
     if (candidate.obstacleHits !== best.obstacleHits) {
         return candidate.obstacleHits < best.obstacleHits;
     }
-    if (candidate.bendCount !== best.bendCount) {
-        return candidate.bendCount < best.bendCount;
-    }
     if (candidate.crossings !== best.crossings) {
         return candidate.crossings < best.crossings;
+    }
+    if (candidate.overlapLength !== best.overlapLength) {
+        return candidate.overlapLength < best.overlapLength;
+    }
+    if (candidate.bendCount !== best.bendCount) {
+        return candidate.bendCount < best.bendCount;
     }
     const candidateLength = Math.round(candidate.length * 1000);
     const bestLength = Math.round(best.length * 1000);
@@ -173,10 +215,7 @@ const isBetterRoute = (candidate: ScoredRoute, best: ScoredRoute): boolean => {
     return candidate.candidateRank < best.candidateRank;
 };
 
-/**
- * Works out the waypoints + connection-point info for one connection WITHOUT trunk-merging. Returns
- * null when no route is possible.
- */
+/** Computes the waypoints + connection-point info for one connection. Null when no route is possible. */
 export function routeDeterministic({
     fromComponent,
     toComponent,
@@ -197,9 +236,11 @@ export function routeDeterministic({
         .filter((component) => component.id !== fromComponent.id && component.id !== toComponent.id)
         .map(rectOf);
 
-    // The other connections' drawn lines (from their cached waypoints), so equal-cost routes can
-    // prefer the one that crosses fewer of them. This connection's own line is left out.
+    // The other connections' drawn lines, split by whether they share a component with this one:
+    // crossings are counted against all of them, overlap only against the unrelated ones.
     const otherSegments: Segment[] = [];
+    const unrelatedSegments: Segment[] = [];
+    const ownEndpointIds = new Set([from.id, to.id]);
     for (const connection of connections) {
         const isThisConnection =
             (connection.from.id === from.id && connection.to.id === to.id) ||
@@ -207,8 +248,12 @@ export function routeDeterministic({
         if (isThisConnection) {
             continue;
         }
+        const sharesEndpoint = ownEndpointIds.has(connection.from.id) || ownEndpointIds.has(connection.to.id);
         for (const segment of segmentsOfPoints(pointsFromWaypoints(connection.waypoints))) {
             otherSegments.push(segment);
+            if (!sharesEndpoint) {
+                unrelatedSegments.push(segment);
+            }
         }
     }
 
@@ -221,57 +266,74 @@ export function routeDeterministic({
           ? (findBestAnchor(toComponent, fromComponent) as Face)
           : null;
 
-    const sourceFaces = candidateFaces(fromComponent, toComponent);
-    const targetFaces = candidateFaces(toComponent, fromComponent);
+    const bestRouteForFaces = (sourceFaces: Face[], targetFaces: Face[]): ScoredRoute | null => {
+        let best: ScoredRoute | null = null;
 
-    let best: ScoredRoute | null = null;
+        for (const [sourceIndex, sourceFace] of sourceFaces.entries()) {
+            const sourceAttach = faceMidpoint(fromComponent, sourceFace);
+            const sourceOutward = outwardUnit(sourceFace);
 
-    for (const [sourceIndex, sourceFace] of sourceFaces.entries()) {
-        const sourceAttach = faceMidpoint(fromComponent, sourceFace);
-        const sourceOutward = outwardUnit(sourceFace);
+            for (const [targetIndex, targetFace] of targetFaces.entries()) {
+                const targetAttach = faceMidpoint(toComponent, targetFace);
+                const targetOutward = outwardUnit(targetFace);
+                const targetInward = { x: -targetOutward.x, y: -targetOutward.y };
+                const facePairRank = sourceIndex * targetFaces.length + targetIndex;
 
-        for (const [targetIndex, targetFace] of targetFaces.entries()) {
-            const targetAttach = faceMidpoint(toComponent, targetFace);
-            const targetOutward = outwardUnit(targetFace);
-            // Entering the target means moving inward — the opposite of its outward arrow.
-            const targetInward = { x: -targetOutward.x, y: -targetOutward.y };
-            const facePairRank = sourceIndex * 2 + targetIndex;
+                const candidates = buildConnectorCandidates(sourceAttach, targetAttach, fromRectangle, toRectangle);
+                for (const [candidateRank, corners] of candidates.entries()) {
+                    const points = simplifyPolyline([sourceAttach, ...corners, targetAttach]);
+                    if (points.length < 2 || !isOrthogonal(points) || !allFinite(points)) {
+                        continue;
+                    }
+                    // The route must leave the source face outward and enter the target face inward.
+                    const firstStep = stepDirection(points[0]!, points[1]!);
+                    const lastStep = stepDirection(points[points.length - 2]!, points[points.length - 1]!);
+                    if (!sameDirection(firstStep, sourceOutward) || !sameDirection(lastStep, targetInward)) {
+                        continue;
+                    }
 
-            const candidates = buildConnectorCandidates(sourceAttach, targetAttach, fromRectangle, toRectangle);
-            for (const [candidateRank, corners] of candidates.entries()) {
-                const points = simplifyPolyline([sourceAttach, ...corners, targetAttach]);
-                if (points.length < 2 || !isOrthogonal(points) || !allFinite(points)) {
-                    continue;
-                }
-                // Straight-out ends: the first segment must leave the source face outward and the last
-                // must enter the target face inward. Segments run to the real corner, no short stub.
-                const firstStep = stepDirection(points[0]!, points[1]!);
-                const lastStep = stepDirection(points[points.length - 2]!, points[points.length - 1]!);
-                if (!sameDirection(firstStep, sourceOutward) || !sameDirection(lastStep, targetInward)) {
-                    continue;
-                }
+                    // 1 when this route enters a hub on a side not facing the leaf, else 0.
+                    const hubFace = fromIsHub ? sourceFace : toIsHub ? targetFace : null;
+                    const hubFacePenalty = hubPrimaryFace !== null && hubFace !== hubPrimaryFace ? 1 : 0;
 
-                // 0 when this route enters the hub on the side facing the leaf, 1 otherwise (and for
-                // hubless pairs, where hubPrimaryFace is null and every route scores 0).
-                const hubFace = fromIsHub ? sourceFace : toIsHub ? targetFace : null;
-                const hubFacePenalty = hubPrimaryFace !== null && hubFace !== hubPrimaryFace ? 1 : 0;
-
-                const scored: ScoredRoute = {
-                    points,
-                    sourceFace,
-                    targetFace,
-                    obstacleHits: countObstacleHits(points, obstacles),
-                    crossings: countLineCrossings(points, otherSegments),
-                    bendCount: Math.max(0, points.length - 2),
-                    length: routeLength(points),
-                    hubFacePenalty,
-                    facePairRank,
-                    candidateRank,
-                };
-                if (best === null || isBetterRoute(scored, best)) {
-                    best = scored;
+                    const scored: ScoredRoute = {
+                        points,
+                        sourceFace,
+                        targetFace,
+                        obstacleHits: countObstacleHits(points, obstacles),
+                        crossings: countLineCrossings(points, otherSegments),
+                        overlapLength: countUnrelatedOverlap(points, unrelatedSegments),
+                        bendCount: Math.max(0, points.length - 2),
+                        length: routeLength(points),
+                        hubFacePenalty,
+                        facePairRank,
+                        candidateRank,
+                    };
+                    if (best === null || isBetterRoute(scored, best)) {
+                        best = scored;
+                    }
                 }
             }
+        }
+
+        return best;
+    };
+
+    let best = bestRouteForFaces(
+        candidateFaces(fromComponent, toComponent),
+        candidateFaces(toComponent, fromComponent)
+    );
+
+    // Still crossing? Retry with the away-side faces too — a detour may only exist there. Not part
+    // of the normal search: against not-yet-drawn lines (batch recalculation) nothing would count
+    // against those wide sweeps, so they'd win too often.
+    if (best && best.crossings > 0) {
+        const extended = bestRouteForFaces(
+            extendedCandidateFaces(fromComponent, toComponent),
+            extendedCandidateFaces(toComponent, fromComponent)
+        );
+        if (extended && extended.crossings < best.crossings) {
+            best = extended;
         }
     }
 

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
@@ -12,6 +12,7 @@ import {
     GEOMETRY_TOLERANCE,
     allFinite,
     buildAnchorMeta,
+    buildDegreeMap,
     countObstacleHits,
     faceMidpoint,
     findBestAnchor,
@@ -36,6 +37,7 @@ interface ScoredRoute {
     crossings: number;
     bendCount: number;
     length: number;
+    hubFacePenalty: number;
     facePairRank: number;
     candidateRank: number;
 }
@@ -175,7 +177,8 @@ const countLineCrossings = (points: Point[], otherSegments: Segment[]): number =
 };
 
 // Ranks two routes: avoid component boxes first, then keep turns few, then cross fewer other lines,
-// then stay short — with face/candidate order as the final, fully deterministic tiebreak.
+// then stay short, then enter a hub on the side facing this leaf — with face/candidate order as the
+// final, fully deterministic tiebreak.
 const isBetterRoute = (candidate: ScoredRoute, best: ScoredRoute): boolean => {
     if (candidate.obstacleHits !== best.obstacleHits) {
         return candidate.obstacleHits < best.obstacleHits;
@@ -190,6 +193,9 @@ const isBetterRoute = (candidate: ScoredRoute, best: ScoredRoute): boolean => {
     const bestLength = Math.round(best.length * 1000);
     if (candidateLength !== bestLength) {
         return candidateLength < bestLength;
+    }
+    if (candidate.hubFacePenalty !== best.hubFacePenalty) {
+        return candidate.hubFacePenalty < best.hubFacePenalty;
     }
     if (candidate.facePairRank !== best.facePairRank) {
         return candidate.facePairRank < best.facePairRank;
@@ -236,6 +242,15 @@ export function routeDeterministic({
         }
     }
 
+    const degree = buildDegreeMap(connections);
+    const fromIsHub = (degree.get(fromComponent.id) ?? 0) > (degree.get(toComponent.id) ?? 0);
+    const toIsHub = (degree.get(toComponent.id) ?? 0) > (degree.get(fromComponent.id) ?? 0);
+    const hubPrimaryFace = fromIsHub
+        ? (findBestAnchor(fromComponent, toComponent) as Face)
+        : toIsHub
+          ? (findBestAnchor(toComponent, fromComponent) as Face)
+          : null;
+
     const sourceFaces = candidateFaces(fromComponent, toComponent);
     const targetFaces = candidateFaces(toComponent, fromComponent);
 
@@ -266,6 +281,11 @@ export function routeDeterministic({
                     continue;
                 }
 
+                // 0 when this route enters the hub on the side facing the leaf, 1 otherwise (and for
+                // hubless pairs, where hubPrimaryFace is null and every route scores 0).
+                const hubFace = fromIsHub ? sourceFace : toIsHub ? targetFace : null;
+                const hubFacePenalty = hubPrimaryFace !== null && hubFace !== hubPrimaryFace ? 1 : 0;
+
                 const scored: ScoredRoute = {
                     points,
                     sourceFace,
@@ -274,6 +294,7 @@ export function routeDeterministic({
                     crossings: countLineCrossings(points, otherSegments),
                     bendCount: Math.max(0, points.length - 2),
                     length: routeLength(points),
+                    hubFacePenalty,
                     facePairRank,
                     candidateRank,
                 };

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
@@ -9,19 +9,20 @@ import {
     type Face,
     type Point,
     type Rectangle,
+    type RouteDefects,
     GEOMETRY_TOLERANCE,
     allFinite,
     buildAnchorMeta,
     buildDegreeMap,
-    countObstacleHits,
-    crossesTransversally,
+    buildRouteScoringContext,
+    compareRouteDefects,
+    countRouteDefects,
     faceMidpoint,
     findBestAnchor,
     flattenPoints,
     isHorizontalFace,
     isOrthogonal,
     outwardUnit,
-    pointsFromWaypoints,
     rectOf,
     routeLength,
     sameDirection,
@@ -32,13 +33,10 @@ import {
 const WRAP_CLEARANCE = 20; // how far outside the boxes a wrap-around line routes, in pixels
 const CHANNEL_NUDGE = 20; // sideways offset for the extra Z-channels that dodge an occupied channel
 
-interface ScoredRoute {
+interface ScoredRoute extends RouteDefects {
     points: Point[];
     sourceFace: Face;
     targetFace: Face;
-    obstacleHits: number;
-    crossings: number;
-    overlapLength: number;
     bendCount: number;
     length: number;
     hubFacePenalty: number;
@@ -121,82 +119,12 @@ const buildConnectorCandidates = (p: Point, q: Point, fromRectangle: Rectangle, 
     return candidates;
 };
 
-// ----- line-crossing avoidance -----
-
-interface Segment {
-    start: Point;
-    end: Point;
-}
-
-/** The straight segments of a polyline. */
-const segmentsOfPoints = (points: Point[]): Segment[] => {
-    const segments: Segment[] = [];
-    for (let index = 1; index < points.length; index++) {
-        segments.push({ start: points[index - 1]!, end: points[index]! });
-    }
-    return segments;
-};
-
-/** How many of the other connections' segments this route crosses (used to prefer non-crossing routes). */
-const countLineCrossings = (points: Point[], otherSegments: Segment[]): number => {
-    let crossings = 0;
-    for (const routeSegment of segmentsOfPoints(points)) {
-        for (const otherSegment of otherSegments) {
-            if (crossesTransversally(routeSegment.start, routeSegment.end, otherSegment.start, otherSegment.end)) {
-                crossings++;
-            }
-        }
-    }
-    return crossings;
-};
-
-/** How far two 1-D ranges overlap (0 when they don't touch). */
-const rangeOverlap = (start1: number, end1: number, start2: number, end2: number): number =>
-    Math.max(
-        0,
-        Math.min(Math.max(start1, end1), Math.max(start2, end2)) -
-            Math.max(Math.min(start1, end1), Math.min(start2, end2))
-    );
-
-/** The length two parallel collinear segments run on top of each other (0 when they don't). */
-const collinearOverlap = (a: Point, b: Point, c: Point, d: Point): number => {
-    const bothVerticalOnSameX = a.x === b.x && c.x === d.x && a.x === c.x;
-    if (bothVerticalOnSameX) {
-        return rangeOverlap(a.y, b.y, c.y, d.y);
-    }
-    const bothHorizontalOnSameY = a.y === b.y && c.y === d.y && a.y === c.y;
-    if (bothHorizontalOnSameY) {
-        return rangeOverlap(a.x, b.x, c.x, d.x);
-    }
-    return 0;
-};
-
-/**
- * How many pixels of this route lie on top of unrelated connections' lines — on canvas that reads
- * as a false merge. (Overlap with lines into a shared component is intended trunk merging and is
- * not counted here.)
- */
-const countUnrelatedOverlap = (points: Point[], unrelatedSegments: Segment[]): number => {
-    let overlap = 0;
-    for (const routeSegment of segmentsOfPoints(points)) {
-        for (const otherSegment of unrelatedSegments) {
-            overlap += collinearOverlap(routeSegment.start, routeSegment.end, otherSegment.start, otherSegment.end);
-        }
-    }
-    return overlap;
-};
-
-// Ranking order: boxes avoided > fewer crossings > less overlap > fewer bends > shorter > hub face,
-// with face/candidate order as the final deterministic tiebreak.
+// Ranking order: fewest defects (boxes > crossings > overlap, see compareRouteDefects) > fewer
+// bends > shorter > hub face, with face/candidate order as the final deterministic tiebreak.
 const isBetterRoute = (candidate: ScoredRoute, best: ScoredRoute): boolean => {
-    if (candidate.obstacleHits !== best.obstacleHits) {
-        return candidate.obstacleHits < best.obstacleHits;
-    }
-    if (candidate.crossings !== best.crossings) {
-        return candidate.crossings < best.crossings;
-    }
-    if (candidate.overlapLength !== best.overlapLength) {
-        return candidate.overlapLength < best.overlapLength;
+    const defectComparison = compareRouteDefects(candidate, best);
+    if (defectComparison !== 0) {
+        return defectComparison < 0;
     }
     if (candidate.bendCount !== best.bendCount) {
         return candidate.bendCount < best.bendCount;
@@ -216,16 +144,8 @@ const isBetterRoute = (candidate: ScoredRoute, best: ScoredRoute): boolean => {
 };
 
 /** Computes the waypoints + connection-point info for one connection. Null when no route is possible. */
-export function routeDeterministic({
-    connectionId,
-    fromComponent,
-    toComponent,
-    components,
-    connections,
-    from,
-    to,
-    pointsOfAttack,
-}: ConnectionRoutingInput): ConnectionRoutingResult | null {
+export function routeDeterministic(input: ConnectionRoutingInput): ConnectionRoutingResult | null {
+    const { fromComponent, toComponent, connections, from, to, pointsOfAttack } = input;
     // Same spot — nothing to draw.
     if (fromComponent.gridX === toComponent.gridX && fromComponent.gridY === toComponent.gridY) {
         return null;
@@ -233,32 +153,7 @@ export function routeDeterministic({
 
     const fromRectangle = rectOf(fromComponent);
     const toRectangle = rectOf(toComponent);
-    const obstacles = components
-        .filter((component) => component.id !== fromComponent.id && component.id !== toComponent.id)
-        .map(rectOf);
-
-    // The other connections' drawn lines, split by whether they share a component with this one:
-    // crossings are counted against all of them, overlap only against the unrelated ones.
-    const otherSegments: Segment[] = [];
-    const unrelatedSegments: Segment[] = [];
-    const ownEndpointIds = new Set([from.id, to.id]);
-    for (const connection of connections) {
-        const isSamePair =
-            (connection.from.id === from.id && connection.to.id === to.id) ||
-            (connection.from.id === to.id && connection.to.id === from.id);
-        const isThisConnection = connectionId !== undefined ? connection.id === connectionId : isSamePair;
-        if (isThisConnection) {
-            continue;
-        }
-        const sharesEndpoint =
-            !isSamePair && (ownEndpointIds.has(connection.from.id) || ownEndpointIds.has(connection.to.id));
-        for (const segment of segmentsOfPoints(pointsFromWaypoints(connection.waypoints))) {
-            otherSegments.push(segment);
-            if (!sharesEndpoint) {
-                unrelatedSegments.push(segment);
-            }
-        }
-    }
+    const scoringContext = buildRouteScoringContext(input);
 
     const degree = buildDegreeMap(connections);
     const fromIsHub = (degree.get(fromComponent.id) ?? 0) > (degree.get(toComponent.id) ?? 0);
@@ -303,9 +198,7 @@ export function routeDeterministic({
                         points,
                         sourceFace,
                         targetFace,
-                        obstacleHits: countObstacleHits(points, obstacles),
-                        crossings: countLineCrossings(points, otherSegments),
-                        overlapLength: countUnrelatedOverlap(points, unrelatedSegments),
+                        ...countRouteDefects(points, scoringContext),
                         bendCount: Math.max(0, points.length - 2),
                         length: routeLength(points),
                         hubFacePenalty,

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
@@ -230,13 +230,14 @@ export function routeDeterministic(input: ConnectionRoutingInput): ConnectionRou
 
     // Still crossing? Retry with the away-side faces too — a detour may only exist there. Not part
     // of the normal search: against not-yet-drawn lines (batch recalculation) nothing would count
-    // against those wide sweeps, so they'd win too often.
+    // against those wide sweeps, so they'd win too often. (Gated on crossings only on purpose —
+    // firing on box/overlap defects pulls in away-side routes that cross siblings in dense hubs.)
     if (best && best.crossings > 0) {
         const extended = bestRouteForFaces(
             extendedCandidateFaces(fromComponent, toComponent),
             extendedCandidateFaces(toComponent, fromComponent)
         );
-        if (extended && extended.crossings < best.crossings) {
+        if (extended && compareRouteDefects(extended, best) < 0) {
             best = extended;
         }
     }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/deterministic.ts
@@ -14,6 +14,7 @@ import {
     buildAnchorMeta,
     buildDegreeMap,
     countObstacleHits,
+    crossesTransversally,
     faceMidpoint,
     findBestAnchor,
     flattenPoints,
@@ -132,43 +133,12 @@ const segmentsOfPoints = (points: Point[]): Segment[] => {
     return segments;
 };
 
-const isHorizontalSegment = (segment: Segment): boolean =>
-    segment.start.y === segment.end.y && segment.start.x !== segment.end.x;
-
-const isVerticalSegment = (segment: Segment): boolean =>
-    segment.start.x === segment.end.x && segment.start.y !== segment.end.y;
-
-/**
- * True when one horizontal and one vertical segment cross at a point inside BOTH. Lines that only
- * touch at an end (a shared box, a T-junction) don't count — so connections meeting at the same
- * component aren't mistaken for a crossing.
- */
-const segmentsCrossTransversally = (first: Segment, second: Segment): boolean => {
-    let horizontal: Segment;
-    let vertical: Segment;
-    if (isHorizontalSegment(first) && isVerticalSegment(second)) {
-        horizontal = first;
-        vertical = second;
-    } else if (isVerticalSegment(first) && isHorizontalSegment(second)) {
-        horizontal = second;
-        vertical = first;
-    } else {
-        return false; // parallel — a side-by-side or collinear overlap is not a crossing
-    }
-    const strictlyBetween = (value: number, bound1: number, bound2: number): boolean =>
-        value > Math.min(bound1, bound2) && value < Math.max(bound1, bound2);
-    return (
-        strictlyBetween(vertical.start.x, horizontal.start.x, horizontal.end.x) &&
-        strictlyBetween(horizontal.start.y, vertical.start.y, vertical.end.y)
-    );
-};
-
 /** How many of the other connections' segments this route crosses (used to prefer non-crossing routes). */
 const countLineCrossings = (points: Point[], otherSegments: Segment[]): number => {
     let crossings = 0;
     for (const routeSegment of segmentsOfPoints(points)) {
         for (const otherSegment of otherSegments) {
-            if (segmentsCrossTransversally(routeSegment, otherSegment)) {
+            if (crossesTransversally(routeSegment.start, routeSegment.end, otherSegment.start, otherSegment.end)) {
                 crossings++;
             }
         }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
@@ -75,10 +75,10 @@ describe("routeFishbone trunk-merging", () => {
 
     it("does not let approaches into the same hub cross transversally", () => {
         const routes = connectionIds.map((id) => routeInContext(id, connections, components)!.waypoints);
-        for (let i = 0; i < routes.length; i++) {
-            for (let j = i + 1; j < routes.length; j++) {
-                for (const [a1, a2] of segmentsOf(routes[i]!)) {
-                    for (const [b1, b2] of segmentsOf(routes[j]!)) {
+        for (let first = 0; first < routes.length; first++) {
+            for (let second = first + 1; second < routes.length; second++) {
+                for (const [a1, a2] of segmentsOf(routes[first]!)) {
+                    for (const [b1, b2] of segmentsOf(routes[second]!)) {
                         expect(crossesTransversally(a1, a2, b1, b2)).toBe(false);
                     }
                 }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
@@ -22,6 +22,7 @@ const routeInContext = (
     const fromComponent = components.find((component) => component.id === connection.from.id)!;
     const toComponent = components.find((component) => component.id === connection.to.id)!;
     return routeFishbone({
+        connectionId,
         fromComponent,
         toComponent,
         components,

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
@@ -1,5 +1,5 @@
 import { routeFishbone } from "./fishbone.ts";
-import { rectOf, segHitsRect } from "./shared.ts";
+import { rectangleOf, segmentHitsRectangle } from "./shared.ts";
 import {
     crossesTransversally,
     expectRadialEnd,
@@ -220,9 +220,9 @@ describe("routeFishbone congestion (merges over the cluster)", () => {
             createAugmentedConnection({ id: "c-client", fromComponent: client, toComponent: hub }),
         ];
         const route = routeInContext("c-d", connections, components)!.waypoints;
-        const d1Rect = rectOf(d1);
+        const d1Rect = rectangleOf(d1);
         for (const [a, b] of segmentsOf(route)) {
-            expect(segHitsRect(a, b, d1Rect)).toBe(false);
+            expect(segmentHitsRectangle(a, b, d1Rect)).toBe(false);
         }
         // It enters the hub's top-face midpoint (-85, 450) after the comb flips over the cluster.
         expect(toPoints(route).at(-1)).toEqual({ x: -85, y: 450 });
@@ -262,10 +262,10 @@ describe("routeFishbone congestion (merges over the cluster)", () => {
             expect(toPoints(route).at(-1)).toEqual(hubTopMidpoint);
         }
 
-        const nearRectangle = rectOf(nearLeaf);
+        const nearRectangle = rectangleOf(nearLeaf);
         for (const route of [routes[1]!, routes[2]!]) {
             for (const [a, b] of segmentsOf(route)) {
-                expect(segHitsRect(a, b, nearRectangle)).toBe(false);
+                expect(segmentHitsRectangle(a, b, nearRectangle)).toBe(false);
             }
         }
         // No two approaches cross transversally.

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
@@ -151,7 +151,7 @@ describe("routeFishbone trunk-merging", () => {
 });
 
 describe("routeFishbone congestion (merges over the cluster)", () => {
-    it("does not let a comb connection run over another member squeezed against the hub", () => {
+    it("declines a two-member congested comb so it routes directly instead of looping over the cluster", () => {
         const hub = createSystemComponent({ id: "hub", gridX: 60, gridY: 0 });
         const nearLeaf = createSystemComponent({ id: "near", gridX: 42, gridY: 0 }); // squeezed against the hub
         const farLeaf = createSystemComponent({ id: "far", gridX: 0, gridY: 0 });
@@ -160,11 +160,8 @@ describe("routeFishbone congestion (merges over the cluster)", () => {
             createAugmentedConnection({ id: "c-near", fromComponent: nearLeaf, toComponent: hub }),
             createAugmentedConnection({ id: "c-far", fromComponent: farLeaf, toComponent: hub }),
         ];
-        // c-far must never run through nearLeaf (the comb merges over the cluster to avoid it).
-        const nearRectangle = rectOf(nearLeaf);
-        for (const [a, b] of segmentsOf(routeInContext("c-far", connections, components)!.waypoints)) {
-            expect(segHitsRect(a, b, nearRectangle)).toBe(false);
-        }
+        expect(routeInContext("c-near", connections, components)).toBeNull();
+        expect(routeInContext("c-far", connections, components)).toBeNull();
     });
 
     it("(repro) d merges over the top instead of crossing d1 — real logged geometry", () => {
@@ -192,47 +189,58 @@ describe("routeFishbone congestion (merges over the cluster)", () => {
         expect(toPoints(route).at(-1)).toEqual({ x: -85, y: 450 });
     });
 
-    it("does not let a far comb connection run over a nearer member on the same row", () => {
-        // Mirrors d → d1: two same-row right-side connections where an inside trunk would cross.
-        const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 60 });
-        const nearLeaf = createSystemComponent({ id: "d1", gridX: 60, gridY: 50 });
-        const farLeaf = createSystemComponent({ id: "d", gridX: 120, gridY: 50 });
-        const components = [hub, nearLeaf, farLeaf];
+    it("(repro) declines two servers near a hub instead of looping them over the top — real logged geometry", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 34, gridY: -20 });
+        const server1 = createSystemComponent({ id: "server1", gridX: -20, gridY: -34 });
+        const server2 = createSystemComponent({ id: "server2", gridX: 10, gridY: -30 });
+        const components = [hub, server1, server2];
         const connections = [
-            createAugmentedConnection({ id: "c-near", fromComponent: nearLeaf, toComponent: hub }),
-            createAugmentedConnection({ id: "c-far", fromComponent: farLeaf, toComponent: hub }),
+            createAugmentedConnection({ id: "c-server1", fromComponent: server1, toComponent: hub }),
+            createAugmentedConnection({ id: "c-server2", fromComponent: server2, toComponent: hub }),
         ];
-        const nearRectangle = rectOf(nearLeaf);
-        for (const [a, b] of segmentsOf(routeInContext("c-far", connections, components)!.waypoints)) {
-            expect(segHitsRect(a, b, nearRectangle)).toBe(false);
-        }
+        expect(routeInContext("c-server1", connections, components)).toBeNull();
+        expect(routeInContext("c-server2", connections, components)).toBeNull();
     });
 
-    it("merges a congested same-row comb over the cluster, sharing one perpendicular trunk", () => {
-        // Same-row d1/d: an inside trunk would cross, so the comb flips to one trunk above the cluster.
+    it("merges a congested same-row comb of three over the cluster, sharing one perpendicular trunk", () => {
+        // Three same-row right-side leaves where an inside trunk would cross: a comb this size is worth
+        // the lift, so it flips to one trunk above the cluster and they share the approach into the hub.
         const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 60 });
         const nearLeaf = createSystemComponent({ id: "d1", gridX: 60, gridY: 50 });
-        const farLeaf = createSystemComponent({ id: "d", gridX: 120, gridY: 50 });
-        const components = [hub, nearLeaf, farLeaf];
+        const midLeaf = createSystemComponent({ id: "d2", gridX: 120, gridY: 50 });
+        const farLeaf = createSystemComponent({ id: "d3", gridX: 180, gridY: 50 });
+        const components = [hub, nearLeaf, midLeaf, farLeaf];
         const connections = [
             createAugmentedConnection({ id: "c-near", fromComponent: nearLeaf, toComponent: hub }),
+            createAugmentedConnection({ id: "c-mid", fromComponent: midLeaf, toComponent: hub }),
             createAugmentedConnection({ id: "c-far", fromComponent: farLeaf, toComponent: hub }),
         ];
-        const nearRoute = routeInContext("c-near", connections, components)!.waypoints;
-        const farRoute = routeInContext("c-far", connections, components)!.waypoints;
-        // Both end at the hub's top-face midpoint (40, 300) — one shared approach.
+        const ids = ["c-near", "c-mid", "c-far"];
+        const routes = ids.map((id) => routeInContext(id, connections, components)!.waypoints);
         const hubTopMidpoint = { x: 40, y: 300 };
-        expect(toPoints(nearRoute).at(-1)).toEqual(hubTopMidpoint);
-        expect(toPoints(farRoute).at(-1)).toEqual(hubTopMidpoint);
-        for (const [a1, a2] of segmentsOf(nearRoute)) {
-            for (const [b1, b2] of segmentsOf(farRoute)) {
-                expect(crossesTransversally(a1, a2, b1, b2)).toBe(false);
+
+        for (const route of routes) {
+            expect(toPoints(route).at(-1)).toEqual(hubTopMidpoint);
+        }
+
+        const nearRectangle = rectOf(nearLeaf);
+        for (const route of [routes[1]!, routes[2]!]) {
+            for (const [a, b] of segmentsOf(route)) {
+                expect(segHitsRect(a, b, nearRectangle)).toBe(false);
             }
         }
-        const nearPoints = toPoints(nearRoute);
-        const farPoints = toPoints(farRoute);
+        // No two approaches cross transversally.
+        for (let first = 0; first < routes.length; first++) {
+            for (let second = first + 1; second < routes.length; second++) {
+                for (const [a1, a2] of segmentsOf(routes[first]!)) {
+                    for (const [b1, b2] of segmentsOf(routes[second]!)) {
+                        expect(crossesTransversally(a1, a2, b1, b2)).toBe(false);
+                    }
+                }
+            }
+        }
+        const nearPoints = toPoints(routes[0]!);
         expectRadialEnd(nearLeaf.gridX, nearLeaf.gridY, nearPoints[0]!, nearPoints[1]!);
-        expectRadialEnd(farLeaf.gridX, farLeaf.gridY, farPoints[0]!, farPoints[1]!);
         expectRadialEnd(hub.gridX, hub.gridY, nearPoints.at(-1)!, nearPoints.at(-2)!);
     });
 });

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
@@ -150,6 +150,45 @@ describe("routeFishbone trunk-merging", () => {
     });
 });
 
+describe("routeFishbone reciprocity", () => {
+    // Hub with two plain leaves on its right, plus a connection to a busier neighbour also on the
+    // right. The busier neighbour hubs its own comb elsewhere, so it must not join this hub's trunk.
+    const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 50 });
+    const leafA = createSystemComponent({ id: "leaf-a", gridX: 80, gridY: 45 });
+    const leafB = createSystemComponent({ id: "leaf-b", gridX: 80, gridY: 55 });
+    const busyNeighbour = createSystemComponent({ id: "busy", gridX: 120, gridY: 50 });
+    const farLeaves = [0, 1, 2, 3].map((index) =>
+        createSystemComponent({ id: `far-${index}`, gridX: 200 + index * 20, gridY: 50 })
+    );
+    const components = [hub, leafA, leafB, busyNeighbour, ...farLeaves];
+
+    const baseConnections = [
+        createAugmentedConnection({ id: "c-a", fromComponent: leafA, toComponent: hub }),
+        createAugmentedConnection({ id: "c-b", fromComponent: leafB, toComponent: hub }),
+        // busyNeighbour connects to four far leaves — degree 5, well above the hub's degree.
+        ...farLeaves.map((farLeaf, index) =>
+            createAugmentedConnection({ id: `c-far-${index}`, fromComponent: busyNeighbour, toComponent: farLeaf })
+        ),
+    ];
+
+    it("does not let a busier neighbour's connection change the hub's own comb", () => {
+        // World A: the hub also connects to the busier neighbour.
+        const withNeighbour = [
+            ...baseConnections,
+            createAugmentedConnection({ id: "c-busy", fromComponent: hub, toComponent: busyNeighbour }),
+        ];
+        // World B: the same graph without that one connection.
+        const withoutNeighbour = baseConnections;
+
+        const routeWith = routeInContext("c-a", withNeighbour, components)!;
+        const routeWithout = routeInContext("c-a", withoutNeighbour, components)!;
+
+        expect(routeWith).not.toBeNull();
+        // Leaf A's route onto the hub is the same either way — the busier neighbour is not a member.
+        expect(routeWith.waypoints).toEqual(routeWithout.waypoints);
+    });
+});
+
 describe("routeFishbone congestion (merges over the cluster)", () => {
     it("declines a two-member congested comb so it routes directly instead of looping over the cluster", () => {
         const hub = createSystemComponent({ id: "hub", gridX: 60, gridY: 0 });

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
@@ -243,6 +243,28 @@ describe("routeFishbone congestion (merges over the cluster)", () => {
         expectRadialEnd(nearLeaf.gridX, nearLeaf.gridY, nearPoints[0]!, nearPoints[1]!);
         expectRadialEnd(hub.gridX, hub.gridY, nearPoints.at(-1)!, nearPoints.at(-2)!);
     });
+
+    it("merges a comb's offset members over the cluster and drops a hub-level member to a direct entry", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 0 });
+        const level = createSystemComponent({ id: "level", gridX: 100, gridY: 0 }); // level with the hub
+        const below1 = createSystemComponent({ id: "below1", gridX: 100, gridY: 40 }); // stacked below `level`
+        const below2 = createSystemComponent({ id: "below2", gridX: 90, gridY: 40 });
+        const below3 = createSystemComponent({ id: "below3", gridX: 110, gridY: 40 });
+        const components = [hub, level, below1, below2, below3];
+        const connections = [
+            createAugmentedConnection({ id: "c-level", fromComponent: level, toComponent: hub }),
+            createAugmentedConnection({ id: "c-below1", fromComponent: below1, toComponent: hub }),
+            createAugmentedConnection({ id: "c-below2", fromComponent: below2, toComponent: hub }),
+            createAugmentedConnection({ id: "c-below3", fromComponent: below3, toComponent: hub }),
+        ];
+        // The level leaf can't ride the over-trunk → declines (the plain router enters it directly).
+        expect(routeInContext("c-level", connections, components)).toBeNull();
+        // The three below it merge onto one shared trunk into the hub's bottom face.
+        const hubBottomMidpoint = { x: 40, y: 80 };
+        for (const id of ["c-below1", "c-below2", "c-below3"]) {
+            expect(toPoints(routeInContext(id, connections, components)!.waypoints).at(-1)).toEqual(hubBottomMidpoint);
+        }
+    });
 });
 
 describe("routeFishbone declines (hands off to the plain router)", () => {

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.test.ts
@@ -1,0 +1,296 @@
+import { routeFishbone } from "./fishbone.ts";
+import { rectOf, segHitsRect } from "./shared.ts";
+import {
+    crossesTransversally,
+    expectRadialEnd,
+    routeCoversPoint,
+    segmentsOf,
+    toPoints,
+} from "#test-utils/connection-routing-helpers.ts";
+import { createAugmentedConnection, createPointOfAttack, createSystemComponent } from "#test-utils/builders.ts";
+import type { AugmentedSystemComponent, PointOfAttack } from "#api/types/system.types.ts";
+import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
+
+// Routes one connection (by id) through the fishbone router; null means it declined.
+const routeInContext = (
+    connectionId: string,
+    connections: AugmentedSystemConnection[],
+    components: AugmentedSystemComponent[],
+    pointsOfAttack: PointOfAttack[] = []
+) => {
+    const connection = connections.find((candidate) => candidate.id === connectionId)!;
+    const fromComponent = components.find((component) => component.id === connection.from.id)!;
+    const toComponent = components.find((component) => component.id === connection.to.id)!;
+    return routeFishbone({
+        fromComponent,
+        toComponent,
+        components,
+        connections,
+        from: connection.from,
+        to: connection.to,
+        pointsOfAttack,
+    });
+};
+
+describe("routeFishbone trunk-merging", () => {
+    // Hub on the left; three leaves to the right — above, on, and below the hub's centre row.
+    const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 50 });
+    const leafAbove = createSystemComponent({ id: "leaf-above", gridX: 80, gridY: 40 });
+    const leafOnRow = createSystemComponent({ id: "leaf-on-row", gridX: 80, gridY: 50 });
+    const leafBelow = createSystemComponent({ id: "leaf-below", gridX: 80, gridY: 60 });
+    const components = [hub, leafAbove, leafOnRow, leafBelow];
+    const connections = [
+        createAugmentedConnection({ id: "c-above", fromComponent: leafAbove, toComponent: hub }),
+        createAugmentedConnection({ id: "c-on-row", fromComponent: leafOnRow, toComponent: hub }),
+        createAugmentedConnection({ id: "c-below", fromComponent: leafBelow, toComponent: hub }),
+    ];
+    const hubFaceMidpoint = { x: 80, y: 290 };
+    const connectionIds = ["c-above", "c-on-row", "c-below"];
+
+    it("ends every connection into the shared hub at the same face midpoint", () => {
+        for (const id of connectionIds) {
+            const points = toPoints(routeInContext(id, connections, components)!.waypoints);
+            expect(points[points.length - 1]).toEqual(hubFaceMidpoint);
+        }
+    });
+
+    it("merges the connections onto one shared trunk into the hub", () => {
+        const pointIntoHub = { x: 90, y: 290 };
+        for (const id of connectionIds) {
+            const waypoints = routeInContext(id, connections, components)!.waypoints;
+            expect(routeCoversPoint(waypoints, pointIntoHub)).toBe(true);
+            expect(routeCoversPoint(waypoints, hubFaceMidpoint)).toBe(true);
+        }
+    });
+
+    it("keeps radial ends on both the leaf and the hub", () => {
+        const leaves = [leafAbove, leafOnRow, leafBelow];
+        connectionIds.forEach((id, index) => {
+            const leaf = leaves[index]!;
+            const points = toPoints(routeInContext(id, connections, components)!.waypoints);
+            expectRadialEnd(leaf.gridX, leaf.gridY, points[0]!, points[1]!);
+            expectRadialEnd(hub.gridX, hub.gridY, points[points.length - 1]!, points[points.length - 2]!);
+        });
+    });
+
+    it("does not let approaches into the same hub cross transversally", () => {
+        const routes = connectionIds.map((id) => routeInContext(id, connections, components)!.waypoints);
+        for (let i = 0; i < routes.length; i++) {
+            for (let j = i + 1; j < routes.length; j++) {
+                for (const [a1, a2] of segmentsOf(routes[i]!)) {
+                    for (const [b1, b2] of segmentsOf(routes[j]!)) {
+                        expect(crossesTransversally(a1, a2, b1, b2)).toBe(false);
+                    }
+                }
+            }
+        }
+    });
+
+    it("is deterministic and independent of connection order", () => {
+        const original = routeInContext("c-above", connections, components);
+        const reordered = routeInContext("c-above", [connections[2]!, connections[0]!, connections[1]!], components);
+        expect(reordered).toEqual(original);
+    });
+
+    it("maps points of attack to the from/to endpoints in order", () => {
+        const pointsOfAttack = [createPointOfAttack({ id: "poa-from" }), createPointOfAttack({ id: "poa-to" })];
+        const routing = routeInContext("c-above", connections, components, pointsOfAttack);
+        expect(routing!.connectionPointsMeta).toHaveLength(2);
+        expect(routing!.connectionPointsMeta[0]!.pointOfAttack?.id).toBe("poa-from");
+        expect(routing!.connectionPointsMeta[1]!.pointOfAttack?.id).toBe("poa-to");
+    });
+
+    it("snaps a near-diagonal leaf into the busier neighbouring comb", () => {
+        const cornerHub = createSystemComponent({ id: "corner-hub", gridX: 0, gridY: 0 });
+        const right1 = createSystemComponent({ id: "r1", gridX: 60, gridY: -4 });
+        const right2 = createSystemComponent({ id: "r2", gridX: 60, gridY: 4 });
+        // diag is near-diagonal — alone it would pick top, here it should join r1/r2's right comb.
+        const nearDiagonal = createSystemComponent({ id: "diag", gridX: 30, gridY: -40 });
+        const cornerComponents = [cornerHub, right1, right2, nearDiagonal];
+        const cornerConnections = [
+            createAugmentedConnection({ id: "c-r1", fromComponent: right1, toComponent: cornerHub }),
+            createAugmentedConnection({ id: "c-r2", fromComponent: right2, toComponent: cornerHub }),
+            createAugmentedConnection({ id: "c-diag", fromComponent: nearDiagonal, toComponent: cornerHub }),
+        ];
+        const points = toPoints(routeInContext("c-diag", cornerConnections, cornerComponents)!.waypoints);
+        // It snaps onto the busier right face (80, 40), not the top.
+        expect(points[points.length - 1]).toEqual({ x: 80, y: 40 });
+    });
+
+    it("merges two near-diagonal connections from one quadrant onto the same face (no split)", () => {
+        const quadHub = createSystemComponent({ id: "quad-hub", gridX: 0, gridY: 0 });
+        // Both up-and-left but on opposite sides of the 45° line — without the quadrant snap they'd split.
+        const moreLeft = createSystemComponent({ id: "more-left", gridX: -40, gridY: -30 });
+        const moreUp = createSystemComponent({ id: "more-up", gridX: -30, gridY: -40 });
+        const quadComponents = [quadHub, moreLeft, moreUp];
+        const quadConnections = [
+            createAugmentedConnection({ id: "c-left", fromComponent: moreLeft, toComponent: quadHub }),
+            createAugmentedConnection({ id: "c-up", fromComponent: moreUp, toComponent: quadHub }),
+        ];
+        const leftEnd = toPoints(routeInContext("c-left", quadConnections, quadComponents)!.waypoints);
+        const upEnd = toPoints(routeInContext("c-up", quadConnections, quadComponents)!.waypoints);
+        expect(leftEnd[leftEnd.length - 1]).toEqual(upEnd[upEnd.length - 1]);
+    });
+
+    it("puts the shared trunk near the leaves so a far leaf's run stays short", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 60, gridY: 60 });
+        const leafA = createSystemComponent({ id: "la", gridX: 40, gridY: 0 }); // far above the hub
+        const leafB = createSystemComponent({ id: "lb", gridX: 80, gridY: 0 });
+        const components = [hub, leafA, leafB];
+        const connections = [
+            createAugmentedConnection({ id: "c-a", fromComponent: leafA, toComponent: hub }),
+            createAugmentedConnection({ id: "c-b", fromComponent: leafB, toComponent: hub }),
+        ];
+        const waypoints = routeInContext("c-a", connections, components)!.waypoints;
+        const points = toPoints(waypoints);
+        // Short run onto the nearby trunk (y=100), then one long line down to the hub's top face.
+        expect(points[1]).toEqual({ x: 240, y: 100 });
+        expect(points[points.length - 1]).toEqual({ x: 340, y: 300 });
+        expect(routeCoversPoint(waypoints, { x: 340, y: 100 })).toBe(true);
+    });
+});
+
+describe("routeFishbone congestion (merges over the cluster)", () => {
+    it("does not let a comb connection run over another member squeezed against the hub", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 60, gridY: 0 });
+        const nearLeaf = createSystemComponent({ id: "near", gridX: 42, gridY: 0 }); // squeezed against the hub
+        const farLeaf = createSystemComponent({ id: "far", gridX: 0, gridY: 0 });
+        const components = [hub, nearLeaf, farLeaf];
+        const connections = [
+            createAugmentedConnection({ id: "c-near", fromComponent: nearLeaf, toComponent: hub }),
+            createAugmentedConnection({ id: "c-far", fromComponent: farLeaf, toComponent: hub }),
+        ];
+        // c-far must never run through nearLeaf (the comb merges over the cluster to avoid it).
+        const nearRectangle = rectOf(nearLeaf);
+        for (const [a, b] of segmentsOf(routeInContext("c-far", connections, components)!.waypoints)) {
+            expect(segHitsRect(a, b, nearRectangle)).toBe(false);
+        }
+    });
+
+    it("(repro) d merges over the top instead of crossing d1 — real logged geometry", () => {
+        // Exact grid positions captured from the running app's console (the d → d1 crossing report).
+        const hub = createSystemComponent({ id: "hub", gridX: -25, gridY: 90 });
+        const d1 = createSystemComponent({ id: "d1", gridX: 40, gridY: 89 });
+        const d = createSystemComponent({ id: "d", gridX: 79, gridY: 89 });
+        const d2 = createSystemComponent({ id: "d2", gridX: 108, gridY: 111 });
+        const database = createSystemComponent({ id: "database", gridX: 9, gridY: 70 });
+        const client = createSystemComponent({ id: "client", gridX: -59, gridY: 133 });
+        const components = [hub, d1, d, d2, database, client];
+        const connections = [
+            createAugmentedConnection({ id: "c-d1", fromComponent: d1, toComponent: hub }),
+            createAugmentedConnection({ id: "c-d", fromComponent: d, toComponent: hub }),
+            createAugmentedConnection({ id: "c-d2", fromComponent: d2, toComponent: hub }),
+            createAugmentedConnection({ id: "c-db", fromComponent: database, toComponent: hub }),
+            createAugmentedConnection({ id: "c-client", fromComponent: client, toComponent: hub }),
+        ];
+        const route = routeInContext("c-d", connections, components)!.waypoints;
+        const d1Rect = rectOf(d1);
+        for (const [a, b] of segmentsOf(route)) {
+            expect(segHitsRect(a, b, d1Rect)).toBe(false);
+        }
+        // It enters the hub's top-face midpoint (-85, 450) after the comb flips over the cluster.
+        expect(toPoints(route).at(-1)).toEqual({ x: -85, y: 450 });
+    });
+
+    it("does not let a far comb connection run over a nearer member on the same row", () => {
+        // Mirrors d → d1: two same-row right-side connections where an inside trunk would cross.
+        const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 60 });
+        const nearLeaf = createSystemComponent({ id: "d1", gridX: 60, gridY: 50 });
+        const farLeaf = createSystemComponent({ id: "d", gridX: 120, gridY: 50 });
+        const components = [hub, nearLeaf, farLeaf];
+        const connections = [
+            createAugmentedConnection({ id: "c-near", fromComponent: nearLeaf, toComponent: hub }),
+            createAugmentedConnection({ id: "c-far", fromComponent: farLeaf, toComponent: hub }),
+        ];
+        const nearRectangle = rectOf(nearLeaf);
+        for (const [a, b] of segmentsOf(routeInContext("c-far", connections, components)!.waypoints)) {
+            expect(segHitsRect(a, b, nearRectangle)).toBe(false);
+        }
+    });
+
+    it("merges a congested same-row comb over the cluster, sharing one perpendicular trunk", () => {
+        // Same-row d1/d: an inside trunk would cross, so the comb flips to one trunk above the cluster.
+        const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 60 });
+        const nearLeaf = createSystemComponent({ id: "d1", gridX: 60, gridY: 50 });
+        const farLeaf = createSystemComponent({ id: "d", gridX: 120, gridY: 50 });
+        const components = [hub, nearLeaf, farLeaf];
+        const connections = [
+            createAugmentedConnection({ id: "c-near", fromComponent: nearLeaf, toComponent: hub }),
+            createAugmentedConnection({ id: "c-far", fromComponent: farLeaf, toComponent: hub }),
+        ];
+        const nearRoute = routeInContext("c-near", connections, components)!.waypoints;
+        const farRoute = routeInContext("c-far", connections, components)!.waypoints;
+        // Both end at the hub's top-face midpoint (40, 300) — one shared approach.
+        const hubTopMidpoint = { x: 40, y: 300 };
+        expect(toPoints(nearRoute).at(-1)).toEqual(hubTopMidpoint);
+        expect(toPoints(farRoute).at(-1)).toEqual(hubTopMidpoint);
+        for (const [a1, a2] of segmentsOf(nearRoute)) {
+            for (const [b1, b2] of segmentsOf(farRoute)) {
+                expect(crossesTransversally(a1, a2, b1, b2)).toBe(false);
+            }
+        }
+        const nearPoints = toPoints(nearRoute);
+        const farPoints = toPoints(farRoute);
+        expectRadialEnd(nearLeaf.gridX, nearLeaf.gridY, nearPoints[0]!, nearPoints[1]!);
+        expectRadialEnd(farLeaf.gridX, farLeaf.gridY, farPoints[0]!, farPoints[1]!);
+        expectRadialEnd(hub.gridX, hub.gridY, nearPoints.at(-1)!, nearPoints.at(-2)!);
+    });
+});
+
+describe("routeFishbone declines (hands off to the plain router)", () => {
+    it("returns null for a leaf-leaf pair (no hub)", () => {
+        const from = createSystemComponent({ id: "from", gridX: 0, gridY: 0 });
+        const to = createSystemComponent({ id: "to", gridX: 60, gridY: 0 });
+        const lone = createAugmentedConnection({ id: "lone", fromComponent: from, toComponent: to });
+        expect(routeInContext("lone", [lone], [from, to])).toBeNull();
+    });
+
+    it("returns null for a hub-to-hub connection of equal degree", () => {
+        const hubA = createSystemComponent({ id: "hub-a", gridX: 0, gridY: 50 });
+        const hubB = createSystemComponent({ id: "hub-b", gridX: 60, gridY: 50 });
+        const leafA1 = createSystemComponent({ id: "a1", gridX: 0, gridY: 0 });
+        const leafA2 = createSystemComponent({ id: "a2", gridX: 0, gridY: 100 });
+        const leafB1 = createSystemComponent({ id: "b1", gridX: 60, gridY: 0 });
+        const leafB2 = createSystemComponent({ id: "b2", gridX: 60, gridY: 100 });
+        const components = [hubA, hubB, leafA1, leafA2, leafB1, leafB2];
+        const connections = [
+            createAugmentedConnection({ id: "a-b", fromComponent: hubA, toComponent: hubB }),
+            createAugmentedConnection({ id: "a-a1", fromComponent: hubA, toComponent: leafA1 }),
+            createAugmentedConnection({ id: "a-a2", fromComponent: hubA, toComponent: leafA2 }),
+            createAugmentedConnection({ id: "b-b1", fromComponent: hubB, toComponent: leafB1 }),
+            createAugmentedConnection({ id: "b-b2", fromComponent: hubB, toComponent: leafB2 }),
+        ];
+        // Both endpoints have degree 3 → no single hub → the fishbone declines.
+        expect(routeInContext("a-b", connections, components)).toBeNull();
+    });
+
+    it("returns null when an unrelated component blocks the trunk, but would otherwise merge", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 50 });
+        const leafTop = createSystemComponent({ id: "leaf-top", gridX: 80, gridY: 20 });
+        const leafBottom = createSystemComponent({ id: "leaf-bottom", gridX: 80, gridY: 80 });
+        const onTrunk = createSystemComponent({ id: "on-trunk", gridX: 40, gridY: 50 }); // sits on c-top's line into the hub
+        const connections = [
+            createAugmentedConnection({ id: "c-top", fromComponent: leafTop, toComponent: hub }),
+            createAugmentedConnection({ id: "c-bottom", fromComponent: leafBottom, toComponent: hub }),
+        ];
+        // Without the blocker the comb merges...
+        expect(routeInContext("c-top", connections, [hub, leafTop, leafBottom])).not.toBeNull();
+        // ...but with a component on the trunk the fishbone declines (the entry then routes it plainly).
+        expect(routeInContext("c-top", connections, [hub, leafTop, leafBottom, onTrunk])).toBeNull();
+    });
+
+    it("returns null for a connection alone on its hub face", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 0 });
+        const right1 = createSystemComponent({ id: "r1", gridX: 60, gridY: -4 });
+        const right2 = createSystemComponent({ id: "r2", gridX: 60, gridY: 4 });
+        const topLone = createSystemComponent({ id: "top-lone", gridX: 0, gridY: -60 }); // only one on the top face
+        const components = [hub, right1, right2, topLone];
+        const connections = [
+            createAugmentedConnection({ id: "c-r1", fromComponent: right1, toComponent: hub }),
+            createAugmentedConnection({ id: "c-r2", fromComponent: right2, toComponent: hub }),
+            createAugmentedConnection({ id: "c-top", fromComponent: topLone, toComponent: hub }),
+        ];
+        // Alone on the top face, it would be a one-member comb → the fishbone declines.
+        expect(routeInContext("c-top", connections, components)).toBeNull();
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
@@ -32,10 +32,10 @@ import {
     isHorizontalFace,
     isOrthogonal,
     outwardUnit,
-    rectOf,
+    rectangleOf,
     routeLength,
     sameDirection,
-    segHitsRect,
+    segmentHitsRectangle,
     shrinkRectangle,
     simplifyPolyline,
     stepDirection,
@@ -124,8 +124,8 @@ const combTrunkPosition = (
     members: AugmentedSystemComponent[],
     mode: CombMode
 ): number => {
-    const hubRectangle = rectOf(hub);
-    const memberRectangles = members.map(rectOf);
+    const hubRectangle = rectangleOf(hub);
+    const memberRectangles = members.map(rectangleOf);
 
     if (mode === "over") {
         const clusterRectangles = [hubRectangle, ...memberRectangles];
@@ -177,8 +177,8 @@ const fishbonePath = (
     trunkPosition: number
 ): FishbonePath | null => {
     const hubMidpoint = faceMidpoint(hub, hubFace);
-    const hubRectangle = rectOf(hub);
-    const leafRectangle = rectOf(leaf);
+    const hubRectangle = rectangleOf(hub);
+    const leafRectangle = rectangleOf(leaf);
     const leafCenter = centerOf(leaf);
 
     if (isHorizontalFace(hubFace)) {
@@ -296,7 +296,7 @@ const memberRunHitsOthers = (
     }
     const otherInteriors = members
         .filter((candidate) => candidate.id !== member.id)
-        .map((candidate) => shrinkRectangle(rectOf(candidate)));
+        .map((candidate) => shrinkRectangle(rectangleOf(candidate)));
     return countObstacleHits(simplifyPolyline(path.points), otherInteriors) > 0;
 };
 
@@ -393,15 +393,15 @@ const cleanInsideMemberRoute = (
     if (!sameDirection(leafStep, leafOutward) || !sameDirection(hubStep, { x: -hubOutward.x, y: -hubOutward.y })) {
         return null;
     }
-    const hubInterior = shrinkRectangle(rectOf(hub));
+    const hubInterior = shrinkRectangle(rectangleOf(hub));
     for (let index = 1; index < points.length; index++) {
-        if (segHitsRect(points[index - 1]!, points[index]!, hubInterior)) {
+        if (segmentHitsRectangle(points[index - 1]!, points[index]!, hubInterior)) {
             return null;
         }
     }
     const obstacles = components
         .filter((component) => component.id !== hub.id && component.id !== member.id)
-        .map(rectOf);
+        .map(rectangleOf);
     return countObstacleHits(points, obstacles) > 0 ? null : points;
 };
 
@@ -657,10 +657,12 @@ export const routeFishbone = (input: ConnectionRoutingInput): ConnectionRoutingR
 
     // The route must not cross the hub or any other box (only this connection's own hub and leaf are
     // exempt). If any segment would, this connection drops out to the plain router instead.
-    const hubInterior = shrinkRectangle(rectOf(hub));
-    const obstacles = components.filter((component) => component.id !== hub.id && component.id !== leaf.id).map(rectOf);
+    const hubInterior = shrinkRectangle(rectangleOf(hub));
+    const obstacles = components
+        .filter((component) => component.id !== hub.id && component.id !== leaf.id)
+        .map(rectangleOf);
     for (let index = 1; index < points.length; index++) {
-        if (segHitsRect(points[index - 1]!, points[index]!, hubInterior)) {
+        if (segmentHitsRectangle(points[index - 1]!, points[index]!, hubInterior)) {
             return null;
         }
     }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
@@ -259,8 +259,26 @@ const collectDirectionMembers = (
     return members;
 };
 
+/** True when one member's run onto the shared trunk would cut through another member's box. */
+const memberRunHitsOthers = (
+    hub: AugmentedSystemComponent,
+    hubFace: Face,
+    member: AugmentedSystemComponent,
+    members: AugmentedSystemComponent[],
+    trunkPosition: number
+): boolean => {
+    const path = fishbonePath(hub, member, hubFace, trunkPosition);
+    if (!path) {
+        return true;
+    }
+    const otherInteriors = members
+        .filter((candidate) => candidate.id !== member.id)
+        .map((candidate) => shrinkRectangle(rectOf(candidate)));
+    return countObstacleHits(simplifyPolyline(path.points), otherInteriors) > 0;
+};
+
 /**
- * True if this comb can't be drawn cleanly here — one member's line would cut through another member.
+ * True if this comb can't be drawn cleanly here — any member's line would cut through another member.
  * (Boxes are shrunk first, so just touching a stacked neighbour's edge is fine.) This is what makes a
  * crowded face switch to an over-the-cluster trunk.
  */
@@ -271,19 +289,7 @@ const combCollides = (
     mode: CombMode
 ): boolean => {
     const trunkPosition = combTrunkPosition(hub, hubFace, members, mode);
-    for (const member of members) {
-        const path = fishbonePath(hub, member, hubFace, trunkPosition);
-        if (!path) {
-            return true;
-        }
-        const otherInteriors = members
-            .filter((candidate) => candidate.id !== member.id)
-            .map((candidate) => shrinkRectangle(rectOf(candidate)));
-        if (countObstacleHits(simplifyPolyline(path.points), otherInteriors) > 0) {
-            return true;
-        }
-    }
-    return false;
+    return members.some((member) => memberRunHitsOthers(hub, hubFace, member, members, trunkPosition));
 };
 
 /** The clear 90° side a crowded comb switches to, picked by where most of its members sit. */
@@ -302,6 +308,29 @@ const perpendicularApproachFace = (
 };
 
 /**
+ * The members that can actually share an over-the-cluster trunk: drop the ones whose run onto it would
+ * cross another member (typically a leaf level with the hub, sitting in front of a lower one) — those
+ * enter the hub directly instead. Re-checked after each drop, since removing a member shifts the trunk.
+ */
+const overMergeableMembers = (
+    hub: AugmentedSystemComponent,
+    flippedFace: Face,
+    members: AugmentedSystemComponent[]
+): AugmentedSystemComponent[] => {
+    let survivors = members;
+    for (;;) {
+        const trunkPosition = combTrunkPosition(hub, flippedFace, survivors, "over");
+        const kept = survivors.filter(
+            (member) => !memberRunHitsOthers(hub, flippedFace, member, survivors, trunkPosition)
+        );
+        if (kept.length === survivors.length || kept.length === 0) {
+            return kept;
+        }
+        survivors = kept;
+    }
+};
+
+/**
  * Decides a leaf's hub face + trunk mode: its direction face with an INSIDE trunk, or — if that face
  * is crowded — the clear 90° face with an OVER trunk. Returns null when a congested comb is too small
  * to be worth lifting over the cluster, so its members route directly (radially) instead. Depends only
@@ -316,11 +345,10 @@ const resolveHubFace = (
     const directionFace = assignHubFace(hub, leaf, connections, components);
     const directionMembers = collectDirectionMembers(hub, leaf, directionFace, connections, components);
     if (directionMembers.length >= 2 && combCollides(hub, directionFace, directionMembers, "inside")) {
-        if (directionMembers.length >= MIN_OVER_TRUNK_MEMBERS) {
-            const flippedFace = perpendicularApproachFace(hub, directionFace, directionMembers);
-            if (!combCollides(hub, flippedFace, directionMembers, "over")) {
-                return { hubFace: flippedFace, mode: "over" };
-            }
+        const flippedFace = perpendicularApproachFace(hub, directionFace, directionMembers);
+        const mergeable = overMergeableMembers(hub, flippedFace, directionMembers);
+        if (mergeable.length >= MIN_OVER_TRUNK_MEMBERS && mergeable.some((member) => member.id === leaf.id)) {
+            return { hubFace: flippedFace, mode: "over" };
         }
         return null;
     }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
@@ -22,6 +22,7 @@ import {
     type Point,
     allFinite,
     buildAnchorMeta,
+    buildDegreeMap,
     centerOf,
     countObstacleHits,
     faceMidpoint,
@@ -40,23 +41,7 @@ import {
 
 const TRUNK_CLEARANCE = 20; // how far outside the hub the shared trunk sits, in pixels
 const FISHBONE_DIAGONAL_RATIO = 0.5; // above this, a leaf counts as "almost diagonal" from the hub
-
-/** Counts how many connections touch each component (its "degree"). */
-const buildDegreeMap = (connections: AugmentedSystemConnection[]): Map<string, number> => {
-    const counted = new Set<string>();
-    const degree = new Map<string, number>();
-    for (const connection of connections) {
-        if (counted.has(connection.id)) {
-            continue;
-        }
-        counted.add(connection.id);
-        degree.set(connection.from.id, (degree.get(connection.from.id) ?? 0) + 1);
-        if (connection.to.id !== connection.from.id) {
-            degree.set(connection.to.id, (degree.get(connection.to.id) ?? 0) + 1);
-        }
-    }
-    return degree;
-};
+const MIN_OVER_TRUNK_MEMBERS = 3; // an over-the-top trunk is only worth its detour for 3+ merged lines
 
 interface FishbonePath {
     points: Point[];
@@ -318,22 +303,26 @@ const perpendicularApproachFace = (
 
 /**
  * Decides a leaf's hub face + trunk mode: its direction face with an INSIDE trunk, or — if that face
- * is crowded — the clear 90° face with an OVER trunk. Depends only on the comb, so every member lands
- * on the same face+mode and they stay merged.
+ * is crowded — the clear 90° face with an OVER trunk. Returns null when a congested comb is too small
+ * to be worth lifting over the cluster, so its members route directly (radially) instead. Depends only
+ * on the comb, so every member lands on the same decision and they stay consistent.
  */
 const resolveHubFace = (
     hub: AugmentedSystemComponent,
     leaf: AugmentedSystemComponent,
     connections: AugmentedSystemConnection[],
     components: AugmentedSystemComponent[]
-): HubFaceResolution => {
+): HubFaceResolution | null => {
     const directionFace = assignHubFace(hub, leaf, connections, components);
     const directionMembers = collectDirectionMembers(hub, leaf, directionFace, connections, components);
     if (directionMembers.length >= 2 && combCollides(hub, directionFace, directionMembers, "inside")) {
-        const flippedFace = perpendicularApproachFace(hub, directionFace, directionMembers);
-        if (!combCollides(hub, flippedFace, directionMembers, "over")) {
-            return { hubFace: flippedFace, mode: "over" };
+        if (directionMembers.length >= MIN_OVER_TRUNK_MEMBERS) {
+            const flippedFace = perpendicularApproachFace(hub, directionFace, directionMembers);
+            if (!combCollides(hub, flippedFace, directionMembers, "over")) {
+                return { hubFace: flippedFace, mode: "over" };
+            }
         }
+        return null;
     }
     return { hubFace: directionFace, mode: "inside" };
 };
@@ -364,7 +353,11 @@ export const routeFishbone = (input: ConnectionRoutingInput): ConnectionRoutingR
     const hub = fromIsHub ? fromComponent : toComponent;
     const leaf = fromIsHub ? toComponent : fromComponent;
 
-    const { hubFace, mode } = resolveHubFace(hub, leaf, connections, components);
+    const resolution = resolveHubFace(hub, leaf, connections, components);
+    if (!resolution) {
+        return null;
+    }
+    const { hubFace, mode } = resolution;
 
     // This comb's members: the hub's connections landing on the same face AND mode (incl. this leaf).
     // A comb needs at least two — a lone connection draws better as a plain direct line.
@@ -381,7 +374,7 @@ export const routeFishbone = (input: ConnectionRoutingInput): ConnectionRoutingR
             continue;
         }
         const otherResolution = resolveHubFace(hub, other, connections, components);
-        if (otherResolution.hubFace === hubFace && otherResolution.mode === mode) {
+        if (otherResolution && otherResolution.hubFace === hubFace && otherResolution.mode === mode) {
             members.push(other);
         }
     }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
@@ -1,0 +1,432 @@
+/**
+ * Fishbone router: connections sharing a hub merge onto one trunk and branch off (AC b).
+ *
+ * Terms used throughout this file:
+ *   hub    the box several connections lead to (the busy endpoint)
+ *   leaf   the box at the far end of one of those connections
+ *   comb   all the leaves that approach the hub from the same face
+ *   trunk  the one shared line a comb rides toward the hub
+ *
+ *     [leaf]  [leaf]  [leaf]
+ *        |       |      |      each leaf runs out onto the shared TRUNK,
+ *        +-------+------+      which carries them into the HUB
+ *                |             (these leaves form one COMB)
+ *              [hub]
+ */
+import { AnchorOrientation, type AugmentedSystemComponent, type ConnectionPointMeta } from "#api/types/system.types.ts";
+import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
+import {
+    type ConnectionRoutingInput,
+    type ConnectionRoutingResult,
+    type Face,
+    type Point,
+    allFinite,
+    buildAnchorMeta,
+    centerOf,
+    countObstacleHits,
+    faceMidpoint,
+    findBestAnchor,
+    flattenPoints,
+    isHorizontalFace,
+    isOrthogonal,
+    outwardUnit,
+    rectOf,
+    sameDirection,
+    segHitsRect,
+    shrinkRectangle,
+    simplifyPolyline,
+    stepDirection,
+} from "./shared.ts";
+
+const TRUNK_CLEARANCE = 20; // how far outside the hub the shared trunk sits, in pixels
+const FISHBONE_DIAGONAL_RATIO = 0.5; // above this, a leaf counts as "almost diagonal" from the hub
+
+/** Counts how many connections touch each component (its "degree"). */
+const buildDegreeMap = (connections: AugmentedSystemConnection[]): Map<string, number> => {
+    const counted = new Set<string>();
+    const degree = new Map<string, number>();
+    for (const connection of connections) {
+        if (counted.has(connection.id)) {
+            continue;
+        }
+        counted.add(connection.id);
+        degree.set(connection.from.id, (degree.get(connection.from.id) ?? 0) + 1);
+        if (connection.to.id !== connection.from.id) {
+            degree.set(connection.to.id, (degree.get(connection.to.id) ?? 0) + 1);
+        }
+    }
+    return degree;
+};
+
+interface FishbonePath {
+    points: Point[];
+    hubFace: Face;
+    leafFace: Face;
+}
+
+/**
+ * Picks which hub face a leaf joins, by direction. An almost-diagonal leaf takes whichever of its two
+ * possible faces already has more connections, so same-direction leaves share one comb.
+ */
+const assignHubFace = (
+    hub: AugmentedSystemComponent,
+    leaf: AugmentedSystemComponent,
+    connections: AugmentedSystemConnection[],
+    components: AugmentedSystemComponent[]
+): Face => {
+    const isNearBoundary = (component: AugmentedSystemComponent): boolean => {
+        const dx = Math.abs(component.gridX - hub.gridX);
+        const dy = Math.abs(component.gridY - hub.gridY);
+        const major = Math.max(dx, dy);
+        return major > 0 && Math.min(dx, dy) / major >= FISHBONE_DIAGONAL_RATIO;
+    };
+
+    const primary = findBestAnchor(hub, leaf) as Face;
+    if (!isNearBoundary(leaf)) {
+        return primary; // clearly in one direction sector — keep it
+    }
+
+    // Almost diagonal: count the hub's clearly-directed connections per face (skip other almost-
+    // diagonal ones, so ambiguous leaves don't vote on each other).
+    const componentById = new Map(components.map((component) => [component.id, component]));
+    const perFace = new Map<Face, number>();
+    for (const connection of connections) {
+        const neighbourId =
+            connection.from.id === hub.id ? connection.to.id : connection.to.id === hub.id ? connection.from.id : null;
+        if (neighbourId === null || neighbourId === hub.id || neighbourId === leaf.id) {
+            continue;
+        }
+        const neighbour = componentById.get(neighbourId);
+        if (neighbour && !isNearBoundary(neighbour)) {
+            const face = findBestAnchor(hub, neighbour) as Face;
+            perFace.set(face, (perFace.get(face) ?? 0) + 1);
+        }
+    }
+
+    // Pick the busier of the two faces this leaf's corner sits between (by which side of the hub it's
+    // on, so every almost-diagonal leaf in the same corner lands on the SAME face). Ties go horizontal.
+    const horizontalFace = leaf.gridX >= hub.gridX ? AnchorOrientation.right : AnchorOrientation.left;
+    const verticalFace = leaf.gridY >= hub.gridY ? AnchorOrientation.bottom : AnchorOrientation.top;
+    return (perFace.get(horizontalFace) ?? 0) >= (perFace.get(verticalFace) ?? 0) ? horizontalFace : verticalFace;
+};
+
+type CombMode = "inside" | "over";
+
+/**
+ * Where the shared trunk sits (an x for left/right faces, a y for top/bottom).
+ *   INSIDE — just past the member nearest the hub, so each leaf's run onto the trunk stays short.
+ *   OVER   — just outside the whole cluster, used when the natural face is crowded (see combCollides).
+ */
+const combTrunkPosition = (
+    hub: AugmentedSystemComponent,
+    hubFace: Face,
+    members: AugmentedSystemComponent[],
+    mode: CombMode
+): number => {
+    const hubRectangle = rectOf(hub);
+    const memberRectangles = members.map(rectOf);
+
+    if (mode === "over") {
+        const clusterRectangles = [hubRectangle, ...memberRectangles];
+        switch (hubFace) {
+            case AnchorOrientation.top:
+                return Math.min(...clusterRectangles.map((rectangle) => rectangle.minY)) - TRUNK_CLEARANCE;
+            case AnchorOrientation.bottom:
+                return Math.max(...clusterRectangles.map((rectangle) => rectangle.maxY)) + TRUNK_CLEARANCE;
+            case AnchorOrientation.left:
+                return Math.min(...clusterRectangles.map((rectangle) => rectangle.minX)) - TRUNK_CLEARANCE;
+            case AnchorOrientation.right:
+                return Math.max(...clusterRectangles.map((rectangle) => rectangle.maxX)) + TRUNK_CLEARANCE;
+        }
+    }
+
+    switch (hubFace) {
+        case AnchorOrientation.top:
+            return Math.min(
+                Math.max(...memberRectangles.map((rectangle) => rectangle.maxY)) + TRUNK_CLEARANCE,
+                hubRectangle.minY - TRUNK_CLEARANCE
+            );
+        case AnchorOrientation.bottom:
+            return Math.max(
+                Math.min(...memberRectangles.map((rectangle) => rectangle.minY)) - TRUNK_CLEARANCE,
+                hubRectangle.maxY + TRUNK_CLEARANCE
+            );
+        case AnchorOrientation.left:
+            return Math.min(
+                Math.max(...memberRectangles.map((rectangle) => rectangle.maxX)) + TRUNK_CLEARANCE,
+                hubRectangle.minX - TRUNK_CLEARANCE
+            );
+        case AnchorOrientation.right:
+            return Math.max(
+                Math.min(...memberRectangles.map((rectangle) => rectangle.minX)) - TRUNK_CLEARANCE,
+                hubRectangle.maxX + TRUNK_CLEARANCE
+            );
+    }
+};
+
+/**
+ * Builds one leaf's route: out from the leaf, onto the shared trunk, then into the hub. The leaf's
+ * exit face comes from the trunk position, so this works for both an inside and an over trunk. Returns
+ * null if no clean trunk fits.
+ */
+const fishbonePath = (
+    hub: AugmentedSystemComponent,
+    leaf: AugmentedSystemComponent,
+    hubFace: Face,
+    trunkPosition: number
+): FishbonePath | null => {
+    const hubMidpoint = faceMidpoint(hub, hubFace);
+    const hubRectangle = rectOf(hub);
+    const leafRectangle = rectOf(leaf);
+    const leafCenter = centerOf(leaf);
+
+    if (isHorizontalFace(hubFace)) {
+        // Vertical trunk at trunkX; the hub and each leaf reach it with a horizontal segment.
+        const trunkX = trunkPosition;
+        // The line into the hub stays straight-out only if the trunk is past the hub's face.
+        if (hubFace === AnchorOrientation.right && trunkX <= hubRectangle.maxX) {
+            return null;
+        }
+        if (hubFace === AnchorOrientation.left && trunkX >= hubRectangle.minX) {
+            return null;
+        }
+        // The leaf leaves the side facing the trunk; the trunk must sit outside the leaf box.
+        let leafFace: Face;
+        let leafX: number;
+        if (trunkX < leafRectangle.minX) {
+            leafFace = AnchorOrientation.left;
+            leafX = leafRectangle.minX;
+        } else if (trunkX > leafRectangle.maxX) {
+            leafFace = AnchorOrientation.right;
+            leafX = leafRectangle.maxX;
+        } else {
+            return null; // the trunk would run through the leaf — no clean route
+        }
+        return {
+            points: [
+                { x: leafX, y: leafCenter.y },
+                { x: trunkX, y: leafCenter.y },
+                { x: trunkX, y: hubMidpoint.y },
+                { x: hubMidpoint.x, y: hubMidpoint.y },
+            ],
+            hubFace,
+            leafFace,
+        };
+    }
+
+    // Horizontal trunk at trunkY; the hub and each leaf reach it with a vertical segment.
+    const trunkY = trunkPosition;
+    if (hubFace === AnchorOrientation.bottom && trunkY <= hubRectangle.maxY) {
+        return null;
+    }
+    if (hubFace === AnchorOrientation.top && trunkY >= hubRectangle.minY) {
+        return null;
+    }
+    let leafFace: Face;
+    let leafY: number;
+    if (trunkY < leafRectangle.minY) {
+        leafFace = AnchorOrientation.top;
+        leafY = leafRectangle.minY;
+    } else if (trunkY > leafRectangle.maxY) {
+        leafFace = AnchorOrientation.bottom;
+        leafY = leafRectangle.maxY;
+    } else {
+        return null; // the trunk would run through the leaf — no clean route
+    }
+    return {
+        points: [
+            { x: leafCenter.x, y: leafY },
+            { x: leafCenter.x, y: trunkY },
+            { x: hubMidpoint.x, y: trunkY },
+            { x: hubMidpoint.x, y: hubMidpoint.y },
+        ],
+        hubFace,
+        leafFace,
+    };
+};
+
+interface HubFaceResolution {
+    hubFace: Face;
+    mode: CombMode;
+}
+
+/** The hub's other leaves (plus this one) that point at the same hub face by direction. */
+const collectDirectionMembers = (
+    hub: AugmentedSystemComponent,
+    leaf: AugmentedSystemComponent,
+    directionFace: Face,
+    connections: AugmentedSystemConnection[],
+    components: AugmentedSystemComponent[]
+): AugmentedSystemComponent[] => {
+    const componentById = new Map(components.map((component) => [component.id, component]));
+    const members: AugmentedSystemComponent[] = [leaf];
+    for (const connection of connections) {
+        const otherId =
+            connection.from.id === hub.id ? connection.to.id : connection.to.id === hub.id ? connection.from.id : null;
+        if (otherId === null || otherId === hub.id || otherId === leaf.id) {
+            continue;
+        }
+        const other = componentById.get(otherId);
+        if (other && assignHubFace(hub, other, connections, components) === directionFace) {
+            members.push(other);
+        }
+    }
+    return members;
+};
+
+/**
+ * True if this comb can't be drawn cleanly here — one member's line would cut through another member.
+ * (Boxes are shrunk first, so just touching a stacked neighbour's edge is fine.) This is what makes a
+ * crowded face switch to an over-the-cluster trunk.
+ */
+const combCollides = (
+    hub: AugmentedSystemComponent,
+    hubFace: Face,
+    members: AugmentedSystemComponent[],
+    mode: CombMode
+): boolean => {
+    const trunkPosition = combTrunkPosition(hub, hubFace, members, mode);
+    for (const member of members) {
+        const path = fishbonePath(hub, member, hubFace, trunkPosition);
+        if (!path) {
+            return true;
+        }
+        const otherInteriors = members
+            .filter((candidate) => candidate.id !== member.id)
+            .map((candidate) => shrinkRectangle(rectOf(candidate)));
+        if (countObstacleHits(simplifyPolyline(path.points), otherInteriors) > 0) {
+            return true;
+        }
+    }
+    return false;
+};
+
+/** The clear 90° side a crowded comb switches to, picked by where most of its members sit. */
+const perpendicularApproachFace = (
+    hub: AugmentedSystemComponent,
+    directionFace: Face,
+    members: AugmentedSystemComponent[]
+): Face => {
+    const hubCenter = centerOf(hub);
+    if (isHorizontalFace(directionFace)) {
+        const above = members.filter((member) => centerOf(member).y <= hubCenter.y).length;
+        return above >= members.length - above ? AnchorOrientation.top : AnchorOrientation.bottom;
+    }
+    const leftward = members.filter((member) => centerOf(member).x <= hubCenter.x).length;
+    return leftward >= members.length - leftward ? AnchorOrientation.left : AnchorOrientation.right;
+};
+
+/**
+ * Decides a leaf's hub face + trunk mode: its direction face with an INSIDE trunk, or — if that face
+ * is crowded — the clear 90° face with an OVER trunk. Depends only on the comb, so every member lands
+ * on the same face+mode and they stay merged.
+ */
+const resolveHubFace = (
+    hub: AugmentedSystemComponent,
+    leaf: AugmentedSystemComponent,
+    connections: AugmentedSystemConnection[],
+    components: AugmentedSystemComponent[]
+): HubFaceResolution => {
+    const directionFace = assignHubFace(hub, leaf, connections, components);
+    const directionMembers = collectDirectionMembers(hub, leaf, directionFace, connections, components);
+    if (directionMembers.length >= 2 && combCollides(hub, directionFace, directionMembers, "inside")) {
+        const flippedFace = perpendicularApproachFace(hub, directionFace, directionMembers);
+        if (!combCollides(hub, flippedFace, directionMembers, "over")) {
+            return { hubFace: flippedFace, mode: "over" };
+        }
+    }
+    return { hubFace: directionFace, mode: "inside" };
+};
+
+/**
+ * Fishbone entry: picks the hub (busier endpoint) and routes the leaf onto its trunk. Returns null —
+ * handing off to the plain router — for lone/equal-degree pairs or any trunk that isn't clean.
+ */
+export const routeFishbone = (input: ConnectionRoutingInput): ConnectionRoutingResult | null => {
+    const { fromComponent, toComponent, components, connections, from, to, pointsOfAttack } = input;
+
+    if (from.id === to.id) {
+        return null;
+    }
+    if (fromComponent.gridX === toComponent.gridX && fromComponent.gridY === toComponent.gridY) {
+        return null;
+    }
+
+    const degree = buildDegreeMap(connections);
+    const fromDegree = degree.get(fromComponent.id) ?? 0;
+    const toDegree = degree.get(toComponent.id) ?? 0;
+    // One endpoint must be busier to be the hub; lone pairs and equal pairs fall back.
+    if (Math.max(fromDegree, toDegree) <= 1 || fromDegree === toDegree) {
+        return null;
+    }
+
+    const fromIsHub = fromDegree > toDegree;
+    const hub = fromIsHub ? fromComponent : toComponent;
+    const leaf = fromIsHub ? toComponent : fromComponent;
+
+    const { hubFace, mode } = resolveHubFace(hub, leaf, connections, components);
+
+    // This comb's members: the hub's connections landing on the same face AND mode (incl. this leaf).
+    // A comb needs at least two — a lone connection draws better as a plain direct line.
+    const componentById = new Map(components.map((component) => [component.id, component]));
+    const members: AugmentedSystemComponent[] = [leaf];
+    for (const connection of connections) {
+        const otherId =
+            connection.from.id === hub.id ? connection.to.id : connection.to.id === hub.id ? connection.from.id : null;
+        if (otherId === null || otherId === hub.id || otherId === leaf.id) {
+            continue;
+        }
+        const other = componentById.get(otherId);
+        if (!other) {
+            continue;
+        }
+        const otherResolution = resolveHubFace(hub, other, connections, components);
+        if (otherResolution.hubFace === hubFace && otherResolution.mode === mode) {
+            members.push(other);
+        }
+    }
+    if (members.length < 2) {
+        return null;
+    }
+
+    const fishbone = fishbonePath(hub, leaf, hubFace, combTrunkPosition(hub, hubFace, members, mode));
+    if (!fishbone) {
+        return null;
+    }
+
+    const points = simplifyPolyline(fishbone.points);
+    if (points.length < 2 || !isOrthogonal(points) || !allFinite(points)) {
+        return null;
+    }
+
+    // Both ends must still leave/enter straight-out (also catches a collapsed segment).
+    const leafOutward = outwardUnit(fishbone.leafFace);
+    const hubOutward = outwardUnit(fishbone.hubFace);
+    const hubInward = { x: -hubOutward.x, y: -hubOutward.y };
+    const leafStep = stepDirection(points[0]!, points[1]!);
+    const hubStep = stepDirection(points[points.length - 2]!, points[points.length - 1]!);
+    if (!sameDirection(leafStep, leafOutward) || !sameDirection(hubStep, hubInward)) {
+        return null;
+    }
+
+    // The route must not cross the hub or any other box (only this connection's own hub and leaf are
+    // exempt). If any segment would, this connection drops out to the plain router instead.
+    const hubInterior = shrinkRectangle(rectOf(hub));
+    const obstacles = components.filter((component) => component.id !== hub.id && component.id !== leaf.id).map(rectOf);
+    for (let index = 1; index < points.length; index++) {
+        if (segHitsRect(points[index - 1]!, points[index]!, hubInterior)) {
+            return null;
+        }
+    }
+    if (countObstacleHits(points, obstacles) > 0) {
+        return null;
+    }
+
+    const fromFace = fromIsHub ? fishbone.hubFace : fishbone.leafFace;
+    const toFace = fromIsHub ? fishbone.leafFace : fishbone.hubFace;
+    const connectionPointsMeta: ConnectionPointMeta[] = [
+        buildAnchorMeta(fromComponent, fromFace, from.anchor, pointsOfAttack[0] ?? null),
+        buildAnchorMeta(toComponent, toFace, to.anchor, pointsOfAttack[1] ?? null),
+    ];
+    return { waypoints: flattenPoints(points), connectionPointsMeta };
+};

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
@@ -461,14 +461,14 @@ const splitIsCrossingFree = (
     }
     for (let first = 0; first < routes.length; first++) {
         for (let second = first + 1; second < routes.length; second++) {
-            for (let a = 1; a < routes[first]!.length; a++) {
-                for (let b = 1; b < routes[second]!.length; b++) {
+            for (let firstSegmentIndex = 1; firstSegmentIndex < routes[first]!.length; firstSegmentIndex++) {
+                for (let secondSegmentIndex = 1; secondSegmentIndex < routes[second]!.length; secondSegmentIndex++) {
                     if (
                         crossesTransversally(
-                            routes[first]![a - 1]!,
-                            routes[first]![a]!,
-                            routes[second]![b - 1]!,
-                            routes[second]![b]!
+                            routes[first]![firstSegmentIndex - 1]!,
+                            routes[first]![firstSegmentIndex]!,
+                            routes[second]![secondSegmentIndex - 1]!,
+                            routes[second]![secondSegmentIndex]!
                         )
                     ) {
                         return false;
@@ -513,8 +513,10 @@ const resolveFace = (
     if (mergeable.length >= MIN_OVER_TRUNK_MEMBERS) {
         // The over-trunk forms: its members merge over the cluster; the rest route directly. (No split
         // here — mixing an over-trunk member into an inside sub-comb would draw a trunk we never validated.)
+        // The combKey identifies THIS cluster: two crowded faces that both flip to the same perpendicular
+        // face would otherwise share (hubFace, mode) and fuse into one trunk neither cluster validated.
         setAll(directionMembers, null);
-        setAll(mergeable, { hubFace: flippedFace, mode: "over", combKey: "" });
+        setAll(mergeable, { hubFace: flippedFace, mode: "over", combKey: combRepresentative(mergeable) });
         return byMember;
     }
 

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
@@ -54,6 +54,18 @@ interface FishbonePath {
 }
 
 /**
+ * True when the connection between `hub` and `neighbour` routes onto `hub`'s trunk. Only the busier
+ * endpoint becomes the hub (see routeFishbone), so a neighbour with equal or higher degree hubs
+ * elsewhere and must not count toward this hub's comb — otherwise the trunk is placed for a member
+ * that never rides it.
+ */
+const ridesHubTrunk = (
+    hub: AugmentedSystemComponent,
+    neighbour: AugmentedSystemComponent,
+    degree: Map<string, number>
+): boolean => (degree.get(hub.id) ?? 0) > (degree.get(neighbour.id) ?? 0);
+
+/**
  * Picks which hub face a leaf joins, by direction. An almost-diagonal leaf takes whichever of its two
  * possible faces already has more connections, so same-direction leaves share one comb.
  */
@@ -241,7 +253,7 @@ interface HubFaceResolution {
     combKey: string;
 }
 
-/** The hub's other leaves (plus this one) that point at the same hub face by direction. */
+/** The hub's other leaves (plus this one) that ride this hub's trunk and point at the same face. */
 const collectDirectionMembers = (
     hub: AugmentedSystemComponent,
     leaf: AugmentedSystemComponent,
@@ -250,6 +262,7 @@ const collectDirectionMembers = (
     components: AugmentedSystemComponent[]
 ): AugmentedSystemComponent[] => {
     const componentById = new Map(components.map((component) => [component.id, component]));
+    const degree = buildDegreeMap(connections);
     const members: AugmentedSystemComponent[] = [leaf];
     for (const connection of connections) {
         const otherId =
@@ -258,7 +271,11 @@ const collectDirectionMembers = (
             continue;
         }
         const other = componentById.get(otherId);
-        if (other && assignHubFace(hub, other, connections, components) === directionFace) {
+        if (
+            other &&
+            ridesHubTrunk(hub, other, degree) &&
+            assignHubFace(hub, other, connections, components) === directionFace
+        ) {
             members.push(other);
         }
     }
@@ -591,6 +608,7 @@ export const routeFishbone = (input: ConnectionRoutingInput): ConnectionRoutingR
 
     // This comb's members: the hub's connections landing on the same face, mode AND sub-comb (incl.
     // this leaf). A comb needs at least two — a lone connection draws better as a plain direct line.
+    // Only neighbours that ride this hub's trunk count; a busier neighbour hubs elsewhere.
     const componentById = new Map(components.map((component) => [component.id, component]));
     const members: AugmentedSystemComponent[] = [leaf];
     for (const connection of connections) {
@@ -600,7 +618,7 @@ export const routeFishbone = (input: ConnectionRoutingInput): ConnectionRoutingR
             continue;
         }
         const other = componentById.get(otherId);
-        if (!other) {
+        if (!other || !ridesHubTrunk(hub, other, degree)) {
             continue;
         }
         const otherResolution = resolveHubFace(hub, other, connections, components, faceCache);

--- a/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/fishbone.ts
@@ -25,6 +25,7 @@ import {
     buildDegreeMap,
     centerOf,
     countObstacleHits,
+    crossesTransversally,
     faceMidpoint,
     findBestAnchor,
     flattenPoints,
@@ -32,6 +33,7 @@ import {
     isOrthogonal,
     outwardUnit,
     rectOf,
+    routeLength,
     sameDirection,
     segHitsRect,
     shrinkRectangle,
@@ -42,6 +44,8 @@ import {
 const TRUNK_CLEARANCE = 20; // how far outside the hub the shared trunk sits, in pixels
 const FISHBONE_DIAGONAL_RATIO = 0.5; // above this, a leaf counts as "almost diagonal" from the hub
 const MIN_OVER_TRUNK_MEMBERS = 3; // an over-the-top trunk is only worth its detour for 3+ merged lines
+const MAX_OVER_DETOUR_RATIO = 2; // a leaf joins an over-trunk only if its route stays within 2x a direct line
+const SPLIT_MEMBER_CAP = 12; // skip the (polynomial) sub-comb split for absurdly crowded faces — rare, and the plain router handles them
 
 interface FishbonePath {
     points: Point[];
@@ -233,6 +237,8 @@ const fishbonePath = (
 interface HubFaceResolution {
     hubFace: Face;
     mode: CombMode;
+    // Distinguishes sub-combs that share a face + mode after a crowded face is split
+    combKey: string;
 }
 
 /** The hub's other leaves (plus this one) that point at the same hub face by direction. */
@@ -317,12 +323,24 @@ const overMergeableMembers = (
     flippedFace: Face,
     members: AugmentedSystemComponent[]
 ): AugmentedSystemComponent[] => {
+    const hubCenter = centerOf(hub);
     let survivors = members;
     for (;;) {
         const trunkPosition = combTrunkPosition(hub, flippedFace, survivors, "over");
-        const kept = survivors.filter(
-            (member) => !memberRunHitsOthers(hub, flippedFace, member, survivors, trunkPosition)
-        );
+        const kept = survivors.filter((member) => {
+            if (memberRunHitsOthers(hub, flippedFace, member, survivors, trunkPosition)) {
+                return false;
+            }
+
+            const path = fishbonePath(hub, member, flippedFace, trunkPosition);
+            if (!path) {
+                return false;
+            }
+            const overLength = routeLength(simplifyPolyline(path.points));
+            const memberCenter = centerOf(member);
+            const directLength = Math.abs(memberCenter.x - hubCenter.x) + Math.abs(memberCenter.y - hubCenter.y);
+            return overLength <= directLength * MAX_OVER_DETOUR_RATIO;
+        });
         if (kept.length === survivors.length || kept.length === 0) {
             return kept;
         }
@@ -331,28 +349,208 @@ const overMergeableMembers = (
 };
 
 /**
- * Decides a leaf's hub face + trunk mode: its direction face with an INSIDE trunk, or — if that face
- * is crowded — the clear 90° face with an OVER trunk. Returns null when a congested comb is too small
- * to be worth lifting over the cluster, so its members route directly (radially) instead. Depends only
- * on the comb, so every member lands on the same decision and they stay consistent.
+ * One comb member's inside route, validated exactly as routeFishbone validates the final route:
+ * orthogonal, finite, clear of the hub interior and of every other component box. Returns the
+ * simplified points when clean, else null.
+ */
+const cleanInsideMemberRoute = (
+    hub: AugmentedSystemComponent,
+    hubFace: Face,
+    member: AugmentedSystemComponent,
+    trunkPosition: number,
+    components: AugmentedSystemComponent[]
+): Point[] | null => {
+    const path = fishbonePath(hub, member, hubFace, trunkPosition);
+    if (!path) {
+        return null;
+    }
+    const points = simplifyPolyline(path.points);
+    if (points.length < 2 || !isOrthogonal(points) || !allFinite(points)) {
+        return null;
+    }
+    // Mirror routeFishbone's straight-out check: leave the leaf outward, enter the hub inward.
+    const leafOutward = outwardUnit(path.leafFace);
+    const hubOutward = outwardUnit(path.hubFace);
+    const leafStep = stepDirection(points[0]!, points[1]!);
+    const hubStep = stepDirection(points[points.length - 2]!, points[points.length - 1]!);
+    if (!sameDirection(leafStep, leafOutward) || !sameDirection(hubStep, { x: -hubOutward.x, y: -hubOutward.y })) {
+        return null;
+    }
+    const hubInterior = shrinkRectangle(rectOf(hub));
+    for (let index = 1; index < points.length; index++) {
+        if (segHitsRect(points[index - 1]!, points[index]!, hubInterior)) {
+            return null;
+        }
+    }
+    const obstacles = components
+        .filter((component) => component.id !== hub.id && component.id !== member.id)
+        .map(rectOf);
+    return countObstacleHits(points, obstacles) > 0 ? null : points;
+};
+
+/** How far a member sits from the hub along the axis the trunk is perpendicular to. */
+const hubNormalDistance = (hub: AugmentedSystemComponent, hubFace: Face, member: AugmentedSystemComponent): number => {
+    const hubCenter = centerOf(hub);
+    const memberCenter = centerOf(member);
+    return isHorizontalFace(hubFace) ? Math.abs(memberCenter.x - hubCenter.x) : Math.abs(memberCenter.y - hubCenter.y);
+};
+
+/**
+ * Greedily partitions a crowded face's members into inside sub-combs that each draw cleanly (no run
+ * cuts the hub or any box). Farthest-from-hub members seed combs first, so the trunk stays tight.
+ * Deterministic — the order depends only on positions and ids — so every member computes the same
+ * partition and agrees which sub-comb it belongs to.
+ */
+const partitionSubCombs = (
+    hub: AugmentedSystemComponent,
+    hubFace: Face,
+    members: AugmentedSystemComponent[],
+    components: AugmentedSystemComponent[]
+): AugmentedSystemComponent[][] => {
+    const sorted = [...members].sort(
+        (first, second) =>
+            hubNormalDistance(hub, hubFace, second) - hubNormalDistance(hub, hubFace, first) ||
+            (first.id < second.id ? -1 : 1)
+    );
+    const combs: AugmentedSystemComponent[][] = [];
+    for (const member of sorted) {
+        let placed = false;
+        for (const comb of combs) {
+            const candidate = [...comb, member];
+            const trunkPosition = combTrunkPosition(hub, hubFace, candidate, "inside");
+            if (
+                candidate.every(
+                    (each) => cleanInsideMemberRoute(hub, hubFace, each, trunkPosition, components) !== null
+                )
+            ) {
+                comb.push(member);
+                placed = true;
+                break;
+            }
+        }
+        if (!placed) {
+            combs.push([member]);
+        }
+    }
+    return combs;
+};
+
+/**
+ * The gate that makes a split safe to use: every 2+ member sub-comb must draw cleanly AND no two of
+ * their routes may cross. Otherwise the cluster stays on the plain router (no regression).
+ */
+const splitIsCrossingFree = (
+    hub: AugmentedSystemComponent,
+    hubFace: Face,
+    combs: AugmentedSystemComponent[][],
+    components: AugmentedSystemComponent[]
+): boolean => {
+    const routes: Point[][] = [];
+    for (const comb of combs) {
+        if (comb.length < 2) {
+            continue;
+        }
+        const trunkPosition = combTrunkPosition(hub, hubFace, comb, "inside");
+        for (const member of comb) {
+            const points = cleanInsideMemberRoute(hub, hubFace, member, trunkPosition, components);
+            if (!points) {
+                return false;
+            }
+            routes.push(points);
+        }
+    }
+    for (let first = 0; first < routes.length; first++) {
+        for (let second = first + 1; second < routes.length; second++) {
+            for (let a = 1; a < routes[first]!.length; a++) {
+                for (let b = 1; b < routes[second]!.length; b++) {
+                    if (
+                        crossesTransversally(
+                            routes[first]![a - 1]!,
+                            routes[first]![a]!,
+                            routes[second]![b - 1]!,
+                            routes[second]![b]!
+                        )
+                    ) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+    return true;
+};
+
+/** The id a sub-comb is keyed by, so its members recognise each other: the smallest id, stably. */
+const combRepresentative = (comb: AugmentedSystemComponent[]): string => comb.map((member) => member.id).sort()[0]!;
+
+type FaceResolutionCache = Map<Face, Map<string, HubFaceResolution | null>>;
+
+/**
+ * Resolves EVERY member of one (crowded or not) hub face at once: a plain INSIDE comb, an OVER trunk
+ * for the members that can merge over the cluster, or — only when no over-trunk forms — a split into
+ * compact INSIDE sub-combs. Members with no clean comb get null (they route directly).
+ */
+const resolveFace = (
+    hub: AugmentedSystemComponent,
+    directionFace: Face,
+    directionMembers: AugmentedSystemComponent[],
+    components: AugmentedSystemComponent[]
+): Map<string, HubFaceResolution | null> => {
+    const byMember = new Map<string, HubFaceResolution | null>();
+    const setAll = (members: AugmentedSystemComponent[], resolution: HubFaceResolution | null): void => {
+        for (const member of members) {
+            byMember.set(member.id, resolution);
+        }
+    };
+
+    if (directionMembers.length < 2 || !combCollides(hub, directionFace, directionMembers, "inside")) {
+        setAll(directionMembers, { hubFace: directionFace, mode: "inside", combKey: "" });
+        return byMember;
+    }
+
+    const flippedFace = perpendicularApproachFace(hub, directionFace, directionMembers);
+    const mergeable = overMergeableMembers(hub, flippedFace, directionMembers);
+    if (mergeable.length >= MIN_OVER_TRUNK_MEMBERS) {
+        // The over-trunk forms: its members merge over the cluster; the rest route directly. (No split
+        // here — mixing an over-trunk member into an inside sub-comb would draw a trunk we never validated.)
+        setAll(directionMembers, null);
+        setAll(mergeable, { hubFace: flippedFace, mode: "over", combKey: "" });
+        return byMember;
+    }
+
+    // No over-trunk. Try splitting the crowded face into compact inside sub-combs — adopting it only
+    // when every sub-comb draws cleanly and none of their routes cross (else everyone routes directly).
+    setAll(directionMembers, null);
+    if (directionMembers.length <= SPLIT_MEMBER_CAP) {
+        const combs = partitionSubCombs(hub, directionFace, directionMembers, components);
+        if (combs.every((comb) => comb.length >= 2) && splitIsCrossingFree(hub, directionFace, combs, components)) {
+            for (const comb of combs) {
+                setAll(comb, { hubFace: directionFace, mode: "inside", combKey: combRepresentative(comb) });
+            }
+        }
+    }
+    return byMember;
+};
+
+/**
+ * Decides a leaf's hub face + trunk mode (see resolveFace), cached per face. Returns null when no clean
+ * comb fits, so the leaf routes directly. Depends only on the comb, so every member stays consistent.
  */
 const resolveHubFace = (
     hub: AugmentedSystemComponent,
     leaf: AugmentedSystemComponent,
     connections: AugmentedSystemConnection[],
-    components: AugmentedSystemComponent[]
+    components: AugmentedSystemComponent[],
+    cache: FaceResolutionCache
 ): HubFaceResolution | null => {
     const directionFace = assignHubFace(hub, leaf, connections, components);
-    const directionMembers = collectDirectionMembers(hub, leaf, directionFace, connections, components);
-    if (directionMembers.length >= 2 && combCollides(hub, directionFace, directionMembers, "inside")) {
-        const flippedFace = perpendicularApproachFace(hub, directionFace, directionMembers);
-        const mergeable = overMergeableMembers(hub, flippedFace, directionMembers);
-        if (mergeable.length >= MIN_OVER_TRUNK_MEMBERS && mergeable.some((member) => member.id === leaf.id)) {
-            return { hubFace: flippedFace, mode: "over" };
-        }
-        return null;
+    let byMember = cache.get(directionFace);
+    if (!byMember) {
+        const directionMembers = collectDirectionMembers(hub, leaf, directionFace, connections, components);
+        byMember = resolveFace(hub, directionFace, directionMembers, components);
+        cache.set(directionFace, byMember);
     }
-    return { hubFace: directionFace, mode: "inside" };
+    return byMember.get(leaf.id) ?? null;
 };
 
 /**
@@ -381,14 +579,16 @@ export const routeFishbone = (input: ConnectionRoutingInput): ConnectionRoutingR
     const hub = fromIsHub ? fromComponent : toComponent;
     const leaf = fromIsHub ? toComponent : fromComponent;
 
-    const resolution = resolveHubFace(hub, leaf, connections, components);
+    // One cache for every resolveHubFace call below, so the hub's face decision is computed once.
+    const faceCache: FaceResolutionCache = new Map();
+    const resolution = resolveHubFace(hub, leaf, connections, components, faceCache);
     if (!resolution) {
         return null;
     }
-    const { hubFace, mode } = resolution;
+    const { hubFace, mode, combKey } = resolution;
 
-    // This comb's members: the hub's connections landing on the same face AND mode (incl. this leaf).
-    // A comb needs at least two — a lone connection draws better as a plain direct line.
+    // This comb's members: the hub's connections landing on the same face, mode AND sub-comb (incl.
+    // this leaf). A comb needs at least two — a lone connection draws better as a plain direct line.
     const componentById = new Map(components.map((component) => [component.id, component]));
     const members: AugmentedSystemComponent[] = [leaf];
     for (const connection of connections) {
@@ -401,8 +601,13 @@ export const routeFishbone = (input: ConnectionRoutingInput): ConnectionRoutingR
         if (!other) {
             continue;
         }
-        const otherResolution = resolveHubFace(hub, other, connections, components);
-        if (otherResolution && otherResolution.hubFace === hubFace && otherResolution.mode === mode) {
+        const otherResolution = resolveHubFace(hub, other, connections, components, faceCache);
+        if (
+            otherResolution &&
+            otherResolution.hubFace === hubFace &&
+            otherResolution.mode === mode &&
+            otherResolution.combKey === combKey
+        ) {
             members.push(other);
         }
     }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
@@ -1,0 +1,62 @@
+import { computeConnectionRouting } from "./index.ts";
+import { routeFishbone } from "./fishbone.ts";
+import { routeDeterministic } from "./deterministic.ts";
+import { createAugmentedConnection, createSystemComponent } from "#test-utils/builders.ts";
+
+describe("computeConnectionRouting composition", () => {
+    it("uses the fishbone route when connections form a comb", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 50 });
+        const leafA = createSystemComponent({ id: "leaf-a", gridX: 80, gridY: 40 });
+        const leafB = createSystemComponent({ id: "leaf-b", gridX: 80, gridY: 60 });
+        const components = [hub, leafA, leafB];
+        const connectionA = createAugmentedConnection({ id: "c-a", fromComponent: leafA, toComponent: hub });
+        const connectionB = createAugmentedConnection({ id: "c-b", fromComponent: leafB, toComponent: hub });
+        const input = {
+            fromComponent: leafA,
+            toComponent: hub,
+            components,
+            connections: [connectionA, connectionB],
+            from: connectionA.from,
+            to: connectionA.to,
+            pointsOfAttack: [],
+        };
+
+        expect(routeFishbone(input)).not.toBeNull();
+        expect(computeConnectionRouting(input)).toEqual(routeFishbone(input));
+    });
+
+    it("falls back to the deterministic route when there is no hub", () => {
+        const from = createSystemComponent({ id: "from", gridX: 0, gridY: 0 });
+        const to = createSystemComponent({ id: "to", gridX: 60, gridY: 0 });
+        const connection = createAugmentedConnection({ id: "lone", fromComponent: from, toComponent: to });
+        const input = {
+            fromComponent: from,
+            toComponent: to,
+            components: [from, to],
+            connections: [connection],
+            from: connection.from,
+            to: connection.to,
+            pointsOfAttack: [],
+        };
+
+        expect(routeFishbone(input)).toBeNull();
+        expect(computeConnectionRouting(input)).toEqual(routeDeterministic(input));
+    });
+
+    it("returns null when neither router can route (two components in the same cell)", () => {
+        const a = createSystemComponent({ id: "a", gridX: 0, gridY: 0 });
+        const b = createSystemComponent({ id: "b", gridX: 0, gridY: 0 });
+        const connection = createAugmentedConnection({ id: "same", fromComponent: a, toComponent: b });
+        const input = {
+            fromComponent: a,
+            toComponent: b,
+            components: [a, b],
+            connections: [connection],
+            from: connection.from,
+            to: connection.to,
+            pointsOfAttack: [],
+        };
+
+        expect(computeConnectionRouting(input)).toBeNull();
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
@@ -14,6 +14,7 @@ describe("computeConnectionRouting composition", () => {
         const connectionA = createAugmentedConnection({ id: "c-a", fromComponent: leafA, toComponent: hub });
         const connectionB = createAugmentedConnection({ id: "c-b", fromComponent: leafB, toComponent: hub });
         const input = {
+            connectionId: "c-a",
             fromComponent: leafA,
             toComponent: hub,
             components,
@@ -82,6 +83,7 @@ describe("computeConnectionRouting composition", () => {
         const to = createSystemComponent({ id: "to", gridX: 60, gridY: 0 });
         const connection = createAugmentedConnection({ id: "lone", fromComponent: from, toComponent: to });
         const input = {
+            connectionId: "lone",
             fromComponent: from,
             toComponent: to,
             components: [from, to],
@@ -100,6 +102,7 @@ describe("computeConnectionRouting composition", () => {
         const b = createSystemComponent({ id: "b", gridX: 0, gridY: 0 });
         const connection = createAugmentedConnection({ id: "same", fromComponent: a, toComponent: b });
         const input = {
+            connectionId: "same",
             fromComponent: a,
             toComponent: b,
             components: [a, b],
@@ -137,6 +140,7 @@ describe("computeConnectionRouting composition", () => {
         const routes = Object.keys(grid).map((id) => {
             const connection = connections.find((candidate) => candidate.id === id)!;
             return computeConnectionRouting({
+                connectionId: connection.id,
                 fromComponent: leaves[id]!,
                 toComponent: hub,
                 components,
@@ -186,6 +190,7 @@ describe("computeConnectionRouting composition", () => {
         const routeOf = (leafId: string): number[] => {
             const connection = connections.find((candidate) => candidate.from.id === leafId)!;
             return computeConnectionRouting({
+                connectionId: connection.id,
                 fromComponent: byId.get(leafId)!,
                 toComponent: byId.get("main")!,
                 components,
@@ -267,6 +272,7 @@ describe("computeConnectionRouting composition", () => {
         for (const id of leaves) {
             const connection = connections.find((candidate) => candidate.from.id === id)!;
             const route = computeConnectionRouting({
+                connectionId: connection.id,
                 fromComponent: byId.get(id)!,
                 toComponent: byId.get("main")!,
                 components,

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
@@ -1,6 +1,7 @@
 import { computeConnectionRouting } from "./index.ts";
 import { routeFishbone } from "./fishbone.ts";
 import { routeDeterministic } from "./deterministic.ts";
+import { buildRouteScoringContext, countRouteDefects, pointsFromWaypoints } from "./shared.ts";
 import { crossesTransversally, segmentsOf } from "#test-utils/connection-routing-helpers.ts";
 import { createAugmentedConnection, createSystemComponent } from "#test-utils/builders.ts";
 
@@ -24,6 +25,56 @@ describe("computeConnectionRouting composition", () => {
 
         expect(routeFishbone(input)).not.toBeNull();
         expect(computeConnectionRouting(input)).toEqual(routeFishbone(input));
+    });
+
+    it("abandons a fishbone that would fuse with an unrelated line for a route with fewer defects", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 0, gridY: 50 });
+        const leafA = createSystemComponent({ id: "leaf-a", gridX: 80, gridY: 40 });
+        const leafB = createSystemComponent({ id: "leaf-b", gridX: 80, gridY: 60 });
+        const connectionA = createAugmentedConnection({ id: "c-a", fromComponent: leafA, toComponent: hub });
+        const connectionB = createAugmentedConnection({ id: "c-b", fromComponent: leafB, toComponent: hub });
+        const baseInput = {
+            connectionId: "c-a",
+            fromComponent: leafA,
+            toComponent: hub,
+            components: [hub, leafA, leafB],
+            connections: [connectionA, connectionB],
+            from: connectionA.from,
+            to: connectionA.to,
+            pointsOfAttack: [],
+        };
+        const fishbone = routeFishbone(baseInput)!;
+        expect(fishbone).not.toBeNull();
+
+        // Lay an unrelated connection's stored line exactly along the fishbone route's longest
+        // segment, so keeping the fishbone would draw the two as one fused line.
+        const fishboneSegments = segmentsOf(fishbone.waypoints);
+        const longest = fishboneSegments.reduce((best, candidate) => {
+            const lengthOf = ([start, end]: (typeof fishboneSegments)[number]) =>
+                Math.abs(end.x - start.x) + Math.abs(end.y - start.y);
+            return lengthOf(candidate) > lengthOf(best) ? candidate : best;
+        });
+        const farAway = createSystemComponent({ id: "far-away", gridX: 400, gridY: 400 });
+        const farAwayToo = createSystemComponent({ id: "far-away-too", gridX: 400, gridY: 440 });
+        const unrelated = createAugmentedConnection({
+            id: "unrelated",
+            fromComponent: farAway,
+            toComponent: farAwayToo,
+            waypoints: [longest[0].x, longest[0].y, longest[1].x, longest[1].y],
+        });
+        const input = {
+            ...baseInput,
+            components: [...baseInput.components, farAway, farAwayToo],
+            connections: [...baseInput.connections, unrelated],
+        };
+
+        const chosen = computeConnectionRouting(input)!;
+        expect(chosen).not.toBeNull();
+        const scoringContext = buildRouteScoringContext(input);
+        const chosenDefects = countRouteDefects(pointsFromWaypoints(chosen.waypoints), scoringContext);
+        const fishboneDefects = countRouteDefects(pointsFromWaypoints(fishbone.waypoints), scoringContext);
+        expect(fishboneDefects.overlapLength).toBeGreaterThan(0);
+        expect(chosenDefects.overlapLength).toBeLessThan(fishboneDefects.overlapLength);
     });
 
     it("falls back to the deterministic route when there is no hub", () => {

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
@@ -106,4 +106,127 @@ describe("computeConnectionRouting composition", () => {
             }
         }
     });
+
+    it("splits a crowded hub face into compact sub-combs so same-target lines merge without crossing", () => {
+        const grid: Record<string, { gridX: number; gridY: number }> = {
+            main: { gridX: 197, gridY: 20 },
+            A: { gridX: 226, gridY: -11 },
+            C: { gridX: 235, gridY: 73 },
+            B: { gridX: 298, gridY: 74 },
+            D: { gridX: 307, gridY: 146 },
+            H: { gridX: 347, gridY: 21 },
+            F: { gridX: 166, gridY: -36 },
+            J: { gridX: 106, gridY: 27 },
+            G: { gridX: 101, gridY: 85 },
+            E: { gridX: 140, gridY: 67 },
+            K: { gridX: 112, gridY: -11 },
+            L: { gridX: -25, gridY: 49 },
+        };
+        const components = Object.entries(grid).map(([id, position]) => createSystemComponent({ id, ...position }));
+        const byId = new Map(components.map((component) => [component.id, component]));
+        const leaves = Object.keys(grid).filter((id) => id !== "main");
+        const connections = leaves.map((id) =>
+            createAugmentedConnection({
+                id: `${id}-main`,
+                fromComponent: byId.get(id)!,
+                toComponent: byId.get("main")!,
+            })
+        );
+        const routeOf = (leafId: string): number[] => {
+            const connection = connections.find((candidate) => candidate.from.id === leafId)!;
+            return computeConnectionRouting({
+                fromComponent: byId.get(leafId)!,
+                toComponent: byId.get("main")!,
+                components,
+                connections,
+                from: connection.from,
+                to: connection.to,
+                pointsOfAttack: [],
+            })!.waypoints;
+        };
+        const routes = leaves.map((id) => routeOf(id));
+
+        // No two connections to the same target (main) may cross.
+        for (let first = 0; first < routes.length; first++) {
+            for (let second = first + 1; second < routes.length; second++) {
+                for (const [a, b] of segmentsOf(routes[first]!)) {
+                    for (const [c, d] of segmentsOf(routes[second]!)) {
+                        expect(crossesTransversally(a, b, c, d)).toBe(false);
+                    }
+                }
+            }
+        }
+
+        // B and H land in the same sub-comb: their routes must share a collinear trunk segment (merge),
+        // not run independently.
+        const sharesTrunk = (first: number[], second: number[]): boolean =>
+            segmentsOf(first).some(([a, b]) =>
+                segmentsOf(second).some(([c, d]) => {
+                    if (a.x === b.x && c.x === d.x && a.x === c.x) {
+                        return (
+                            Math.min(Math.max(a.y, b.y), Math.max(c.y, d.y)) >
+                            Math.max(Math.min(a.y, b.y), Math.min(c.y, d.y))
+                        );
+                    }
+                    if (a.y === b.y && c.y === d.y && a.y === c.y) {
+                        return (
+                            Math.min(Math.max(a.x, b.x), Math.max(c.x, d.x)) >
+                            Math.max(Math.min(a.x, b.x), Math.min(c.x, d.x))
+                        );
+                    }
+                    return false;
+                })
+            );
+        expect(sharesTrunk(routeOf("B"), routeOf("H"))).toBe(true);
+    });
+
+    // Detour cap: a leaf level with / above a busy hub must not plunge out to a far over-trunk and back.
+    // Without the cap, A and H loop ~1600-2045px (5x and 2.7x their straight-line distance to the hub).
+    it("does not route a busy hub's leaves on absurd over-trunk detours", () => {
+        const grid: Record<string, { gridX: number; gridY: number }> = {
+            main: { gridX: 197, gridY: 20 },
+            A: { gridX: 226, gridY: -11 },
+            C: { gridX: 235, gridY: 73 },
+            B: { gridX: 298, gridY: 74 },
+            D: { gridX: 307, gridY: 146 },
+            H: { gridX: 347, gridY: 21 },
+            F: { gridX: 166, gridY: -36 },
+            K: { gridX: 112, gridY: -11 },
+            L: { gridX: -25, gridY: 49 },
+        };
+        const components = Object.entries(grid).map(([id, position]) => createSystemComponent({ id, ...position }));
+        const byId = new Map(components.map((component) => [component.id, component]));
+        const leaves = Object.keys(grid).filter((id) => id !== "main");
+        const connections = leaves.map((id) =>
+            createAugmentedConnection({
+                id: `${id}-main`,
+                fromComponent: byId.get(id)!,
+                toComponent: byId.get("main")!,
+            })
+        );
+        const lengthOf = (waypoints: number[]): number => {
+            let total = 0;
+            for (let index = 2; index < waypoints.length; index += 2) {
+                total +=
+                    Math.abs(waypoints[index]! - waypoints[index - 2]!) +
+                    Math.abs(waypoints[index + 1]! - waypoints[index - 1]!);
+            }
+            return total;
+        };
+        for (const id of leaves) {
+            const connection = connections.find((candidate) => candidate.from.id === id)!;
+            const route = computeConnectionRouting({
+                fromComponent: byId.get(id)!,
+                toComponent: byId.get("main")!,
+                components,
+                connections,
+                from: connection.from,
+                to: connection.to,
+                pointsOfAttack: [],
+            })!;
+            const directDistance =
+                (Math.abs(grid[id]!.gridX - grid["main"]!.gridX) + Math.abs(grid[id]!.gridY - grid["main"]!.gridY)) * 5;
+            expect(lengthOf(route.waypoints)).toBeLessThanOrEqual(directDistance * 2.5);
+        }
+    });
 });

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.test.ts
@@ -1,6 +1,7 @@
 import { computeConnectionRouting } from "./index.ts";
 import { routeFishbone } from "./fishbone.ts";
 import { routeDeterministic } from "./deterministic.ts";
+import { crossesTransversally, segmentsOf } from "#test-utils/connection-routing-helpers.ts";
 import { createAugmentedConnection, createSystemComponent } from "#test-utils/builders.ts";
 
 describe("computeConnectionRouting composition", () => {
@@ -58,5 +59,51 @@ describe("computeConnectionRouting composition", () => {
         };
 
         expect(computeConnectionRouting(input)).toBeNull();
+    });
+
+    it("keeps a dense real-world hub crossing-free by merging a boxed-in leaf while a level one enters directly", () => {
+        const hub = createSystemComponent({ id: "hub", gridX: 153, gridY: 55 });
+        const grid: Record<string, { gridX: number; gridY: number }> = {
+            A: { gridX: 270, gridY: 97 },
+            B: { gridX: 226, gridY: 100 },
+            C: { gridX: 191, gridY: 99 },
+            D: { gridX: 268, gridY: 55 },
+            E: { gridX: 126, gridY: 121 },
+            F: { gridX: 116, gridY: 19 },
+            G: { gridX: 75, gridY: 90 },
+            H: { gridX: 155, gridY: -26 },
+            J: { gridX: 41, gridY: 55 },
+            K: { gridX: 74, gridY: -24 },
+            L: { gridX: -20, gridY: 47 },
+        };
+        const leaves = Object.fromEntries(
+            Object.entries(grid).map(([id, position]) => [id, createSystemComponent({ id, ...position })])
+        );
+        const components = [hub, ...Object.values(leaves)];
+        const connections = Object.keys(grid).map((id) =>
+            createAugmentedConnection({ id, fromComponent: leaves[id]!, toComponent: hub })
+        );
+        const routes = Object.keys(grid).map((id) => {
+            const connection = connections.find((candidate) => candidate.id === id)!;
+            return computeConnectionRouting({
+                fromComponent: leaves[id]!,
+                toComponent: hub,
+                components,
+                connections,
+                from: connection.from,
+                to: connection.to,
+                pointsOfAttack: [],
+            })!.waypoints;
+        });
+
+        for (let first = 0; first < routes.length; first++) {
+            for (let second = first + 1; second < routes.length; second++) {
+                for (const [a, b] of segmentsOf(routes[first]!)) {
+                    for (const [c, d] of segmentsOf(routes[second]!)) {
+                        expect(crossesTransversally(a, b, c, d)).toBe(false);
+                    }
+                }
+            }
+        }
     });
 });

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
@@ -1,10 +1,44 @@
-import type { ConnectionRoutingInput, ConnectionRoutingResult } from "./shared.ts";
+import {
+    type ConnectionRoutingInput,
+    type ConnectionRoutingResult,
+    countObstacleHits,
+    countUnrelatedLineCrossings,
+    pointsFromWaypoints,
+    rectOf,
+} from "./shared.ts";
 import { routeFishbone } from "./fishbone.ts";
 import { routeDeterministic } from "./deterministic.ts";
 
 export type { ConnectionRoutingInput, ConnectionRoutingResult } from "./shared.ts";
 export { rectOf, segHitsRect, simplifyPolyline, findBestAnchor } from "./shared.ts";
 
+/** True when the route runs through any component box other than its own two endpoints. */
+const hitsAnyComponent = (waypoints: number[], input: ConnectionRoutingInput): boolean => {
+    const obstacles = input.components
+        .filter((component) => component.id !== input.from.id && component.id !== input.to.id)
+        .map(rectOf);
+    return countObstacleHits(pointsFromWaypoints(waypoints), obstacles) > 0;
+};
+
 export function computeConnectionRouting(input: ConnectionRoutingInput): ConnectionRoutingResult | null {
-    return routeFishbone(input) ?? routeDeterministic(input);
+    const fishbone = routeFishbone(input);
+    if (!fishbone) {
+        return routeDeterministic(input);
+    }
+    // The fishbone router ignores unrelated lines. When its route crosses one, fall back to the
+    // deterministic route — but only if that crosses less AND stays out of every component box
+    // (the fishbone route is always box-free; a line crossing beats a line through a box).
+    const fishboneCrossings = countUnrelatedLineCrossings(fishbone.waypoints, input);
+    if (fishboneCrossings === 0) {
+        return fishbone;
+    }
+    const deterministic = routeDeterministic(input);
+    if (
+        deterministic &&
+        countUnrelatedLineCrossings(deterministic.waypoints, input) < fishboneCrossings &&
+        !hitsAnyComponent(deterministic.waypoints, input)
+    ) {
+        return deterministic;
+    }
+    return fishbone;
 }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
@@ -1,10 +1,10 @@
 import {
     type ConnectionRoutingInput,
     type ConnectionRoutingResult,
-    countObstacleHits,
-    countUnrelatedLineCrossings,
+    buildRouteScoringContext,
+    compareRouteDefects,
+    countRouteDefects,
     pointsFromWaypoints,
-    rectOf,
 } from "./shared.ts";
 import { routeFishbone } from "./fishbone.ts";
 import { routeDeterministic } from "./deterministic.ts";
@@ -12,33 +12,24 @@ import { routeDeterministic } from "./deterministic.ts";
 export type { ConnectionRoutingInput, ConnectionRoutingResult } from "./shared.ts";
 export { rectOf, segHitsRect, simplifyPolyline, findBestAnchor, hasDrawableLine } from "./shared.ts";
 
-/** True when the route runs through any component box other than its own two endpoints. */
-const hitsAnyComponent = (waypoints: number[], input: ConnectionRoutingInput): boolean => {
-    const obstacles = input.components
-        .filter((component) => component.id !== input.from.id && component.id !== input.to.id)
-        .map(rectOf);
-    return countObstacleHits(pointsFromWaypoints(waypoints), obstacles) > 0;
-};
-
 export function computeConnectionRouting(input: ConnectionRoutingInput): ConnectionRoutingResult | null {
     const fishbone = routeFishbone(input);
     if (!fishbone) {
         return routeDeterministic(input);
     }
-    // The fishbone router ignores unrelated lines. When its route crosses one, fall back to the
-    // deterministic route — but only if that crosses less AND stays out of every component box
-    // (the fishbone route is always box-free; a line crossing beats a line through a box).
-    const fishboneCrossings = countUnrelatedLineCrossings(fishbone.waypoints, input);
-    if (fishboneCrossings === 0) {
+    // The fishbone router ignores unrelated lines, so score its route with the same defect policy
+    // (boxes > crossings > overlap) the deterministic router uses. A defect-free fishbone wins;
+    // otherwise the deterministic route takes over only with strictly fewer defects. Ties keep the
+    // fishbone — trunk merging is the preferred look, and bends/length are style, not defects.
+    const scoringContext = buildRouteScoringContext(input);
+    const fishboneDefects = countRouteDefects(pointsFromWaypoints(fishbone.waypoints), scoringContext);
+    if (fishboneDefects.obstacleHits === 0 && fishboneDefects.crossings === 0 && fishboneDefects.overlapLength === 0) {
         return fishbone;
     }
     const deterministic = routeDeterministic(input);
-    if (
-        deterministic &&
-        countUnrelatedLineCrossings(deterministic.waypoints, input) < fishboneCrossings &&
-        !hitsAnyComponent(deterministic.waypoints, input)
-    ) {
-        return deterministic;
+    if (!deterministic) {
+        return fishbone;
     }
-    return fishbone;
+    const deterministicDefects = countRouteDefects(pointsFromWaypoints(deterministic.waypoints), scoringContext);
+    return compareRouteDefects(deterministicDefects, fishboneDefects) < 0 ? deterministic : fishbone;
 }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
@@ -10,7 +10,7 @@ import { routeFishbone } from "./fishbone.ts";
 import { routeDeterministic } from "./deterministic.ts";
 
 export type { ConnectionRoutingInput, ConnectionRoutingResult } from "./shared.ts";
-export { rectOf, segHitsRect, simplifyPolyline, findBestAnchor } from "./shared.ts";
+export { rectOf, segHitsRect, simplifyPolyline, findBestAnchor, hasDrawableLine } from "./shared.ts";
 
 /** True when the route runs through any component box other than its own two endpoints. */
 const hitsAnyComponent = (waypoints: number[], input: ConnectionRoutingInput): boolean => {

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
@@ -1,0 +1,13 @@
+import type { ConnectionRoutingInput, ConnectionRoutingResult } from "./shared.ts";
+import { routeFishbone } from "./fishbone.ts";
+import { routeDeterministic } from "./deterministic.ts";
+
+export type { ConnectionRoutingInput, ConnectionRoutingResult } from "./shared.ts";
+export { rectOf, segHitsRect, simplifyPolyline, findBestAnchor } from "./shared.ts";
+
+/**
+ * Works out the waypoints + connection-point info for one connection. Returns null when no route is possible (nothing gets drawn).
+ */
+export function computeConnectionRouting(input: ConnectionRoutingInput): ConnectionRoutingResult | null {
+    return routeFishbone(input) ?? routeDeterministic(input);
+}

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
@@ -10,7 +10,7 @@ import { routeFishbone } from "./fishbone.ts";
 import { routeDeterministic } from "./deterministic.ts";
 
 export type { ConnectionRoutingInput, ConnectionRoutingResult } from "./shared.ts";
-export { rectOf, segHitsRect, simplifyPolyline, findBestAnchor, hasDrawableLine } from "./shared.ts";
+export { rectangleOf, segmentHitsRectangle, simplifyPolyline, findBestAnchor, hasDrawableLine } from "./shared.ts";
 
 export function computeConnectionRouting(input: ConnectionRoutingInput): ConnectionRoutingResult | null {
     const fishbone = routeFishbone(input);

--- a/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/index.ts
@@ -5,9 +5,6 @@ import { routeDeterministic } from "./deterministic.ts";
 export type { ConnectionRoutingInput, ConnectionRoutingResult } from "./shared.ts";
 export { rectOf, segHitsRect, simplifyPolyline, findBestAnchor } from "./shared.ts";
 
-/**
- * Works out the waypoints + connection-point info for one connection. Returns null when no route is possible (nothing gets drawn).
- */
 export function computeConnectionRouting(input: ConnectionRoutingInput): ConnectionRoutingResult | null {
     return routeFishbone(input) ?? routeDeterministic(input);
 }

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.test.ts
@@ -1,5 +1,6 @@
 import {
     buildAnchorMeta,
+    compareRouteDefects,
     countObstacleHits,
     faceMidpoint,
     findBestAnchor,
@@ -249,5 +250,30 @@ describe("buildAnchorMeta", () => {
             createPointOfAttack({ id: "poa-x" })
         );
         expect(meta.pointOfAttack?.id).toBe("poa-x");
+    });
+});
+
+describe("compareRouteDefects", () => {
+    const defects = (obstacleHits: number, crossings: number, overlapLength: number) => ({
+        obstacleHits,
+        crossings,
+        overlapLength,
+    });
+
+    it("ranks a box hit above any number of crossings", () => {
+        expect(compareRouteDefects(defects(0, 5, 0), defects(1, 0, 0))).toBeLessThan(0);
+    });
+
+    it("ranks a crossing above any amount of overlap", () => {
+        expect(compareRouteDefects(defects(0, 0, 500), defects(0, 1, 0))).toBeLessThan(0);
+    });
+
+    it("breaks a crossing tie by overlap length", () => {
+        expect(compareRouteDefects(defects(0, 1, 10), defects(0, 1, 40))).toBeLessThan(0);
+        expect(compareRouteDefects(defects(0, 1, 40), defects(0, 1, 10))).toBeGreaterThan(0);
+    });
+
+    it("returns zero for equal defects", () => {
+        expect(compareRouteDefects(defects(1, 2, 3), defects(1, 2, 3))).toBe(0);
     });
 });

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.test.ts
@@ -5,9 +5,9 @@ import {
     faceMidpoint,
     findBestAnchor,
     flattenPoints,
-    rectOf,
+    rectangleOf,
     routeLength,
-    segHitsRect,
+    segmentHitsRectangle,
     shrinkRectangle,
     simplifyPolyline,
     stepDirection,
@@ -15,9 +15,9 @@ import {
 import { createSystemComponent, createPointOfAttack } from "#test-utils/builders.ts";
 import { AnchorOrientation } from "#api/types/system.types.ts";
 
-describe("rectOf", () => {
+describe("rectangleOf", () => {
     it("converts a component's grid position to its 80x80 pixel box (gridX*5 top-left)", () => {
-        expect(rectOf(createSystemComponent({ gridX: 10, gridY: 20 }))).toEqual({
+        expect(rectangleOf(createSystemComponent({ gridX: 10, gridY: 20 }))).toEqual({
             minX: 50,
             minY: 100,
             maxX: 130,
@@ -26,7 +26,12 @@ describe("rectOf", () => {
     });
 
     it("places a component at the origin spanning one box size", () => {
-        expect(rectOf(createSystemComponent({ gridX: 0, gridY: 0 }))).toEqual({ minX: 0, minY: 0, maxX: 80, maxY: 80 });
+        expect(rectangleOf(createSystemComponent({ gridX: 0, gridY: 0 }))).toEqual({
+            minX: 0,
+            minY: 0,
+            maxX: 80,
+            maxY: 80,
+        });
     });
 });
 
@@ -107,19 +112,19 @@ describe("simplifyPolyline", () => {
     });
 });
 
-describe("segHitsRect", () => {
+describe("segmentHitsRectangle", () => {
     const rectangle = { minX: 100, minY: 100, maxX: 200, maxY: 200 };
 
     it("detects a segment crossing the rectangle", () => {
-        expect(segHitsRect({ x: 50, y: 150 }, { x: 250, y: 150 }, rectangle)).toBe(true);
+        expect(segmentHitsRectangle({ x: 50, y: 150 }, { x: 250, y: 150 }, rectangle)).toBe(true);
     });
 
     it("ignores a segment that passes clear of the rectangle", () => {
-        expect(segHitsRect({ x: 50, y: 50 }, { x: 250, y: 50 }, rectangle)).toBe(false);
+        expect(segmentHitsRectangle({ x: 50, y: 50 }, { x: 250, y: 50 }, rectangle)).toBe(false);
     });
 
     it("counts touching an edge as a hit", () => {
-        expect(segHitsRect({ x: 50, y: 100 }, { x: 250, y: 100 }, rectangle)).toBe(true);
+        expect(segmentHitsRectangle({ x: 50, y: 100 }, { x: 250, y: 100 }, rectangle)).toBe(true);
     });
 });
 
@@ -139,8 +144,8 @@ describe("shrinkRectangle", () => {
             { x: 50, y: 100 },
             { x: 250, y: 100 },
         ];
-        expect(segHitsRect(onTopEdge[0], onTopEdge[1], box)).toBe(true); // grazes the full box
-        expect(segHitsRect(onTopEdge[0], onTopEdge[1], shrinkRectangle(box))).toBe(false); // clears the shrunk box
+        expect(segmentHitsRectangle(onTopEdge[0], onTopEdge[1], box)).toBe(true); // grazes the full box
+        expect(segmentHitsRectangle(onTopEdge[0], onTopEdge[1], shrinkRectangle(box))).toBe(false); // clears the shrunk box
     });
 });
 

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.test.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.test.ts
@@ -1,0 +1,253 @@
+import {
+    buildAnchorMeta,
+    countObstacleHits,
+    faceMidpoint,
+    findBestAnchor,
+    flattenPoints,
+    rectOf,
+    routeLength,
+    segHitsRect,
+    shrinkRectangle,
+    simplifyPolyline,
+    stepDirection,
+} from "./shared.ts";
+import { createSystemComponent, createPointOfAttack } from "#test-utils/builders.ts";
+import { AnchorOrientation } from "#api/types/system.types.ts";
+
+describe("rectOf", () => {
+    it("converts a component's grid position to its 80x80 pixel box (gridX*5 top-left)", () => {
+        expect(rectOf(createSystemComponent({ gridX: 10, gridY: 20 }))).toEqual({
+            minX: 50,
+            minY: 100,
+            maxX: 130,
+            maxY: 180,
+        });
+    });
+
+    it("places a component at the origin spanning one box size", () => {
+        expect(rectOf(createSystemComponent({ gridX: 0, gridY: 0 }))).toEqual({ minX: 0, minY: 0, maxX: 80, maxY: 80 });
+    });
+});
+
+describe("faceMidpoint", () => {
+    const component = createSystemComponent({ gridX: 10, gridY: 20 }); // box 50..130 x 100..180, centre (90,140)
+
+    it("returns the middle of each requested edge", () => {
+        expect(faceMidpoint(component, AnchorOrientation.left)).toEqual({ x: 50, y: 140 });
+        expect(faceMidpoint(component, AnchorOrientation.right)).toEqual({ x: 130, y: 140 });
+        expect(faceMidpoint(component, AnchorOrientation.top)).toEqual({ x: 90, y: 100 });
+        expect(faceMidpoint(component, AnchorOrientation.bottom)).toEqual({ x: 90, y: 180 });
+    });
+});
+
+describe("findBestAnchor", () => {
+    const base = createSystemComponent({ gridX: 0, gridY: 0 });
+
+    it("picks the right anchor when the other component is mostly to the right", () => {
+        expect(findBestAnchor(base, createSystemComponent({ gridX: 50, gridY: 0 }))).toBe(AnchorOrientation.right);
+    });
+
+    it("picks the left anchor when the other component is mostly to the left", () => {
+        expect(findBestAnchor(base, createSystemComponent({ gridX: -50, gridY: 0 }))).toBe(AnchorOrientation.left);
+    });
+
+    it("picks the bottom anchor when the other component is mostly below", () => {
+        expect(findBestAnchor(base, createSystemComponent({ gridX: 0, gridY: 50 }))).toBe(AnchorOrientation.bottom);
+    });
+
+    it("picks the top anchor when the other component is mostly above", () => {
+        expect(findBestAnchor(base, createSystemComponent({ gridX: 0, gridY: -50 }))).toBe(AnchorOrientation.top);
+    });
+
+    it("breaks an equal horizontal/vertical offset in favour of the vertical axis", () => {
+        expect(findBestAnchor(base, createSystemComponent({ gridX: 50, gridY: 50 }))).toBe(AnchorOrientation.bottom);
+    });
+});
+
+describe("simplifyPolyline", () => {
+    it("collapses a straight run to its endpoints", () => {
+        const simplified = simplifyPolyline([
+            { x: 0, y: 0 },
+            { x: 10, y: 0 },
+            { x: 20, y: 0 },
+        ]);
+
+        expect(simplified).toEqual([
+            { x: 0, y: 0 },
+            { x: 20, y: 0 },
+        ]);
+    });
+
+    it("keeps the corner of an L-shaped path", () => {
+        const simplified = simplifyPolyline([
+            { x: 0, y: 0 },
+            { x: 10, y: 0 },
+            { x: 10, y: 10 },
+        ]);
+
+        expect(simplified).toEqual([
+            { x: 0, y: 0 },
+            { x: 10, y: 0 },
+            { x: 10, y: 10 },
+        ]);
+    });
+
+    it("drops consecutive duplicate points", () => {
+        const simplified = simplifyPolyline([
+            { x: 0, y: 0 },
+            { x: 0, y: 0 },
+            { x: 10, y: 0 },
+        ]);
+
+        expect(simplified).toEqual([
+            { x: 0, y: 0 },
+            { x: 10, y: 0 },
+        ]);
+    });
+});
+
+describe("segHitsRect", () => {
+    const rectangle = { minX: 100, minY: 100, maxX: 200, maxY: 200 };
+
+    it("detects a segment crossing the rectangle", () => {
+        expect(segHitsRect({ x: 50, y: 150 }, { x: 250, y: 150 }, rectangle)).toBe(true);
+    });
+
+    it("ignores a segment that passes clear of the rectangle", () => {
+        expect(segHitsRect({ x: 50, y: 50 }, { x: 250, y: 50 }, rectangle)).toBe(false);
+    });
+
+    it("counts touching an edge as a hit", () => {
+        expect(segHitsRect({ x: 50, y: 100 }, { x: 250, y: 100 }, rectangle)).toBe(true);
+    });
+});
+
+describe("shrinkRectangle", () => {
+    const box = { minX: 100, minY: 100, maxX: 200, maxY: 200 };
+
+    it("pulls every edge inward", () => {
+        const shrunk = shrinkRectangle(box);
+        expect(shrunk.minX).toBeGreaterThan(box.minX);
+        expect(shrunk.minY).toBeGreaterThan(box.minY);
+        expect(shrunk.maxX).toBeLessThan(box.maxX);
+        expect(shrunk.maxY).toBeLessThan(box.maxY);
+    });
+
+    it("makes a line lying exactly on an edge no longer count as a hit", () => {
+        const onTopEdge: [{ x: number; y: number }, { x: number; y: number }] = [
+            { x: 50, y: 100 },
+            { x: 250, y: 100 },
+        ];
+        expect(segHitsRect(onTopEdge[0], onTopEdge[1], box)).toBe(true); // grazes the full box
+        expect(segHitsRect(onTopEdge[0], onTopEdge[1], shrinkRectangle(box))).toBe(false); // clears the shrunk box
+    });
+});
+
+describe("routeLength", () => {
+    it("sums the Manhattan length of every segment", () => {
+        expect(
+            routeLength([
+                { x: 0, y: 0 },
+                { x: 10, y: 0 },
+                { x: 10, y: 20 },
+            ])
+        ).toBe(30);
+    });
+
+    it("is zero for a single point", () => {
+        expect(routeLength([{ x: 5, y: 5 }])).toBe(0);
+    });
+});
+
+describe("countObstacleHits", () => {
+    const box = { minX: 100, minY: 100, maxX: 200, maxY: 200 };
+
+    it("counts a box the route runs through", () => {
+        expect(
+            countObstacleHits(
+                [
+                    { x: 50, y: 150 },
+                    { x: 250, y: 150 },
+                ],
+                [box]
+            )
+        ).toBe(1);
+    });
+
+    it("counts each box at most once even when several segments hit it", () => {
+        const inAndOut = [
+            { x: 150, y: 50 },
+            { x: 150, y: 250 }, // down through the box
+            { x: 160, y: 250 },
+            { x: 160, y: 50 }, // back up through the box
+        ];
+        expect(countObstacleHits(inAndOut, [box])).toBe(1);
+    });
+
+    it("returns zero when the route clears every box", () => {
+        expect(
+            countObstacleHits(
+                [
+                    { x: 0, y: 0 },
+                    { x: 300, y: 0 },
+                ],
+                [box]
+            )
+        ).toBe(0);
+    });
+});
+
+describe("stepDirection", () => {
+    it("reports the sign of travel on each axis", () => {
+        expect(stepDirection({ x: 0, y: 0 }, { x: 5, y: 0 })).toEqual({ x: 1, y: 0 });
+        expect(stepDirection({ x: 0, y: 0 }, { x: 0, y: -5 })).toEqual({ x: 0, y: -1 });
+        expect(stepDirection({ x: 5, y: 5 }, { x: 5, y: 5 })).toEqual({ x: 0, y: 0 });
+    });
+});
+
+describe("flattenPoints", () => {
+    it("turns points into the flat array Konva's Line expects", () => {
+        expect(
+            flattenPoints([
+                { x: 0, y: 0 },
+                { x: 10, y: 20 },
+                { x: 10, y: 50 },
+            ])
+        ).toEqual([0, 0, 10, 20, 10, 50]);
+    });
+});
+
+describe("buildAnchorMeta", () => {
+    const component = createSystemComponent({ gridX: 0, gridY: 0 }); // box 0..80, centre (40,40)
+
+    it("puts the connection point on the chosen face and reports a right approach as horizontal", () => {
+        const meta = buildAnchorMeta(component, AnchorOrientation.right, AnchorOrientation.center, null);
+        expect(meta.position).toEqual({ x: 80, y: 40 });
+        expect(meta.goesHorizontal).toBe(true);
+        expect(meta.goesLeft).toBe(false);
+        expect(meta.goesUp).toBe(false);
+    });
+
+    it("reports a top approach as vertical and upward", () => {
+        const meta = buildAnchorMeta(component, AnchorOrientation.top, AnchorOrientation.center, null);
+        expect(meta.position).toEqual({ x: 40, y: 0 });
+        expect(meta.goesHorizontal).toBe(false);
+        expect(meta.goesUp).toBe(true);
+    });
+
+    it("lets an explicit (non-centre) anchor drive the reported direction, keeping the routed face's position", () => {
+        const meta = buildAnchorMeta(component, AnchorOrientation.right, AnchorOrientation.left, null);
+        expect(meta.position).toEqual({ x: 80, y: 40 }); // still on the routed (right) face
+        expect(meta.goesLeft).toBe(true); // but direction follows the stored left anchor
+    });
+
+    it("passes the point of attack through", () => {
+        const meta = buildAnchorMeta(
+            component,
+            AnchorOrientation.right,
+            AnchorOrientation.center,
+            createPointOfAttack({ id: "poa-x" })
+        );
+        expect(meta.pointOfAttack?.id).toBe("poa-x");
+    });
+});

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -278,6 +278,49 @@ export const buildDegreeMap = (connections: AugmentedSystemConnection[]): Map<st
 
 // ----- shared scoring + connection-point meta -----
 
+/** Reads a flat [x, y, x, y, …] waypoint array back into points. */
+export const pointsFromWaypoints = (waypoints: number[]): Point[] => {
+    const points: Point[] = [];
+    for (let index = 0; index + 1 < waypoints.length; index += 2) {
+        points.push({ x: waypoints[index]!, y: waypoints[index + 1]! });
+    }
+    return points;
+};
+
+/**
+ * How many X-crossings a route makes with the lines of connections sharing no component with it.
+ * Lines touching the same hub/leaf are skipped — they merge into trunks on purpose.
+ */
+export const countUnrelatedLineCrossings = (
+    waypoints: number[],
+    input: Pick<ConnectionRoutingInput, "connections" | "from" | "to">
+): number => {
+    const ownEndpointIds = new Set([input.from.id, input.to.id]);
+    const ownPoints = pointsFromWaypoints(waypoints);
+    let crossings = 0;
+    for (const connection of input.connections) {
+        if (ownEndpointIds.has(connection.from.id) || ownEndpointIds.has(connection.to.id)) {
+            continue;
+        }
+        const otherPoints = pointsFromWaypoints(connection.waypoints);
+        for (let own = 1; own < ownPoints.length; own++) {
+            for (let other = 1; other < otherPoints.length; other++) {
+                if (
+                    crossesTransversally(
+                        ownPoints[own - 1]!,
+                        ownPoints[own]!,
+                        otherPoints[other - 1]!,
+                        otherPoints[other]!
+                    )
+                ) {
+                    crossings++;
+                }
+            }
+        }
+    }
+    return crossings;
+};
+
 /** How many of the given boxes a route's segments run into (each box counted at most once). */
 export const countObstacleHits = (points: Point[], obstacles: Rectangle[]): number => {
     let hits = 0;

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -50,7 +50,7 @@ export interface ConnectionRoutingResult {
 // ----- geometry helpers (pure) -----
 
 /** Pixel-space bounding box of a component's fixed 80x80 footprint. */
-export const rectOf = (component: AugmentedSystemComponent): Rectangle => {
+export const rectangleOf = (component: AugmentedSystemComponent): Rectangle => {
     const minX = component.gridX * 5;
     const minY = component.gridY * 5;
     return { minX, minY, maxX: minX + COMPONENT_SIZE, maxY: minY + COMPONENT_SIZE };
@@ -64,7 +64,7 @@ export const centerOf = (component: AugmentedSystemComponent): Point => ({
 
 /** The pixel point at the middle of one of a component's four edges — where a connection attaches. */
 export const faceMidpoint = (component: AugmentedSystemComponent, face: Face): Point => {
-    const rectangle = rectOf(component);
+    const rectangle = rectangleOf(component);
     const center = centerOf(component);
     switch (face) {
         case AnchorOrientation.left:
@@ -109,16 +109,16 @@ export const isHorizontalFace = (face: Face): boolean =>
 const isFace = (anchor: AnchorOrientation): anchor is Face => anchor !== AnchorOrientation.center;
 
 /** True when a horizontal/vertical line touches a box — the check for "does this connection cross a component". */
-export const segHitsRect = (a: Point, b: Point, rectangle: Rectangle): boolean => {
-    const segMinX = Math.min(a.x, b.x);
-    const segMaxX = Math.max(a.x, b.x);
-    const segMinY = Math.min(a.y, b.y);
-    const segMaxY = Math.max(a.y, b.y);
+export const segmentHitsRectangle = (start: Point, end: Point, rectangle: Rectangle): boolean => {
+    const segmentMinX = Math.min(start.x, end.x);
+    const segmentMaxX = Math.max(start.x, end.x);
+    const segmentMinY = Math.min(start.y, end.y);
+    const segmentMaxY = Math.max(start.y, end.y);
     return !(
-        segMinX > rectangle.maxX ||
-        segMaxX < rectangle.minX ||
-        segMinY > rectangle.maxY ||
-        segMaxY < rectangle.minY
+        segmentMinX > rectangle.maxX ||
+        segmentMaxX < rectangle.minX ||
+        segmentMinY > rectangle.maxY ||
+        segmentMaxY < rectangle.minY
     );
 };
 
@@ -127,20 +127,25 @@ export const segHitsRect = (a: Point, b: Point, rectangle: Rectangle): boolean =
  * Segments that merely touch at an end (a shared box, a T-junction) or run parallel don't count, so two
  * lines meeting at the same component aren't mistaken for a crossing.
  */
-export const crossesTransversally = (a: Point, b: Point, c: Point, d: Point): boolean => {
-    const firstHorizontal = a.y === b.y && a.x !== b.x;
-    const firstVertical = a.x === b.x && a.y !== b.y;
-    const secondHorizontal = c.y === d.y && c.x !== d.x;
-    const secondVertical = c.x === d.x && c.y !== d.y;
+export const crossesTransversally = (
+    firstStart: Point,
+    firstEnd: Point,
+    secondStart: Point,
+    secondEnd: Point
+): boolean => {
+    const firstHorizontal = firstStart.y === firstEnd.y && firstStart.x !== firstEnd.x;
+    const firstVertical = firstStart.x === firstEnd.x && firstStart.y !== firstEnd.y;
+    const secondHorizontal = secondStart.y === secondEnd.y && secondStart.x !== secondEnd.x;
+    const secondVertical = secondStart.x === secondEnd.x && secondStart.y !== secondEnd.y;
 
     let horizontalStart: Point;
     let horizontalEnd: Point;
     let verticalStart: Point;
     let verticalEnd: Point;
     if (firstHorizontal && secondVertical) {
-        [horizontalStart, horizontalEnd, verticalStart, verticalEnd] = [a, b, c, d];
+        [horizontalStart, horizontalEnd, verticalStart, verticalEnd] = [firstStart, firstEnd, secondStart, secondEnd];
     } else if (firstVertical && secondHorizontal) {
-        [horizontalStart, horizontalEnd, verticalStart, verticalEnd] = [c, d, a, b];
+        [horizontalStart, horizontalEnd, verticalStart, verticalEnd] = [secondStart, secondEnd, firstStart, firstEnd];
     } else {
         return false; // parallel, or not both axis-aligned
     }
@@ -298,7 +303,7 @@ export const countObstacleHits = (points: Point[], obstacles: Rectangle[]): numb
         for (let index = 1; index < points.length; index++) {
             const previous = points[index - 1];
             const current = points[index];
-            if (previous && current && segHitsRect(previous, current, obstacle)) {
+            if (previous && current && segmentHitsRectangle(previous, current, obstacle)) {
                 hits++;
                 break;
             }
@@ -384,7 +389,7 @@ export const buildRouteScoringContext = (input: ConnectionRoutingInput): RouteSc
     const { connectionId, fromComponent, toComponent, components, connections, from, to } = input;
     const obstacles = components
         .filter((component) => component.id !== fromComponent.id && component.id !== toComponent.id)
-        .map(rectOf);
+        .map(rectangleOf);
 
     const otherSegments: Segment[] = [];
     const unrelatedSegments: Segment[] = [];

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -32,7 +32,7 @@ export interface Rectangle {
 }
 
 export interface ConnectionRoutingInput {
-    connectionId?: string;
+    connectionId: string;
     fromComponent: AugmentedSystemComponent;
     toComponent: AugmentedSystemComponent;
     components: AugmentedSystemComponent[];
@@ -395,13 +395,12 @@ export const buildRouteScoringContext = (input: ConnectionRoutingInput): RouteSc
     const unrelatedSegments: Segment[] = [];
     const ownEndpointIds = new Set([from.id, to.id]);
     for (const connection of connections) {
+        if (connection.id === connectionId) {
+            continue;
+        }
         const isSamePair =
             (connection.from.id === from.id && connection.to.id === to.id) ||
             (connection.from.id === to.id && connection.to.id === from.id);
-        const isThisConnection = connectionId !== undefined ? connection.id === connectionId : isSamePair;
-        if (isThisConnection) {
-            continue;
-        }
         const sharesEndpoint =
             !isSamePair && (ownEndpointIds.has(connection.from.id) || ownEndpointIds.has(connection.to.id));
         for (const segment of segmentsOfPoints(pointsFromWaypoints(connection.waypoints))) {

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -226,6 +226,25 @@ export const findBestAnchor = (
     return dy > 0 ? AnchorOrientation.bottom : AnchorOrientation.top;
 };
 
+// ----- connection topology -----
+
+/** Counts how many connections touch each component (its "degree") — used to tell a hub from a leaf. */
+export const buildDegreeMap = (connections: AugmentedSystemConnection[]): Map<string, number> => {
+    const counted = new Set<string>();
+    const degree = new Map<string, number>();
+    for (const connection of connections) {
+        if (counted.has(connection.id)) {
+            continue;
+        }
+        counted.add(connection.id);
+        degree.set(connection.from.id, (degree.get(connection.from.id) ?? 0) + 1);
+        if (connection.to.id !== connection.from.id) {
+            degree.set(connection.to.id, (degree.get(connection.to.id) ?? 0) + 1);
+        }
+    }
+    return degree;
+};
+
 // ----- shared scoring + connection-point meta -----
 
 /** How many of the given boxes a route's segments run into (each box counted at most once). */

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -1,0 +1,262 @@
+/**
+ * Shared geometry and helpers for connection routing — used by both routers (the fishbone one and the
+ * deterministic one). Plain functions only (no React/Konva/Redux), so everything here is unit-testable.
+ *
+ * Coordinates: a component is a fixed 80x80 px box with its top-left at (gridX*5, gridY*5). Waypoints
+ * live in the same pixel space Konva draws in.
+ */
+import {
+    AnchorOrientation,
+    type AugmentedSystemComponent,
+    type ConnectionPointMeta,
+    type PointOfAttack,
+} from "#api/types/system.types.ts";
+import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
+
+const COMPONENT_SIZE = 80; // a component box is always 80 px square
+const HALF_COMPONENT_SIZE = COMPONENT_SIZE / 2;
+export const GEOMETRY_TOLERANCE = 1e-6; // coordinates closer than this count as equal (absorbs float rounding)
+
+export type Face = AnchorOrientation.left | AnchorOrientation.right | AnchorOrientation.top | AnchorOrientation.bottom;
+
+export interface Point {
+    x: number;
+    y: number;
+}
+
+export interface Rectangle {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+}
+
+export interface ConnectionRoutingInput {
+    fromComponent: AugmentedSystemComponent;
+    toComponent: AugmentedSystemComponent;
+    components: AugmentedSystemComponent[];
+    connections: AugmentedSystemConnection[];
+    from: AugmentedSystemConnection["from"];
+    to: AugmentedSystemConnection["to"];
+    pointsOfAttack: PointOfAttack[];
+}
+
+export interface ConnectionRoutingResult {
+    waypoints: number[];
+    connectionPointsMeta: ConnectionPointMeta[];
+}
+
+// ----- geometry helpers (pure) -----
+
+/** Pixel-space bounding box of a component's fixed 80x80 footprint. */
+export const rectOf = (component: AugmentedSystemComponent): Rectangle => {
+    const minX = component.gridX * 5;
+    const minY = component.gridY * 5;
+    return { minX, minY, maxX: minX + COMPONENT_SIZE, maxY: minY + COMPONENT_SIZE };
+};
+
+/** The pixel coordinate of a component's centre. */
+export const centerOf = (component: AugmentedSystemComponent): Point => ({
+    x: component.gridX * 5 + HALF_COMPONENT_SIZE,
+    y: component.gridY * 5 + HALF_COMPONENT_SIZE,
+});
+
+/** The pixel point at the middle of one of a component's four edges — where a connection attaches. */
+export const faceMidpoint = (component: AugmentedSystemComponent, face: Face): Point => {
+    const rectangle = rectOf(component);
+    const center = centerOf(component);
+    switch (face) {
+        case AnchorOrientation.left:
+            return { x: rectangle.minX, y: center.y };
+        case AnchorOrientation.right:
+            return { x: rectangle.maxX, y: center.y };
+        case AnchorOrientation.top:
+            return { x: center.x, y: rectangle.minY };
+        case AnchorOrientation.bottom:
+            return { x: center.x, y: rectangle.maxY };
+    }
+};
+
+/** A unit arrow pointing straight out of a face (right → {x:1,y:0}, top → {x:0,y:-1}). */
+export const outwardUnit = (face: Face): Point => {
+    switch (face) {
+        case AnchorOrientation.left:
+            return { x: -1, y: 0 };
+        case AnchorOrientation.right:
+            return { x: 1, y: 0 };
+        case AnchorOrientation.top:
+            return { x: 0, y: -1 };
+        case AnchorOrientation.bottom:
+            return { x: 0, y: 1 };
+    }
+};
+
+/** Which way travel goes from one point to the next: -1, 0, or 1 on each axis. */
+export const stepDirection = (from: Point, to: Point): Point => ({
+    x: Math.sign(to.x - from.x),
+    y: Math.sign(to.y - from.y),
+});
+
+/** True when two direction arrows point exactly the same way. */
+export const sameDirection = (a: Point, b: Point): boolean => a.x === b.x && a.y === b.y;
+
+/** True for the left and right faces (their connections run horizontally). */
+export const isHorizontalFace = (face: Face): boolean =>
+    face === AnchorOrientation.left || face === AnchorOrientation.right;
+
+/** True when an anchor is a real edge (left/right/top/bottom), not the centre. */
+const isFace = (anchor: AnchorOrientation): anchor is Face => anchor !== AnchorOrientation.center;
+
+/** True when a horizontal/vertical line touches a box — the check for "does this connection cross a component". */
+export const segHitsRect = (a: Point, b: Point, rectangle: Rectangle): boolean => {
+    const segMinX = Math.min(a.x, b.x);
+    const segMaxX = Math.max(a.x, b.x);
+    const segMinY = Math.min(a.y, b.y);
+    const segMaxY = Math.max(a.y, b.y);
+    return !(
+        segMinX > rectangle.maxX ||
+        segMaxX < rectangle.minX ||
+        segMinY > rectangle.maxY ||
+        segMaxY < rectangle.minY
+    );
+};
+
+/** Removes duplicate points and points sitting in the middle of a straight line — keeps only real corners. */
+export const simplifyPolyline = (points: Point[]): Point[] => {
+    const deduped: Point[] = [];
+    for (const point of points) {
+        const last = deduped[deduped.length - 1];
+        if (
+            !last ||
+            Math.abs(last.x - point.x) > GEOMETRY_TOLERANCE ||
+            Math.abs(last.y - point.y) > GEOMETRY_TOLERANCE
+        ) {
+            deduped.push(point);
+        }
+    }
+
+    const simplified: Point[] = [];
+    for (let index = 0; index < deduped.length; index++) {
+        const current = deduped[index];
+        const previous = simplified[simplified.length - 1];
+        const next = deduped[index + 1];
+        if (current && previous && next) {
+            const collinearVertical =
+                Math.abs(previous.x - current.x) < GEOMETRY_TOLERANCE &&
+                Math.abs(current.x - next.x) < GEOMETRY_TOLERANCE;
+            const collinearHorizontal =
+                Math.abs(previous.y - current.y) < GEOMETRY_TOLERANCE &&
+                Math.abs(current.y - next.y) < GEOMETRY_TOLERANCE;
+            if (collinearVertical || collinearHorizontal) {
+                continue;
+            }
+        }
+        if (current) {
+            simplified.push(current);
+        }
+    }
+    return simplified;
+};
+
+/** True when every segment runs purely horizontal or vertical — no diagonal. */
+export const isOrthogonal = (points: Point[]): boolean => {
+    for (let index = 1; index < points.length; index++) {
+        const previous = points[index - 1];
+        const current = points[index];
+        if (!previous || !current) {
+            return false;
+        }
+        if (
+            Math.abs(previous.x - current.x) > GEOMETRY_TOLERANCE &&
+            Math.abs(previous.y - current.y) > GEOMETRY_TOLERANCE
+        ) {
+            return false;
+        }
+    }
+    return true;
+};
+
+/** True when every coordinate is a real number (no NaN or Infinity). */
+export const allFinite = (points: Point[]): boolean =>
+    points.every((point) => Number.isFinite(point.x) && Number.isFinite(point.y));
+
+/** Total length of the route in pixels (sum of all its segments). */
+export const routeLength = (points: Point[]): number => {
+    let total = 0;
+    for (let index = 1; index < points.length; index++) {
+        const previous = points[index - 1];
+        const current = points[index];
+        if (previous && current) {
+            total += Math.abs(current.x - previous.x) + Math.abs(current.y - previous.y);
+        }
+    }
+    return total;
+};
+
+/** Turns [{x,y}, …] into the flat [x, y, x, y, …] array Konva's <Line> expects. */
+export const flattenPoints = (points: Point[]): number[] => {
+    const result: number[] = [];
+    for (const point of points) {
+        result.push(point.x, point.y);
+    }
+    return result;
+};
+
+/** A copy of the box pulled in by a hair, so a line grazing an edge isn't counted as crossing the interior. */
+export const shrinkRectangle = (rectangle: Rectangle): Rectangle => ({
+    minX: rectangle.minX + GEOMETRY_TOLERANCE,
+    minY: rectangle.minY + GEOMETRY_TOLERANCE,
+    maxX: rectangle.maxX - GEOMETRY_TOLERANCE,
+    maxY: rectangle.maxY - GEOMETRY_TOLERANCE,
+});
+
+// ----- face selection -----
+
+/** Which face of a box points most directly at another box (left/right if it's more sideways, else top/bottom). */
+export const findBestAnchor = (
+    component: AugmentedSystemComponent,
+    otherComponent: AugmentedSystemComponent
+): AnchorOrientation => {
+    const dx = otherComponent.gridX - component.gridX;
+    const dy = otherComponent.gridY - component.gridY;
+
+    if (Math.abs(dx) > Math.abs(dy)) {
+        return dx > 0 ? AnchorOrientation.right : AnchorOrientation.left;
+    }
+    return dy > 0 ? AnchorOrientation.bottom : AnchorOrientation.top;
+};
+
+// ----- shared scoring + connection-point meta -----
+
+/** How many of the given boxes a route's segments run into (each box counted at most once). */
+export const countObstacleHits = (points: Point[], obstacles: Rectangle[]): number => {
+    let hits = 0;
+    for (const obstacle of obstacles) {
+        for (let index = 1; index < points.length; index++) {
+            const previous = points[index - 1];
+            const current = points[index];
+            if (previous && current && segHitsRect(previous, current, obstacle)) {
+                hits++;
+                break;
+            }
+        }
+    }
+    return hits;
+};
+
+/** Builds the connection-point info for one end: where it sits and which way it leaves the box. */
+export const buildAnchorMeta = (
+    component: AugmentedSystemComponent,
+    face: Face,
+    anchor: AnchorOrientation,
+    pointOfAttack: PointOfAttack | null
+): ConnectionPointMeta => {
+    const reportedAnchor = isFace(anchor) ? anchor : face;
+    return {
+        position: faceMidpoint(component, face),
+        goesHorizontal: reportedAnchor === AnchorOrientation.left || reportedAnchor === AnchorOrientation.right,
+        goesLeft: reportedAnchor === AnchorOrientation.left,
+        goesUp: reportedAnchor === AnchorOrientation.top,
+        pointOfAttack,
+    };
+};

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -121,6 +121,37 @@ export const segHitsRect = (a: Point, b: Point, rectangle: Rectangle): boolean =
     );
 };
 
+/**
+ * True when one horizontal and one vertical segment cross at a point strictly inside BOTH — a real X.
+ * Segments that merely touch at an end (a shared box, a T-junction) or run parallel don't count, so two
+ * lines meeting at the same component aren't mistaken for a crossing.
+ */
+export const crossesTransversally = (a: Point, b: Point, c: Point, d: Point): boolean => {
+    const firstHorizontal = a.y === b.y && a.x !== b.x;
+    const firstVertical = a.x === b.x && a.y !== b.y;
+    const secondHorizontal = c.y === d.y && c.x !== d.x;
+    const secondVertical = c.x === d.x && c.y !== d.y;
+
+    let horizontalStart: Point;
+    let horizontalEnd: Point;
+    let verticalStart: Point;
+    let verticalEnd: Point;
+    if (firstHorizontal && secondVertical) {
+        [horizontalStart, horizontalEnd, verticalStart, verticalEnd] = [a, b, c, d];
+    } else if (firstVertical && secondHorizontal) {
+        [horizontalStart, horizontalEnd, verticalStart, verticalEnd] = [c, d, a, b];
+    } else {
+        return false; // parallel, or not both axis-aligned
+    }
+
+    const strictlyBetween = (value: number, bound1: number, bound2: number): boolean =>
+        value > Math.min(bound1, bound2) && value < Math.max(bound1, bound2);
+    return (
+        strictlyBetween(verticalStart.x, horizontalStart.x, horizontalEnd.x) &&
+        strictlyBetween(horizontalStart.y, verticalStart.y, verticalEnd.y)
+    );
+};
+
 /** Removes duplicate points and points sitting in the middle of a straight line — keeps only real corners. */
 export const simplifyPolyline = (points: Point[]): Point[] => {
     const deduped: Point[] = [];

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -278,6 +278,9 @@ export const buildDegreeMap = (connections: AugmentedSystemConnection[]): Map<st
 
 // ----- shared scoring + connection-point meta -----
 
+/** A drawable line needs at least two points (four values). Tolerates legacy data without the field. */
+export const hasDrawableLine = (waypoints: number[] | undefined): boolean => (waypoints?.length ?? 0) >= 4;
+
 /** Reads a flat [x, y, x, y, …] waypoint array back into points. */
 export const pointsFromWaypoints = (waypoints: number[]): Point[] => {
     const points: Point[] = [];

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -291,40 +291,6 @@ export const pointsFromWaypoints = (waypoints: number[]): Point[] => {
     return points;
 };
 
-/**
- * How many X-crossings a route makes with the lines of connections sharing no component with it.
- * Lines touching the same hub/leaf are skipped — they merge into trunks on purpose.
- */
-export const countUnrelatedLineCrossings = (
-    waypoints: number[],
-    input: Pick<ConnectionRoutingInput, "connections" | "from" | "to">
-): number => {
-    const ownEndpointIds = new Set([input.from.id, input.to.id]);
-    const ownPoints = pointsFromWaypoints(waypoints);
-    let crossings = 0;
-    for (const connection of input.connections) {
-        if (ownEndpointIds.has(connection.from.id) || ownEndpointIds.has(connection.to.id)) {
-            continue;
-        }
-        const otherPoints = pointsFromWaypoints(connection.waypoints);
-        for (let own = 1; own < ownPoints.length; own++) {
-            for (let other = 1; other < otherPoints.length; other++) {
-                if (
-                    crossesTransversally(
-                        ownPoints[own - 1]!,
-                        ownPoints[own]!,
-                        otherPoints[other - 1]!,
-                        otherPoints[other]!
-                    )
-                ) {
-                    crossings++;
-                }
-            }
-        }
-    }
-    return crossings;
-};
-
 /** How many of the given boxes a route's segments run into (each box counted at most once). */
 export const countObstacleHits = (points: Point[], obstacles: Rectangle[]): number => {
     let hits = 0;
@@ -340,6 +306,127 @@ export const countObstacleHits = (points: Point[], obstacles: Rectangle[]): numb
     }
     return hits;
 };
+
+// ----- route defect scoring — one policy for both routers and the arbitration between them -----
+
+export interface Segment {
+    start: Point;
+    end: Point;
+}
+
+/** The straight segments of a polyline. */
+export const segmentsOfPoints = (points: Point[]): Segment[] => {
+    const segments: Segment[] = [];
+    for (let index = 1; index < points.length; index++) {
+        segments.push({ start: points[index - 1]!, end: points[index]! });
+    }
+    return segments;
+};
+
+/** How many of the other connections' segments this route crosses. */
+export const countLineCrossings = (points: Point[], otherSegments: Segment[]): number => {
+    let crossings = 0;
+    for (const routeSegment of segmentsOfPoints(points)) {
+        for (const otherSegment of otherSegments) {
+            if (crossesTransversally(routeSegment.start, routeSegment.end, otherSegment.start, otherSegment.end)) {
+                crossings++;
+            }
+        }
+    }
+    return crossings;
+};
+
+/** How far two 1-D ranges overlap (0 when they don't touch). */
+const rangeOverlap = (start1: number, end1: number, start2: number, end2: number): number =>
+    Math.max(
+        0,
+        Math.min(Math.max(start1, end1), Math.max(start2, end2)) -
+            Math.max(Math.min(start1, end1), Math.min(start2, end2))
+    );
+
+/** The length two parallel collinear segments run on top of each other (0 when they don't). */
+const collinearOverlap = (a: Point, b: Point, c: Point, d: Point): number => {
+    const bothVerticalOnSameX = a.x === b.x && c.x === d.x && a.x === c.x;
+    if (bothVerticalOnSameX) {
+        return rangeOverlap(a.y, b.y, c.y, d.y);
+    }
+    const bothHorizontalOnSameY = a.y === b.y && c.y === d.y && a.y === c.y;
+    if (bothHorizontalOnSameY) {
+        return rangeOverlap(a.x, b.x, c.x, d.x);
+    }
+    return 0;
+};
+
+/** How many pixels of this route lie on top of unrelated lines — on canvas that reads as a false merge. */
+export const countUnrelatedOverlap = (points: Point[], unrelatedSegments: Segment[]): number => {
+    let overlap = 0;
+    for (const routeSegment of segmentsOfPoints(points)) {
+        for (const otherSegment of unrelatedSegments) {
+            overlap += collinearOverlap(routeSegment.start, routeSegment.end, otherSegment.start, otherSegment.end);
+        }
+    }
+    return overlap;
+};
+
+export interface RouteScoringContext {
+    obstacles: Rectangle[];
+    otherSegments: Segment[];
+    unrelatedSegments: Segment[];
+}
+
+/**
+ * Collects what a route is scored against: obstacle boxes (every component but its own endpoints),
+ * all other lines (for crossings), and the unrelated subset (for overlap). Lines into a shared
+ * component are left out of the overlap set — they merge into trunks on purpose — but a second
+ * connection between the same pair is kept in, so two of them don't fuse into one line.
+ */
+export const buildRouteScoringContext = (input: ConnectionRoutingInput): RouteScoringContext => {
+    const { connectionId, fromComponent, toComponent, components, connections, from, to } = input;
+    const obstacles = components
+        .filter((component) => component.id !== fromComponent.id && component.id !== toComponent.id)
+        .map(rectOf);
+
+    const otherSegments: Segment[] = [];
+    const unrelatedSegments: Segment[] = [];
+    const ownEndpointIds = new Set([from.id, to.id]);
+    for (const connection of connections) {
+        const isSamePair =
+            (connection.from.id === from.id && connection.to.id === to.id) ||
+            (connection.from.id === to.id && connection.to.id === from.id);
+        const isThisConnection = connectionId !== undefined ? connection.id === connectionId : isSamePair;
+        if (isThisConnection) {
+            continue;
+        }
+        const sharesEndpoint =
+            !isSamePair && (ownEndpointIds.has(connection.from.id) || ownEndpointIds.has(connection.to.id));
+        for (const segment of segmentsOfPoints(pointsFromWaypoints(connection.waypoints))) {
+            otherSegments.push(segment);
+            if (!sharesEndpoint) {
+                unrelatedSegments.push(segment);
+            }
+        }
+    }
+    return { obstacles, otherSegments, unrelatedSegments };
+};
+
+/** What makes a route objectively bad, independent of style: boxes hit, lines crossed, false merges. */
+export interface RouteDefects {
+    obstacleHits: number;
+    crossings: number;
+    overlapLength: number;
+}
+
+export const countRouteDefects = (points: Point[], context: RouteScoringContext): RouteDefects => ({
+    obstacleHits: countObstacleHits(points, context.obstacles),
+    crossings: countLineCrossings(points, context.otherSegments),
+    overlapLength: countUnrelatedOverlap(points, context.unrelatedSegments),
+});
+
+/** Negative when the candidate is objectively better: boxes avoided > fewer crossings > less overlap. */
+export const compareRouteDefects = (candidate: RouteDefects, best: RouteDefects): number =>
+    candidate.obstacleHits - best.obstacleHits ||
+    candidate.crossings - best.crossings ||
+    candidate.overlapLength - best.overlapLength;
 
 /** Builds the connection-point info for one end: where it sits and which way it leaves the box. */
 export const buildAnchorMeta = (

--- a/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
+++ b/apps/frontend/src/view/components/editor-components/connection-routing/shared.ts
@@ -32,6 +32,7 @@ export interface Rectangle {
 }
 
 export interface ConnectionRoutingInput {
+    connectionId?: string;
     fromComponent: AugmentedSystemComponent;
     toComponent: AugmentedSystemComponent;
     components: AugmentedSystemComponent[];

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
@@ -25,6 +25,7 @@ const defaultProps = {
     recalculate: false,
     waypoints: [100, 100, 300, 300],
     components: [],
+    connections: [],
     onClick: vi.fn(),
     onPointOfAttackClicked: vi.fn(),
     selected: false,

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
 import { POA_COLORS } from "#view/colors/pointsOfAttack.colors.ts";
 import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
-import { createSystemComponent, createConnectionAnchor } from "#test-utils/builders.ts";
+import { createConnectionAnchor } from "#test-utils/builders.ts";
 import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import editorReducer from "#application/reducers/editor.reducer.ts";
 import { SystemComponentConnection } from "./system-component-connection.component";
@@ -24,12 +24,9 @@ const defaultProps = {
     projectId: 1,
     recalculate: false,
     waypoints: [100, 100, 300, 300],
-    components: [],
-    connections: [],
     onClick: vi.fn(),
     onPointOfAttackClicked: vi.fn(),
     selected: false,
-    onRecalculated: vi.fn(),
     stageRef: { current: null },
     pointsOfAttack: [],
     communicationInterface: null,
@@ -43,8 +40,6 @@ describe("SystemComponentConnection", () => {
                     {...defaultProps}
                     from={connectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
                     to={connectionAnchor({ id: "comp-2" })}
-                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
-                    toComponent={createSystemComponent({ id: "comp-2" })}
                 />
             );
 
@@ -58,8 +53,6 @@ describe("SystemComponentConnection", () => {
                     {...defaultProps}
                     from={connectionAnchor()}
                     to={connectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
-                    fromComponent={createSystemComponent()}
-                    toComponent={createSystemComponent({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.USERS })}
                 />
             );
 
@@ -73,8 +66,6 @@ describe("SystemComponentConnection", () => {
                     {...defaultProps}
                     from={connectionAnchor({ type: STANDARD_COMPONENT_TYPES.SERVER })}
                     to={connectionAnchor({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
-                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.SERVER })}
-                    toComponent={createSystemComponent({ id: "comp-2", type: STANDARD_COMPONENT_TYPES.DATABASE })}
                 />
             );
 
@@ -84,8 +75,10 @@ describe("SystemComponentConnection", () => {
                 POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE].normal
             );
         });
+    });
 
-        it("passes waypoints through to the Line when recalculate is false", () => {
+    describe("waypoint rendering", () => {
+        it("passes the stored waypoints through to the Line", () => {
             const waypoints = [50, 50, 200, 100, 350, 350];
 
             renderWithProviders(
@@ -94,8 +87,6 @@ describe("SystemComponentConnection", () => {
                     waypoints={waypoints}
                     from={connectionAnchor()}
                     to={connectionAnchor({ id: "comp-2" })}
-                    fromComponent={createSystemComponent()}
-                    toComponent={createSystemComponent({ id: "comp-2" })}
                 />
             );
 
@@ -104,6 +95,21 @@ describe("SystemComponentConnection", () => {
             expect(renderedPoints).toEqual(waypoints);
         });
 
+        it("renders nothing while the waypoints hold fewer than two points", () => {
+            renderWithProviders(
+                <SystemComponentConnection
+                    {...defaultProps}
+                    waypoints={[100, 100]}
+                    from={connectionAnchor()}
+                    to={connectionAnchor({ id: "comp-2" })}
+                />
+            );
+
+            expect(screen.queryByTestId("konva-line")).not.toBeInTheDocument();
+        });
+    });
+
+    describe("selection styling", () => {
         it("applies hover color when selected", () => {
             renderWithProviders(
                 <SystemComponentConnection
@@ -111,8 +117,6 @@ describe("SystemComponentConnection", () => {
                     selected={true}
                     from={connectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
                     to={connectionAnchor({ id: "comp-2" })}
-                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
-                    toComponent={createSystemComponent({ id: "comp-2" })}
                 />
             );
 
@@ -127,8 +131,6 @@ describe("SystemComponentConnection", () => {
                     selected={true}
                     from={connectionAnchor({ type: STANDARD_COMPONENT_TYPES.USERS })}
                     to={connectionAnchor({ id: "comp-2" })}
-                    fromComponent={createSystemComponent({ type: STANDARD_COMPONENT_TYPES.USERS })}
-                    toComponent={createSystemComponent({ id: "comp-2" })}
                 />,
                 { preloadedState: { editor: { ...defaultEditorState, isCapturing: true } } }
             );

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
@@ -4,12 +4,11 @@ import { POA_COLORS } from "#view/colors/pointsOfAttack.colors.ts";
 import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 import type { KonvaEventObject } from "konva/lib/Node";
 import type { Stage as KonvaStage } from "konva/lib/Stage";
-import type { AugmentedSystemComponent, ConnectionPointMeta } from "#api/types/system.types.ts";
 import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
 import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
 import { useAppSelector } from "#application/hooks/use-app-redux.hook.ts";
 import { editorSelectors } from "#application/selectors/editor.selectors.ts";
-import { computeConnectionRouting } from "./connection-routing/index.ts";
+import { hasDrawableLine } from "./connection-routing/index.ts";
 
 interface LineForPathProps {
     waypoints: number[];
@@ -23,16 +22,10 @@ interface LineForPathProps {
 }
 
 interface SystemComponentConnectionProps extends AugmentedSystemConnection {
-    fromComponent?: AugmentedSystemComponent;
-    toComponent?: AugmentedSystemComponent;
-    components: AugmentedSystemComponent[];
-    connections: AugmentedSystemConnection[];
     onClick: (event: KonvaEventObject<MouseEvent>, connectionId: string) => void;
     onPointOfAttackClicked: (event: KonvaEventObject<MouseEvent>, pointOfAttackId: string) => void;
     selected: boolean;
-    onRecalculated: (connectionId: string, waypoints: number[], connectionPointsMeta: ConnectionPointMeta[]) => void;
     stageRef: RefObject<KonvaStage | null>;
-    connectionPointsMeta: ConnectionPointMeta[];
     selectedConnectionPointId?: string | null;
     onConnectionPointClicked?: (event: KonvaEventObject<MouseEvent>, connectionPointId: string) => void;
 }
@@ -98,15 +91,9 @@ const SystemComponentConnectionInner = ({
     id,
     from,
     to,
-    fromComponent,
-    toComponent,
     onClick,
     onPointOfAttackClicked,
-    components,
-    connections = [],
     selected,
-    recalculate,
-    onRecalculated,
     pointsOfAttack = [],
     waypoints = [],
     stageRef,
@@ -121,10 +108,6 @@ const SystemComponentConnectionInner = ({
     const connectionColors = isUserConnection
         ? POA_COLORS[POINTS_OF_ATTACK.USER_BEHAVIOUR]
         : POA_COLORS[POINTS_OF_ATTACK.COMMUNICATION_INFRASTRUCTURE];
-
-    if (!fromComponent || !toComponent) {
-        return null;
-    }
 
     const handleClick = (event: KonvaEventObject<MouseEvent>) => {
         if (annotationTool !== null) {
@@ -162,41 +145,15 @@ const SystemComponentConnectionInner = ({
         }
     };
 
-    if (recalculate === false) {
-        return (
-            <Group x={0} y={0}>
-                <MemoizedLineForPath
-                    waypoints={waypoints}
-                    handleClick={handleClick}
-                    onMouseEnter={onMouseEnter}
-                    onMouseLeave={onMouseLeave}
-                    onPointOfAttackClicked={handleLinePointOfAttackClicked}
-                    selected={visualSelected}
-                    hover={visualHover}
-                    colors={connectionColors}
-                />
-            </Group>
-        );
+    // No routed line yet; use-editor.hook fills the waypoints in.
+    if (!hasDrawableLine(waypoints)) {
+        return null;
     }
 
-    const routing = computeConnectionRouting({
-        fromComponent,
-        toComponent,
-        components,
-        connections,
-        from,
-        to,
-        pointsOfAttack,
-    });
-    if (!routing) {
-        return <Group></Group>;
-    }
-
-    onRecalculated(id, routing.waypoints, routing.connectionPointsMeta);
     return (
         <Group x={0} y={0}>
             <MemoizedLineForPath
-                waypoints={routing.waypoints}
+                waypoints={waypoints}
                 handleClick={handleClick}
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
@@ -103,7 +103,7 @@ const SystemComponentConnectionInner = ({
     onClick,
     onPointOfAttackClicked,
     components,
-    connections,
+    connections = [],
     selected,
     recalculate,
     onRecalculated,

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
@@ -26,8 +26,6 @@ interface SystemComponentConnectionProps extends AugmentedSystemConnection {
     onPointOfAttackClicked: (event: KonvaEventObject<MouseEvent>, pointOfAttackId: string) => void;
     selected: boolean;
     stageRef: RefObject<KonvaStage | null>;
-    selectedConnectionPointId?: string | null;
-    onConnectionPointClicked?: (event: KonvaEventObject<MouseEvent>, connectionPointId: string) => void;
 }
 
 // LineForPath is a pure presentational component that handles the visual rendering of connections

--- a/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/system-component-connection.component.tsx
@@ -4,13 +4,12 @@ import { POA_COLORS } from "#view/colors/pointsOfAttack.colors.ts";
 import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 import type { KonvaEventObject } from "konva/lib/Node";
 import type { Stage as KonvaStage } from "konva/lib/Stage";
-import { AnchorOrientation, type AugmentedSystemComponent, type ConnectionPointMeta } from "#api/types/system.types.ts";
+import type { AugmentedSystemComponent, ConnectionPointMeta } from "#api/types/system.types.ts";
 import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
 import type { AugmentedSystemConnection } from "#application/selectors/system.selectors.ts";
 import { useAppSelector } from "#application/hooks/use-app-redux.hook.ts";
 import { editorSelectors } from "#application/selectors/editor.selectors.ts";
-
-const TURN_PENALTY = 200;
+import { computeConnectionRouting } from "./connection-routing/index.ts";
 
 interface LineForPathProps {
     waypoints: number[];
@@ -27,6 +26,7 @@ interface SystemComponentConnectionProps extends AugmentedSystemConnection {
     fromComponent?: AugmentedSystemComponent;
     toComponent?: AugmentedSystemComponent;
     components: AugmentedSystemComponent[];
+    connections: AugmentedSystemConnection[];
     onClick: (event: KonvaEventObject<MouseEvent>, connectionId: string) => void;
     onPointOfAttackClicked: (event: KonvaEventObject<MouseEvent>, pointOfAttackId: string) => void;
     selected: boolean;
@@ -35,19 +35,6 @@ interface SystemComponentConnectionProps extends AugmentedSystemConnection {
     connectionPointsMeta: ConnectionPointMeta[];
     selectedConnectionPointId?: string | null;
     onConnectionPointClicked?: (event: KonvaEventObject<MouseEvent>, connectionPointId: string) => void;
-}
-
-interface GridNode {
-    x: number;
-    y: number;
-    gCost: number;
-    hCost: number;
-    fCost: number;
-    walkCost: number;
-    parent: GridNode | null;
-    walkable: boolean;
-    gridX: number;
-    gridY: number;
 }
 
 // LineForPath is a pure presentational component that handles the visual rendering of connections
@@ -116,23 +103,19 @@ const SystemComponentConnectionInner = ({
     onClick,
     onPointOfAttackClicked,
     components,
+    connections,
     selected,
     recalculate,
     onRecalculated,
     pointsOfAttack = [],
     waypoints = [],
     stageRef,
-    connectionPointsMeta: initialConnectionPointsMeta = [],
 }: SystemComponentConnectionProps): JSX.Element | null => {
-    let connectionPointsMeta = initialConnectionPointsMeta;
     const [hover, setHover] = useState<boolean>(false);
     const isCapturing = useAppSelector((state) => state.editor.isCapturing);
     const annotationTool = useAppSelector(editorSelectors.selectAnnotationTool);
     const visualSelected = selected && !isCapturing;
     const visualHover = hover && !isCapturing;
-    let calculatedWaypoints = waypoints;
-    let fromAnchor = from;
-    let toAnchor = to;
 
     const isUserConnection = from.type === STANDARD_COMPONENT_TYPES.USERS || to.type === STANDARD_COMPONENT_TYPES.USERS;
     const connectionColors = isUserConnection
@@ -183,7 +166,7 @@ const SystemComponentConnectionInner = ({
         return (
             <Group x={0} y={0}>
                 <MemoizedLineForPath
-                    waypoints={calculatedWaypoints}
+                    waypoints={waypoints}
                     handleClick={handleClick}
                     onMouseEnter={onMouseEnter}
                     onMouseLeave={onMouseLeave}
@@ -196,122 +179,34 @@ const SystemComponentConnectionInner = ({
         );
     }
 
-    const gridOffset = 100;
-    const distance = {
-        x: Math.max(Math.abs(fromComponent.gridX - toComponent.gridX), 150), // min distance of 150 for x and y
-        y: Math.max(Math.abs(fromComponent.gridY - toComponent.gridY), 150), // so there is enough space for the algorithm to find a path
-    };
-    const gridSize = {
-        x: distance.x + gridOffset,
-        y: distance.y + gridOffset,
-    };
-
-    const begin = {
-        x:
-            Math.min(fromComponent.gridX, toComponent.gridX) +
-            Math.floor(Math.abs(fromComponent.gridX - toComponent.gridX) / 2) -
-            Math.floor(distance.x / 2) -
-            Math.floor(gridOffset / 2),
-        y:
-            Math.min(fromComponent.gridY, toComponent.gridY) +
-            Math.floor(Math.abs(fromComponent.gridY - toComponent.gridY) / 2) -
-            Math.floor(distance.y / 2) -
-            Math.floor(gridOffset / 2),
-    };
-
-    const startNodeGridPosition = calculateGridPositionForAnchor(fromComponent, 8, begin, toComponent);
-    const endNodeGridPosition = calculateGridPositionForAnchor(toComponent, 8, begin, fromComponent);
-
-    if (gridSize.x > 0 && gridSize.y > 0) {
-        let grid = createGridForAStar(components, begin, gridSize);
-        let pathFrom: GridNode[] = [];
-        let waypointsFrom: number[] = [];
-
-        // Add safety checks for grid positions
-        let startNode = grid[startNodeGridPosition.y]?.[startNodeGridPosition.x];
-        let endNode = grid[endNodeGridPosition.y]?.[endNodeGridPosition.x];
-
-        if (startNode && endNode) {
-            pathFrom = findPathOptimized(grid, startNode, endNode);
-            waypointsFrom = calculateWaypoints(pathFrom, fromAnchor.name + " -> " + toAnchor.name, toComponent);
-        } else {
-            // Handle case where start/end positions are invalid
-            console.warn("Invalid start/end positions for connection:", fromAnchor.name + " -> " + toAnchor.name);
-            waypointsFrom = calculateWaypoints([], fromAnchor.name + " -> " + toAnchor.name, toComponent);
-        }
-
-        grid = createGridForAStar(components, begin, gridSize);
-        let pathTo: GridNode[] = [];
-        let waypointsTo: number[] = [];
-
-        startNode = grid[startNodeGridPosition.y]?.[startNodeGridPosition.x];
-        endNode = grid[endNodeGridPosition.y]?.[endNodeGridPosition.x];
-
-        if (startNode && endNode) {
-            pathTo = findPathOptimized(grid, endNode, startNode);
-            waypointsTo = calculateWaypoints(pathTo, fromAnchor.name + " -> " + toAnchor.name, toAnchor);
-        }
-
-        let path = pathFrom;
-        if (path.length > 1) {
-            calculatedWaypoints = waypointsTo;
-            let startNode = path[0];
-            let endNode = path[path.length - 1];
-
-            if (waypointsFrom.length <= waypointsTo.length) {
-                path = pathFrom;
-                calculatedWaypoints = waypointsFrom;
-                startNode = path[path.length - 1];
-                endNode = path[0];
-
-                const tmp = fromAnchor;
-                fromAnchor = toAnchor;
-                toAnchor = tmp;
-            }
-
-            connectionPointsMeta = [
-                {
-                    position: calculateAbsolutePositionForAnchor(
-                        (startNode?.x ?? 0) * 5,
-                        (startNode?.y ?? 0) * 5,
-                        toAnchor.anchor
-                    ),
-                    goesHorizontal: toAnchor.anchor === "left" || toAnchor.anchor === "right",
-                    goesLeft: toAnchor.anchor === "left",
-                    goesUp: toAnchor.anchor === "top",
-                    pointOfAttack: pointsOfAttack[0] ?? null,
-                },
-                {
-                    position: calculateAbsolutePositionForAnchor(
-                        (endNode?.x ?? 0) * 5,
-                        (endNode?.y ?? 0) * 5,
-                        fromAnchor.anchor
-                    ),
-                    goesHorizontal: fromAnchor.anchor === "left" || fromAnchor.anchor === "right",
-                    goesLeft: fromAnchor.anchor === "left",
-                    goesUp: fromAnchor.anchor === "top",
-                    pointOfAttack: pointsOfAttack[1] ?? null,
-                },
-            ];
-
-            onRecalculated(id, calculatedWaypoints, connectionPointsMeta);
-            return (
-                <Group x={0} y={0}>
-                    <MemoizedLineForPath
-                        waypoints={calculatedWaypoints}
-                        handleClick={handleClick}
-                        onMouseEnter={onMouseEnter}
-                        onMouseLeave={onMouseLeave}
-                        onPointOfAttackClicked={handleLinePointOfAttackClicked}
-                        selected={visualSelected}
-                        hover={visualHover}
-                        colors={connectionColors}
-                    />
-                </Group>
-            );
-        }
+    const routing = computeConnectionRouting({
+        fromComponent,
+        toComponent,
+        components,
+        connections,
+        from,
+        to,
+        pointsOfAttack,
+    });
+    if (!routing) {
+        return <Group></Group>;
     }
-    return <Group></Group>;
+
+    onRecalculated(id, routing.waypoints, routing.connectionPointsMeta);
+    return (
+        <Group x={0} y={0}>
+            <MemoizedLineForPath
+                waypoints={routing.waypoints}
+                handleClick={handleClick}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                onPointOfAttackClicked={handleLinePointOfAttackClicked}
+                selected={visualSelected}
+                hover={visualHover}
+                colors={connectionColors}
+            />
+        </Group>
+    );
 };
 
 export const SystemComponentConnection = memo<SystemComponentConnectionProps>(
@@ -322,488 +217,3 @@ export const SystemComponentConnection = memo<SystemComponentConnectionProps>(
         prevProps.from === nextProps.from &&
         prevProps.to === nextProps.to
 );
-
-const calculateAbsolutePositionForAnchor = (x: number, y: number, anchor: AnchorOrientation) => {
-    const position = {
-        // start at mid of the component
-        x,
-        y,
-    };
-    switch (anchor) {
-        case "top":
-            position.y -= 5;
-            break;
-
-        case "left":
-            position.x -= 5;
-            break;
-
-        case "right":
-            position.x += 5;
-            break;
-
-        case "bottom":
-            position.y += 5;
-            break;
-    }
-    return position;
-};
-
-const calculateGridPositionForAnchor = (
-    component: AugmentedSystemComponent,
-    offset: number,
-    begin: { x: number; y: number },
-    otherComponent: AugmentedSystemComponent
-) => {
-    const position = {
-        // start at mid of the component
-        x: component.gridX - begin.x + 8,
-        y: component.gridY - begin.y + 8,
-    };
-
-    const resolvedAnchor = findBestAnchor(component, otherComponent);
-
-    switch (resolvedAnchor) {
-        case "top":
-            position.y -= offset;
-            break;
-
-        case "left":
-            position.x -= offset;
-            break;
-
-        case "right":
-            position.x += offset;
-            break;
-
-        case "bottom":
-            position.y += offset + 5;
-            break;
-    }
-    return position;
-};
-
-const findBestAnchor = (
-    component: AugmentedSystemComponent,
-    otherComponent: AugmentedSystemComponent
-): AnchorOrientation => {
-    const dx = otherComponent.gridX - component.gridX;
-    const dy = otherComponent.gridY - component.gridY;
-
-    if (Math.abs(dx) > Math.abs(dy)) {
-        return dx > 0 ? AnchorOrientation.right : AnchorOrientation.left;
-    }
-    return dy > 0 ? AnchorOrientation.bottom : AnchorOrientation.top;
-};
-const calculateWaypoints = (
-    path: GridNode[],
-    connectionName: string,
-    toComponent?: AugmentedSystemComponent | AugmentedSystemConnection["to"]
-) => {
-    const waypoints: number[] = [];
-
-    // Handle empty or invalid paths
-    if (!path || path.length < 2) {
-        // Create a direct line between components using their grid positions
-        if (toComponent) {
-            const augmentedSystemComponent = toComponent as AugmentedSystemComponent;
-            const augmentedSystemConnection = (toComponent as AugmentedSystemConnection["to"]).component;
-            waypoints.push((augmentedSystemConnection?.gridX ?? augmentedSystemComponent.gridX) * 5);
-            waypoints.push((augmentedSystemConnection?.gridY ?? augmentedSystemComponent.gridY) * 5);
-            waypoints.push((augmentedSystemConnection?.gridX ?? augmentedSystemComponent.gridX) * 5);
-            waypoints.push((augmentedSystemConnection?.gridY ?? augmentedSystemComponent.gridY) * 5);
-            return waypoints;
-        }
-        console.warn(`Unable to create path for connection ${connectionName}`);
-        return [0, 0, 0, 0]; // Fallback to prevent rendering errors
-    }
-
-    const oldDirection = {
-        x: (path[0]?.x ?? 0) - (path[1]?.x ?? 0),
-        y: (path[0]?.y ?? 0) - (path[1]?.y ?? 0),
-    };
-
-    waypoints.push((path[0]?.x ?? 0) * 5);
-    waypoints.push((path[0]?.y ?? 0) * 5);
-
-    for (let i = 1; i < path.length; i++) {
-        const newDirection = {
-            x: (path[i - 1]?.x ?? 0) - (path[i]?.x ?? 0),
-            y: (path[i - 1]?.y ?? 0) - (path[i]?.y ?? 0),
-        };
-        if (oldDirection.x !== newDirection.x || oldDirection.y !== newDirection.y) {
-            waypoints.push((path[i - 1]?.x ?? 0) * 5);
-            waypoints.push((path[i - 1]?.y ?? 0) * 5);
-            oldDirection.x = newDirection.x;
-            oldDirection.y = newDirection.y;
-        }
-    }
-
-    waypoints.push((path[path.length - 1]?.x ?? 0) * 5);
-    waypoints.push((path[path.length - 1]?.y ?? 0) * 5);
-
-    return waypoints;
-};
-
-const createGridForAStar = (
-    components: AugmentedSystemComponent[],
-    begin: { x: number; y: number },
-    gridSize: { x: number; y: number }
-) => {
-    const grid = createGrid(gridSize.x, gridSize.y);
-
-    // Pre-calculate boundaries for component collision checks
-    const gridBounds = {
-        minX: begin.x,
-        minY: begin.y,
-        maxX: begin.x + gridSize.x,
-        maxY: begin.y + gridSize.y,
-    };
-
-    // Initialize grid positions in bulk
-    grid.forEach((row, y) => {
-        const baseY = begin.y + y;
-        row.forEach((node, x) => {
-            node.x = begin.x + x;
-            node.y = baseY;
-        });
-    });
-
-    // Filter components that are within grid bounds first
-    const relevantComponents = components.filter(
-        (component) =>
-            component.gridX >= gridBounds.minX &&
-            component.gridY >= gridBounds.minY &&
-            component.gridX < gridBounds.maxX &&
-            component.gridY < gridBounds.maxY
-    );
-
-    // Process each relevant component
-    for (const component of relevantComponents) {
-        const componentGridX = component.gridX - begin.x;
-        const componentGridY = component.gridY - begin.y;
-
-        // Calculate component bounds once
-        const bounds = {
-            minY: Math.max(0, componentGridY - 5),
-            maxY: Math.min(gridSize.y, componentGridY + 27),
-            minX: Math.max(0, componentGridX - 5),
-            maxX: Math.min(gridSize.x, componentGridX + 22),
-        };
-
-        // Apply walk costs in bulk
-        for (let y = bounds.minY; y < bounds.maxY; y++) {
-            const row = grid[y];
-            if (!row) {
-                continue;
-            }
-
-            const relativeY = y - componentGridY;
-
-            for (let x = bounds.minX; x < bounds.maxX; x++) {
-                const relativeX = x - componentGridX;
-
-                // Skip if this position doesn't need modification
-                if (
-                    (relativeY === 8 && (relativeX < 5 || relativeX > 17)) ||
-                    (relativeX === 8 && (relativeY < 5 || relativeY > 22))
-                ) {
-                    continue;
-                }
-
-                const cell = row[x];
-                if (!cell) {
-                    continue;
-                }
-
-                // Set walk cost
-                cell.walkCost = relativeY >= 5 && relativeY <= 22 && relativeX >= 5 && relativeY <= 17 ? 500 : 300;
-            }
-        }
-
-        // Set unwalkable areas more efficiently
-        for (let y = 3; y < 9; y++) {
-            const gridY = componentGridY + y;
-            if (gridY < 0 || gridY >= grid.length) {
-                continue;
-            }
-
-            const row = grid[gridY];
-            for (let x = 3; x < 9; x++) {
-                const gridX = componentGridX + x;
-                if (gridX < 0 || gridX >= (row?.length ?? 0)) {
-                    continue;
-                }
-
-                const cell = row?.[gridX];
-                if (!cell) {
-                    continue;
-                }
-
-                cell.walkable = false;
-                cell.walkCost = 400000;
-            }
-        }
-    }
-
-    return grid;
-};
-
-const createGrid = (width: number, height: number): GridNode[][] => {
-    // Preallocate the entire grid at once
-    const grid: GridNode[][] = new Array(height);
-
-    // Create a prototype object for cell properties
-    const cellPrototype = {
-        x: 0,
-        y: 0,
-        gCost: 0,
-        hCost: 0,
-        fCost: 0,
-        walkCost: 0,
-        parent: null,
-        walkable: true,
-    };
-
-    // Fill grid with rows
-    for (let y = 0; y < height; y++) {
-        const row: GridNode[] = new Array(width);
-
-        // Fill row with cells
-        for (let x = 0; x < width; x++) {
-            // Create new cell using the prototype as template
-            row[x] = {
-                ...cellPrototype,
-                gridX: x,
-                gridY: y,
-            };
-        }
-
-        grid[y] = row;
-    }
-
-    return grid;
-};
-
-const findPathOptimized = (grid: GridNode[][], startNode: GridNode, targetNode: GridNode) => {
-    const path: GridNode[] = [];
-    const visited = new Set<string>();
-    const openList = new FastPriorityQueue<GridNode>((a, b) => {
-        const aF = a.gCost + a.hCost;
-        const bF = b.gCost + b.hCost;
-        if (aF === bF) {
-            return a.hCost < b.hCost;
-        }
-        return aF < bF;
-    });
-
-    // Store the required final direction based on the target anchor
-    const finalDirection = {
-        x: Math.sign(targetNode.x - startNode.x),
-        y: Math.sign(targetNode.y - startNode.y),
-    };
-
-    openList.add(startNode);
-
-    while (!openList.isEmpty()) {
-        const currentNode = openList.poll();
-        if (!currentNode) {
-            continue;
-        }
-        const nodeKey = `${currentNode.gridX},${currentNode.gridY}`;
-
-        if (visited.has(nodeKey)) {
-            continue;
-        }
-        visited.add(nodeKey);
-
-        if (currentNode === targetNode) {
-            let current: GridNode | null = currentNode;
-            while (current && current !== startNode) {
-                path.push(current);
-                current = current.parent;
-            }
-            path.push(startNode);
-
-            // Verify and fix final approach if needed
-            if (path.length >= 2) {
-                const lastNode = path[0];
-                const secondLastNode = path[1];
-                const actualFinalDirection = {
-                    x: Math.sign((lastNode?.x ?? 0) - (secondLastNode?.x ?? 0)),
-                    y: Math.sign((lastNode?.y ?? 0) - (secondLastNode?.y ?? 0)),
-                };
-
-                // If the final direction is wrong, try to find a better path
-                if (actualFinalDirection.x !== finalDirection.x || actualFinalDirection.y !== finalDirection.y) {
-                    continue; // Keep searching for a better path
-                }
-            }
-            return path;
-        }
-
-        const neighbors: GridNode[] = [];
-        const { gridX, gridY } = currentNode;
-
-        // Prioritize neighbors based on final direction when near target
-        const isNearTarget = getManhattanDistance(currentNode, targetNode) <= 3;
-        const neighborDirections = isNearTarget
-            ? getPrioritizedNeighborDirections(currentNode, targetNode, finalDirection)
-            : [
-                  [1, 0], // Right
-                  [-1, 0], // Left
-                  [0, -1], // Up
-                  [0, 1], // Down
-              ];
-
-        for (const [dx, dy] of neighborDirections) {
-            const newX = gridX + (dx ?? 0);
-            const newY = gridY + (dy ?? 0);
-
-            if (
-                newX >= 0 &&
-                newX < (grid[0]?.length ?? 0) &&
-                newY >= 0 &&
-                newY < (grid.length ?? 0) &&
-                grid[newY]?.[newX]
-            ) {
-                neighbors.push(grid[newY][newX]);
-            }
-        }
-
-        for (const neighbor of neighbors) {
-            const neighborKey = `${neighbor.gridX},${neighbor.gridY}`;
-            if (!neighbor.walkable || visited.has(neighborKey)) {
-                continue;
-            }
-
-            const pathLength = Math.abs(targetNode.x - startNode.x) + Math.abs(targetNode.y - startNode.y);
-            const turnPenaltyMultiplier = Math.max(1, 1000 / pathLength);
-
-            const isNewDirection =
-                currentNode.parent &&
-                (currentNode.x - currentNode.parent.x !== 0) !== (neighbor.x - currentNode.x !== 0);
-
-            const turnCost = isNewDirection ? TURN_PENALTY * turnPenaltyMultiplier : 0;
-            const gCost = currentNode.gCost + neighbor.walkCost + 100 + turnCost;
-
-            if (!neighbor.parent || gCost < neighbor.gCost) {
-                neighbor.parent = currentNode;
-                neighbor.gCost = gCost;
-                neighbor.hCost = getManhattanDistance(neighbor, targetNode) * 100;
-                openList.add(neighbor);
-            }
-        }
-    }
-
-    return path;
-};
-
-// Helper function to prioritize neighbors based on desired final direction
-const getPrioritizedNeighborDirections = (
-    currentNode: GridNode,
-    targetNode: GridNode,
-    finalDirection: { x: number; y: number }
-) => {
-    const dx = targetNode.x - currentNode.x;
-    const dy = targetNode.y - currentNode.y;
-
-    const directions: [number, number][] = [];
-
-    // Add final direction first
-    if (finalDirection.x !== 0) {
-        directions.push([finalDirection.x, 0]);
-    }
-    if (finalDirection.y !== 0) {
-        directions.push([0, finalDirection.y]);
-    }
-
-    // Add remaining orthogonal directions
-    if (Math.abs(dx) > Math.abs(dy)) {
-        directions.push([Math.sign(dx), 0]);
-        directions.push([0, Math.sign(dy)]);
-    } else {
-        directions.push([0, Math.sign(dy)]);
-        directions.push([Math.sign(dx), 0]);
-    }
-
-    // Add opposite directions last
-    directions.push([-Math.sign(dx), 0]);
-    directions.push([0, -Math.sign(dy)]);
-
-    return [...new Set(directions)]; // Remove duplicates
-};
-
-// Replace complex distance calculation with simpler Manhattan distance
-const getManhattanDistance = (nodeA: GridNode, nodeB: GridNode) => {
-    return Math.abs(nodeA.x - nodeB.x) + Math.abs(nodeA.y - nodeB.y);
-};
-
-// Replace existing Heap implementation with more efficient FastPriorityQueue
-class FastPriorityQueue<T> {
-    private readonly heap: T[] = [];
-    private readonly comparator: (a: T, b: T) => boolean;
-
-    constructor(comparator: (a: T, b: T) => boolean) {
-        this.comparator = comparator;
-    }
-
-    add(value: T): void {
-        this.heap.push(value);
-        this.siftUp(this.heap.length - 1);
-    }
-
-    poll(): T | undefined {
-        if (this.isEmpty()) {
-            return undefined;
-        }
-        const value = this.heap[0];
-        const last = this.heap.pop();
-        if (this.heap.length > 0 && last !== undefined) {
-            this.heap[0] = last;
-            this.siftDown(0);
-        }
-        return value;
-    }
-
-    isEmpty(): boolean {
-        return this.heap.length === 0;
-    }
-
-    private siftUp(index: number): void {
-        const item = this.heap[index] as T;
-        while (index > 0) {
-            const parentIndex = (index - 1) >>> 1;
-            const parent = this.heap[parentIndex] as T;
-            if (this.comparator(item, parent)) {
-                this.heap[index] = parent;
-                index = parentIndex;
-            } else {
-                break;
-            }
-        }
-        this.heap[index] = item;
-    }
-
-    private siftDown(index: number): void {
-        const item = this.heap[index] as T;
-        const length = this.heap.length;
-        const halfLength = length >>> 1;
-
-        while (index < halfLength) {
-            let bestIndex = (index << 1) + 1;
-            const right = bestIndex + 1;
-
-            if (right < length && this.comparator(this.heap[right] as T, this.heap[bestIndex] as T)) {
-                bestIndex = right;
-            }
-            if (!this.comparator(this.heap[bestIndex] as T, item)) {
-                break;
-            }
-
-            this.heap[index] = this.heap[bestIndex] as T;
-            index = bestIndex;
-        }
-        this.heap[index] = item;
-    }
-}

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -172,7 +172,6 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         selectedConnection,
         selectedConnectionId,
         selectedPointOfAttack,
-        selectedConnectionPointId,
         mousePointers,
         newConnection,
         pointsOfAttackOfSelectedComponent,
@@ -1419,8 +1418,6 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                                         onClick={handleSelectConnection}
                                         onPointOfAttackClicked={handleOnPointOfAttackClicked}
                                         selected={selectedConnectionId === connection.id}
-                                        onConnectionPointClicked={handleOnConnectionPointClicked}
-                                        selectedConnectionPointId={selectedConnectionPointId}
                                         stageRef={stageRef}
                                     />
                                 );

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -58,7 +58,6 @@ import type {
     ConnectionEndpointWithComponent,
     Coordinate,
     SystemPointOfAttack,
-    ConnectionPointMeta,
     TextAnnotation,
 } from "#api/types/system.types.ts";
 import type { EditorComponentType } from "#application/adapters/editor-component-type.adapter.ts";
@@ -148,7 +147,6 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         addAssetToSelectedPointOfAttack,
         removeAssetToSelectedPointOfAttack,
         updateConnectionsOfComponent,
-        connectionRecalculated,
         selectConnectionPoint,
         deselectConnectionPoint,
         setMousePointers,
@@ -1058,14 +1056,6 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         }
     };
 
-    const onRecalculated = (
-        connectionId: string,
-        waypoints: number[],
-        connectionPointsMeta: ConnectionPointMeta[]
-    ): void => {
-        connectionRecalculated(connectionId, waypoints, connectionPointsMeta);
-    };
-
     const handleAssetSearchChanged = (e: ChangeEvent<HTMLInputElement>): void => {
         setAssetSearchValue(e.target.value);
     };
@@ -1414,13 +1404,11 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                                     return <Group key={i}></Group>;
                                 }
 
-                                const fromComponent = components.filter(
-                                    (component) => component.id === connection.from.id
-                                )[0];
-                                const toComponent = components.filter(
-                                    (component) => component.id === connection.to.id
-                                )[0];
-                                if (!fromComponent || !toComponent) {
+                                // A connection whose endpoint component is gone has no valid line.
+                                const endpointsExist =
+                                    components.some((component) => component.id === connection.from.id) &&
+                                    components.some((component) => component.id === connection.to.id);
+                                if (!endpointsExist) {
                                     return null;
                                 }
 
@@ -1430,13 +1418,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                                         {...connection}
                                         onClick={handleSelectConnection}
                                         onPointOfAttackClicked={handleOnPointOfAttackClicked}
-                                        fromComponent={fromComponent}
-                                        toComponent={toComponent}
-                                        components={components}
-                                        connections={connections}
                                         selected={selectedConnectionId === connection.id}
-                                        recalculate={connection.recalculate}
-                                        onRecalculated={onRecalculated}
                                         onConnectionPointClicked={handleOnConnectionPointClicked}
                                         selectedConnectionPointId={selectedConnectionPointId}
                                         stageRef={stageRef}

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -1433,6 +1433,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                                         fromComponent={fromComponent}
                                         toComponent={toComponent}
                                         components={components}
+                                        connections={connections}
                                         selected={selectedConnectionId === connection.id}
                                         recalculate={connection.recalculate}
                                         onRecalculated={onRecalculated}


### PR DESCRIPTION
## Summary

  Resolves #827 

  - Replaces the old connection router with a new connection-routing/ module: a fishbone router that merges same-target connections onto a shared trunk, plus a deterministic orthogonal router as fallback, arbitrated by a shared defect comparator (obstacle hits > crossings > overlap length)
  - Reworks use-editor.hook.ts's recalculation flow to sequential per-connection batch routing (each connection routes against the already-updated lines of  earlier ones in the same batch), replacing a stale two-pass/flag protocol that could wedge or silently skip connections
  - Makes the Konva connection component (system-component-connection.component.tsx) purely presentational — routing no longer runs in the render path or dispatches during render
  
###  Changes

  - `connection-routing/fishbone.ts (new, 680 lines)` — hub/leaf comb detection, trunk placement (inside/over/split modes), crowded-face sub-comb splitting
  - `connection-routing/deterministic.ts (new, 255 lines)` — per-connection orthogonal routing (straight/L/Z/wrap candidates), ranked by defects → bends →  length → hub-face
  - `connection-routing/shared.ts (new, 450 lines)` — shared geometry, defect scoring (RouteDefects, compareRouteDefects), connection-id-scoped exclusion for  route scoring
  - `connection-routing/index.ts (new) `— computeConnectionRouting, arbitrates fishbone vs. deterministic by defect count
  - `use-editor.hook.ts` — routeConnectionsSequentially, load-time routing keyed on loadedProjectId, routes-last-on-edit ordering, skips dispatch for unchanged waypoints
  - `system-component-connection.component.tsx `— stripped down to presentational rendering of stored waypoints, routing props/logic removed
  - `api/types/system.types.ts` — recalculate field annotated as retirement-pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection paths are now routed more intelligently, with support for shared trunks and more consistent right-angled routes.
  * Connections now render from precomputed paths, improving responsiveness while editing.

* **Bug Fixes**
  * Reduced crossing and overlap issues when moving, adding, or deleting components and connections.
  * Improved routing stability for crowded layouts and edge cases where no valid route exists.
  * Connections with too few points are no longer rendered incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->