### PR TITLE
fix(threats/measures): stay on tab in dialog

### DIFF
--- a/apps/frontend/src/application/hooks/use-threat-measures-list.hook.ts
+++ b/apps/frontend/src/application/hooks/use-threat-measures-list.hook.ts
@@ -63,8 +63,8 @@ export const useThreatMeasuresList = ({ projectId, threatId }: UseThreatMeasures
     }, [projectId, loadMeasureImpacts]);
 
     const items: ThreatMeasure[] = useMemo(() => {
-        if (measuresPending || measureImpactsPending) {
-            //wait until all data is loaded
+        if ((measuresPending && measures.length === 0) || (measureImpactsPending && measureImpacts.length === 0)) {
+            // wait until initial data is loaded; keep showing stale data on re-fetches
             return [];
         }
 

--- a/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.test.tsx
@@ -60,8 +60,8 @@ describe("AddThreatDialog — Apply Measure button", () => {
         await user.click(screen.getByRole("tab", { name: /measures/i }));
         await user.click(screen.getByRole("button", { name: /apply measure/i }));
 
-        expect(navigate).toHaveBeenCalledOnce();
-        expect(navigate).toHaveBeenCalledWith(`/projects/${project.id}/threats/measureImpacts/edit`, {
+        expect(navigate).toHaveBeenCalledTimes(2);
+        expect(navigate).toHaveBeenLastCalledWith(`/projects/${project.id}/threats/measureImpacts/edit`, {
             state: {
                 threat: { ...threat, damage: 4 },
                 project,

--- a/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import AddThreatDialog from "./add-threat.dialog";
+import AddThreatDialog, { type ThreatDialogHostRoute } from "./add-threat.dialog";
 import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import {
     createAsset,
@@ -22,14 +22,16 @@ vi.mock("react-router", async (importOriginal) => {
     return { ...actual, useNavigate: () => navigate };
 });
 
-const setup = (userRole: USER_ROLES = USER_ROLES.EDITOR) => {
+const setup = (userRole: USER_ROLES = USER_ROLES.EDITOR, hostRoute: ThreatDialogHostRoute = "threats") => {
     const project = createProject({ id: 7 });
     const threat = createThreat({
         id: 42,
         assets: [createAsset({ confidentiality: 4, integrity: 2, availability: 1 })],
     });
     const user = userEvent.setup();
-    renderWithProviders(<AddThreatDialog threat={threat} project={project} userRole={userRole} open={true} />);
+    renderWithProviders(
+        <AddThreatDialog threat={threat} project={project} userRole={userRole} open={true} hostRoute={hostRoute} />
+    );
     return { project, threat, user };
 };
 
@@ -54,8 +56,8 @@ describe("AddThreatDialog — Apply Measure button", () => {
         expect(screen.queryByRole("button", { name: /apply measure/i })).not.toBeInTheDocument();
     });
 
-    it("navigates to the apply-measure route with the threat and computed damage on click", async () => {
-        const { project, threat, user } = setup(USER_ROLES.EDITOR);
+    it("navigates to the threats apply-measure route when hostRoute is threats", async () => {
+        const { project, threat, user } = setup(USER_ROLES.EDITOR, "threats");
 
         await user.click(screen.getByRole("tab", { name: /measures/i }));
         await user.click(screen.getByRole("button", { name: /apply measure/i }));
@@ -64,6 +66,93 @@ describe("AddThreatDialog — Apply Measure button", () => {
         expect(navigate).toHaveBeenLastCalledWith(`/projects/${project.id}/threats/measureImpacts/edit`, {
             state: {
                 threat: { ...threat, damage: 4 },
+                project,
+            },
+        });
+    });
+
+    it("navigates to the risk apply-measure route when hostRoute is risk", async () => {
+        const { project, threat, user } = setup(USER_ROLES.EDITOR, "risk");
+
+        await user.click(screen.getByRole("tab", { name: /measures/i }));
+        await user.click(screen.getByRole("button", { name: /apply measure/i }));
+
+        expect(navigate).toHaveBeenCalledTimes(2);
+        expect(navigate).toHaveBeenLastCalledWith(`/projects/${project.id}/risk/measureImpacts/edit`, {
+            state: {
+                threat: { ...threat, damage: 4 },
+                project,
+            },
+        });
+    });
+
+    it("navigates to the threats apply-measure route when hostRoute is measures (no measures sub-route for this action)", async () => {
+        const { project, threat, user } = setup(USER_ROLES.EDITOR, "measures");
+
+        await user.click(screen.getByRole("tab", { name: /measures/i }));
+        await user.click(screen.getByRole("button", { name: /apply measure/i }));
+
+        expect(navigate).toHaveBeenCalledTimes(2);
+        expect(navigate).toHaveBeenLastCalledWith(`/projects/${project.id}/threats/measureImpacts/edit`, {
+            state: {
+                threat: { ...threat, damage: 4 },
+                project,
+            },
+        });
+    });
+});
+
+describe("AddThreatDialog — Edit Measure Impact routing", () => {
+    const threatMeasure = createThreatMeasure();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseThreatMeasuresList({ threatMeasures: [threatMeasure] });
+    });
+
+    it("navigates to threats measureImpacts route when hostRoute is threats", async () => {
+        const { project, threat, user } = setup(USER_ROLES.EDITOR, "threats");
+
+        await user.click(screen.getByRole("tab", { name: /measures/i }));
+        await user.click(screen.getByText("2025-01-01"));
+
+        expect(navigate).toHaveBeenLastCalledWith(`/projects/${project.id}/threats/measureImpacts/edit`, {
+            state: {
+                threat: { ...threat, damage: 4 },
+                measureImpact: threatMeasure.measureImpact,
+                project,
+            },
+        });
+    });
+
+    it("navigates to measures measureImpacts route when hostRoute is measures", async () => {
+        const { project, user } = setup(USER_ROLES.EDITOR, "measures");
+
+        await user.click(screen.getByRole("tab", { name: /measures/i }));
+        await user.click(screen.getByText("2025-01-01"));
+
+        expect(navigate).toHaveBeenLastCalledWith(
+            `/projects/${project.id}/measures/${threatMeasure.measure.id}/measureImpacts/edit`,
+            {
+                state: {
+                    measure: threatMeasure.measure,
+                    measureImpact: threatMeasure.measureImpact,
+                    project,
+                },
+            }
+        );
+    });
+
+    it("navigates to risk measureImpacts route when hostRoute is risk", async () => {
+        const { project, threat, user } = setup(USER_ROLES.EDITOR, "risk");
+
+        await user.click(screen.getByRole("tab", { name: /measures/i }));
+        await user.click(screen.getByText("2025-01-01"));
+
+        expect(navigate).toHaveBeenLastCalledWith(`/projects/${project.id}/risk/measureImpacts/edit`, {
+            state: {
+                threat: { ...threat, damage: 4 },
+                measureImpact: threatMeasure.measureImpact,
                 project,
             },
         });

--- a/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.tsx
@@ -128,13 +128,23 @@ const AddThreatDialog = ({ threat, project, userRole, initialTab, ...props }: Ad
     ) => {
         event.preventDefault();
         event.stopPropagation();
-        navigate(`/projects/${projectId}/measures/${measure.id}/measureImpacts/edit`, {
-            state: {
-                measure,
-                measureImpact,
-                project,
-            },
-        });
+        if (location.pathname.startsWith(`/projects/${projectId}/threats/`)) {
+            navigate(`/projects/${projectId}/threats/measureImpacts/edit`, {
+                state: {
+                    threat: { ...threat, damage: calcDamage(threat) },
+                    measureImpact,
+                    project,
+                },
+            });
+        } else {
+            navigate(`/projects/${projectId}/measures/${measure.id}/measureImpacts/edit`, {
+                state: {
+                    measure,
+                    measureImpact,
+                    project,
+                },
+            });
+        }
     };
 
     const onClickDeleteMeasureThreat = (

--- a/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.tsx
@@ -31,16 +31,26 @@ import { AddThreatMainTab } from "./add-threat-main-tab.component.tsx";
 import { AddThreatAssetsTab } from "./add-threat-assets-tab.component.tsx";
 import { AddThreatMeasuresTab } from "./add-threat-measures-tab.component.tsx";
 
-type ThreatTab = "MAIN" | "ASSETS" | "MEASURES";
+export type ThreatTab = "MAIN" | "ASSETS" | "MEASURES";
+
+export type ThreatDialogHostRoute = "threats" | "measures" | "risk";
 
 interface AddThreatDialogProps extends DialogProps {
     threat: ExtendedThreat;
     project: ExtendedProject;
     userRole: USER_ROLES | undefined;
     initialTab?: ThreatTab;
+    hostRoute?: ThreatDialogHostRoute;
 }
 
-const AddThreatDialog = ({ threat, project, userRole, initialTab, ...props }: AddThreatDialogProps) => {
+const AddThreatDialog = ({
+    threat,
+    project,
+    userRole,
+    initialTab,
+    hostRoute = "threats",
+    ...props
+}: AddThreatDialogProps) => {
     const { confirmDialog, cancelDialog } = useDialog<ThreatFormValues | null>("threats");
     const navigate = useNavigate();
     const location = useLocation();
@@ -128,18 +138,15 @@ const AddThreatDialog = ({ threat, project, userRole, initialTab, ...props }: Ad
     ) => {
         event.preventDefault();
         event.stopPropagation();
-        if (location.pathname.startsWith(`/projects/${projectId}/threats/`)) {
-            navigate(`/projects/${projectId}/threats/measureImpacts/edit`, {
-                state: {
-                    threat: { ...threat, damage: calcDamage(threat) },
-                    measureImpact,
-                    project,
-                },
+        if (hostRoute === "measures") {
+            navigate(`/projects/${projectId}/measures/${measure.id}/measureImpacts/edit`, {
+                state: { measure, measureImpact, project },
             });
         } else {
-            navigate(`/projects/${projectId}/measures/${measure.id}/measureImpacts/edit`, {
+            // threats and risk both have a measureImpacts/edit route at their own root
+            navigate(`/projects/${projectId}/${hostRoute}/measureImpacts/edit`, {
                 state: {
-                    measure,
+                    threat: { ...threat, damage: calcDamage(threat) },
                     measureImpact,
                     project,
                 },
@@ -177,7 +184,8 @@ const AddThreatDialog = ({ threat, project, userRole, initialTab, ...props }: Ad
     };
 
     const onClickApplyMeasure = () => {
-        navigate(`/projects/${projectId}/threats/measureImpacts/edit`, {
+        const basePath = hostRoute === "risk" ? `/projects/${projectId}/risk` : `/projects/${projectId}/threats`;
+        navigate(`${basePath}/measureImpacts/edit`, {
             state: {
                 threat: { ...threat, damage: calcDamage(threat) },
                 project,

--- a/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-threat-dialog/add-threat.dialog.tsx
@@ -13,7 +13,7 @@ import {
 import { useRef, useState, type ChangeEvent, type MouseEvent, type SyntheticEvent } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { useDialog } from "#application/hooks/use-dialog.hook.ts";
 import { Button } from "#view/components/button.component.tsx";
 import { Dialog } from "#view/components/dialog.component.tsx";
@@ -37,13 +37,15 @@ interface AddThreatDialogProps extends DialogProps {
     threat: ExtendedThreat;
     project: ExtendedProject;
     userRole: USER_ROLES | undefined;
+    initialTab?: ThreatTab;
 }
 
-const AddThreatDialog = ({ threat, project, userRole, ...props }: AddThreatDialogProps) => {
+const AddThreatDialog = ({ threat, project, userRole, initialTab, ...props }: AddThreatDialogProps) => {
     const { confirmDialog, cancelDialog } = useDialog<ThreatFormValues | null>("threats");
     const navigate = useNavigate();
+    const location = useLocation();
     const { t } = useTranslation("threatDialogPage");
-    const [tab, setTab] = useState<ThreatTab>("MAIN");
+    const [tab, setTab] = useState<ThreatTab>(initialTab ?? "MAIN");
     const formRef = useRef<HTMLFormElement | null>(null);
     const projectId = project.id;
     const threatId = threat.id;
@@ -181,6 +183,10 @@ const AddThreatDialog = ({ threat, project, userRole, ...props }: AddThreatDialo
      */
     const handleChangeTab = (_event: SyntheticEvent, newTab: ThreatTab) => {
         setTab(newTab);
+        navigate(location.pathname, {
+            replace: true,
+            state: { ...location.state, returnToTab: newTab },
+        });
     };
 
     /**

--- a/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
@@ -8,7 +8,7 @@ import type { DialogProps } from "@mui/material/Dialog";
 import { useState, type ChangeEvent, type SyntheticEvent } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { useDialog } from "#application/hooks/use-dialog.hook.ts";
 import { Button } from "#view/components/button.component.tsx";
 import { Dialog } from "#view/components/dialog.component.tsx";
@@ -42,6 +42,7 @@ interface MeasureDetailsFormValues extends FormValues, Omit<Measure, keyof FormV
 interface MeasureDetailsDialogProps extends DialogProps {
     project: Project;
     measure: Measure;
+    initialTab?: MeasureDetailsTab;
 }
 
 type MeasureDetailsTab = "MAIN" | "THREATS";
@@ -54,8 +55,9 @@ type MeasureDetailsTab = "MAIN" | "THREATS";
  * @param {object} props - Dialog properties.
  * @returns React component for the measure dialog.
  */
-const MeasureDetailsDialog = ({ project, measure, ...props }: MeasureDetailsDialogProps) => {
+const MeasureDetailsDialog = ({ project, measure, initialTab, ...props }: MeasureDetailsDialogProps) => {
     const navigate = useNavigate();
+    const location = useLocation();
     const { confirmDialog, cancelDialog } = useDialog<MeasureDetailsFormValues | null>("measures");
     const userRole = useAppSelector((state) => state.projects.current?.role);
 
@@ -77,7 +79,7 @@ const MeasureDetailsDialog = ({ project, measure, ...props }: MeasureDetailsDial
         },
     });
 
-    const [tab, setTab] = useState<MeasureDetailsTab>("MAIN");
+    const [tab, setTab] = useState<MeasureDetailsTab>(initialTab ?? "MAIN");
     const isNew = !measureId;
 
     const { t } = useTranslation("measureDialog");
@@ -137,10 +139,7 @@ const MeasureDetailsDialog = ({ project, measure, ...props }: MeasureDetailsDial
     };
     const onClickAddMeasureImpact = () => {
         navigate(`/projects/${projectId}/measures/${measureId}/measureImpacts/edit`, {
-            state: {
-                measure,
-                project,
-            },
+            state: { measure, project },
         });
     };
 
@@ -148,11 +147,7 @@ const MeasureDetailsDialog = ({ project, measure, ...props }: MeasureDetailsDial
         event.preventDefault();
         event.stopPropagation();
         navigate(`/projects/${projectId}/measures/${measureId}/measureImpacts/edit`, {
-            state: {
-                measure,
-                measureImpact,
-                project,
-            },
+            state: { measure, measureImpact, project },
         });
     };
 
@@ -173,6 +168,10 @@ const MeasureDetailsDialog = ({ project, measure, ...props }: MeasureDetailsDial
 
     const handleChangeTab = (_event: SyntheticEvent, newTab: MeasureDetailsTab) => {
         setTab(newTab);
+        navigate(location.pathname, {
+            replace: true,
+            state: { ...location.state, returnToTab: newTab },
+        });
     };
 
     /**

--- a/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
@@ -45,7 +45,7 @@ interface MeasureDetailsDialogProps extends DialogProps {
     initialTab?: MeasureDetailsTab;
 }
 
-type MeasureDetailsTab = "MAIN" | "THREATS";
+export type MeasureDetailsTab = "MAIN" | "THREATS";
 
 /**
  * Creates a dialog for the measures.

--- a/apps/frontend/src/view/dialogs/measureImpactByMeasure.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measureImpactByMeasure.dialog.tsx
@@ -87,6 +87,7 @@ const MeasureImpactByMeasureDialog = ({
     });
 
     const disableSelect = !!measureImpact;
+    const [measureSelectOpen, setMeasureSelectOpen] = useState(false);
 
     const {
         register,
@@ -156,9 +157,7 @@ const MeasureImpactByMeasureDialog = ({
         navigate(-1);
     };
 
-    const measuresAddRoute = location.pathname.startsWith(`/projects/${project.id}/threats/`)
-        ? `/projects/${project.id}/threats/measures/add`
-        : `/projects/${project.id}/risk/measures/add`;
+    const measuresAddRoute = `${location.pathname}/measures/add`;
 
     const handleImplementCatalogMeasure = (event: React.MouseEvent<HTMLElement>, catalogMeasure: CatalogMeasure) => {
         event.preventDefault();
@@ -181,6 +180,7 @@ const MeasureImpactByMeasureDialog = ({
     const handleNewBlankMeasure = (event: React.MouseEvent<HTMLElement>) => {
         event.preventDefault();
         event.stopPropagation();
+        setMeasureSelectOpen(false);
         navigate(measuresAddRoute, {
             state: {
                 measure: {
@@ -250,6 +250,9 @@ const MeasureImpactByMeasureDialog = ({
                                     label={t("measure")}
                                     multiple={false}
                                     value={value}
+                                    open={measureSelectOpen}
+                                    onOpen={() => setMeasureSelectOpen(true)}
+                                    onClose={() => setMeasureSelectOpen(false)}
                                     {...register("measureId", {
                                         validate: (value) => value != null,
                                         valueAsNumber: true,

--- a/apps/frontend/src/view/dialogs/measureImpactByMeasure.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measureImpactByMeasure.dialog.tsx
@@ -25,7 +25,7 @@ import SelectBoxCategorySubHeader from "#view/components/selectBox-CategorySubHe
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { useDialog } from "#application/hooks/use-dialog.hook.ts";
 import { Button } from "#view/components/button.component.tsx";
 import { Dialog } from "#view/components/dialog.component.tsx";
@@ -74,6 +74,7 @@ const MeasureImpactByMeasureDialog = ({
     ...props
 }: MeasureImpactByMeasureDialogProps) => {
     const navigate = useNavigate();
+    const location = useLocation();
     const {
         confirmDialog,
         cancelDialog,
@@ -155,10 +156,14 @@ const MeasureImpactByMeasureDialog = ({
         navigate(-1);
     };
 
+    const measuresAddRoute = location.pathname.startsWith(`/projects/${project.id}/threats/`)
+        ? `/projects/${project.id}/threats/measures/add`
+        : `/projects/${project.id}/risk/measures/add`;
+
     const handleImplementCatalogMeasure = (event: React.MouseEvent<HTMLElement>, catalogMeasure: CatalogMeasure) => {
         event.preventDefault();
         event.stopPropagation();
-        navigate(`/projects/${project.id}/risk/measures/add`, {
+        navigate(measuresAddRoute, {
             state: {
                 measure: {
                     active: false,
@@ -176,7 +181,7 @@ const MeasureImpactByMeasureDialog = ({
     const handleNewBlankMeasure = (event: React.MouseEvent<HTMLElement>) => {
         event.preventDefault();
         event.stopPropagation();
-        navigate(`/projects/${project.id}/risk/measures/add`, {
+        navigate(measuresAddRoute, {
             state: {
                 measure: {
                     active: false,

--- a/apps/frontend/src/view/pages/measure-details-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/measure-details-dialog.page.tsx
@@ -1,7 +1,7 @@
 import { useParams, useLocation, Navigate, type Location } from "react-router";
 import type { Project } from "#api/types/project.types.ts";
 import type { Measure } from "#api/types/measure.types.ts";
-import MeasureDetailsDialog from "#view/dialogs/measure-details.dialog.tsx";
+import MeasureDetailsDialog, { type MeasureDetailsTab } from "#view/dialogs/measure-details.dialog.tsx";
 
 /**
  * on this page a measure can be created or edited
@@ -13,7 +13,7 @@ import MeasureDetailsDialog from "#view/dialogs/measure-details.dialog.tsx";
 interface MeasureDetailsDialogLocationState {
     measure: Measure;
     project: Project;
-    returnToTab?: "MAIN" | "THREATS";
+    returnToTab?: MeasureDetailsTab;
 }
 
 const MeasureDetailsDialogPage = () => {

--- a/apps/frontend/src/view/pages/measure-details-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/measure-details-dialog.page.tsx
@@ -13,6 +13,7 @@ import MeasureDetailsDialog from "#view/dialogs/measure-details.dialog.tsx";
 interface MeasureDetailsDialogLocationState {
     measure: Measure;
     project: Project;
+    returnToTab?: "MAIN" | "THREATS";
 }
 
 const MeasureDetailsDialogPage = () => {
@@ -20,9 +21,16 @@ const MeasureDetailsDialogPage = () => {
     const { state } = useLocation() as Location<MeasureDetailsDialogLocationState | undefined>;
 
     if (state) {
-        const { measure, project } = state;
+        const { measure, project, returnToTab } = state;
 
-        return <MeasureDetailsDialog project={project} open={true} measure={measure} />;
+        return (
+            <MeasureDetailsDialog
+                project={project}
+                open={true}
+                measure={measure}
+                {...(returnToTab !== undefined ? { initialTab: returnToTab } : {})}
+            />
+        );
     } else {
         return <Navigate to={`/projects/${projectId}/risk`} replace />;
     }

--- a/apps/frontend/src/view/pages/measure-impact-by-measure-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/measure-impact-by-measure-dialog.page.tsx
@@ -1,4 +1,5 @@
-import { useParams, useLocation, Navigate, type Location } from "react-router";
+import { useState } from "react";
+import { useParams, useLocation, Navigate, Outlet, type Location } from "react-router";
 import type { Project } from "#api/types/project.types.ts";
 import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
 import MeasureImpactByMeasureDialog, { type ApplyMeasureThreat } from "#view/dialogs/measureImpactByMeasure.dialog.tsx";
@@ -18,18 +19,25 @@ interface MeasureImpactByMeasureDialogLocationState {
 
 export const MeasureImpactByMeasureDialogPage = () => {
     const { projectId = "" } = useParams<{ projectId: string }>();
-    const { state } = useLocation() as Location<MeasureImpactByMeasureDialogLocationState | undefined>;
+    const { state: locationState } = useLocation() as Location<MeasureImpactByMeasureDialogLocationState | undefined>;
+    // Capture the initial location state at mount time so that when the child route
+    // (measures/add) is active and useLocation() reflects the child's state, the
+    // parent dialog retains its original threat/project/measureImpact data.
+    const [state] = useState(locationState);
 
     if (state) {
         const { threat, project, measureImpact } = state;
 
         return (
-            <MeasureImpactByMeasureDialog
-                project={project}
-                open={true}
-                threat={threat}
-                measureImpact={measureImpact ?? null}
-            />
+            <>
+                <MeasureImpactByMeasureDialog
+                    project={project}
+                    open={true}
+                    threat={threat}
+                    measureImpact={measureImpact ?? null}
+                />
+                <Outlet />
+            </>
         );
     } else {
         return <Navigate to={`/projects/${projectId}/risk`} replace />;

--- a/apps/frontend/src/view/pages/measure-impact-by-measure-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/measure-impact-by-measure-dialog.page.tsx
@@ -25,7 +25,7 @@ export const MeasureImpactByMeasureDialogPage = () => {
     // parent dialog retains its original threat/project/measureImpact data.
     const [state] = useState(locationState);
 
-    if (state) {
+    if (state?.threat) {
         const { threat, project, measureImpact } = state;
 
         return (

--- a/apps/frontend/src/view/pages/risk.page.tsx
+++ b/apps/frontend/src/view/pages/risk.page.tsx
@@ -868,8 +868,9 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
             </Box>
             {checkUserRole(userRole, USER_ROLES.EDITOR) && (
                 <Routes>
-                    <Route path="measures/add" element={<AddMeasureDialogPage />} />
-                    <Route path="measureImpacts/edit" element={<MeasureImpactByMeasureDialogPage />} />
+                    <Route path="measureImpacts/edit" element={<MeasureImpactByMeasureDialogPage />}>
+                        <Route path="measures/add" element={<AddMeasureDialogPage />} />
+                    </Route>
                     <Route path="threats/edit" element={<ThreatDialogPage />} />
                     <Route path="appliedMeasure/edit" element={<MeasureDetailsDialogPage />} />
                 </Routes>

--- a/apps/frontend/src/view/pages/threat-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/threat-dialog.page.tsx
@@ -5,6 +5,7 @@ import AddThreatDialog from "#view/dialogs/add-threat-dialog/add-threat.dialog.t
 
 interface ThreatDialogLocationState {
     threat: ExtendedThreat | undefined;
+    returnToTab?: "MAIN" | "ASSETS" | "MEASURES";
 }
 
 /**
@@ -22,7 +23,16 @@ const ThreatDialogPage = () => {
     const project = useAppSelector((state) => state.projects.current);
 
     if (threat && project) {
-        return <AddThreatDialog open={true} threat={threat} project={project} userRole={userRole} />;
+        const returnToTab = state?.returnToTab;
+        return (
+            <AddThreatDialog
+                open={true}
+                threat={threat}
+                project={project}
+                userRole={userRole}
+                {...(returnToTab !== undefined ? { initialTab: returnToTab } : {})}
+            />
+        );
     } else {
         return <Navigate to={`/projects/${projectId}/threats`} replace />;
     }

--- a/apps/frontend/src/view/pages/threat-dialog.page.tsx
+++ b/apps/frontend/src/view/pages/threat-dialog.page.tsx
@@ -1,11 +1,14 @@
 import { Navigate, useLocation, useParams, type Location } from "react-router";
 import { useAppSelector } from "#application/hooks/use-app-redux.hook.ts";
 import type { ExtendedThreat } from "#api/types/threat.types.ts";
-import AddThreatDialog from "#view/dialogs/add-threat-dialog/add-threat.dialog.tsx";
+import AddThreatDialog, {
+    type ThreatDialogHostRoute,
+    type ThreatTab,
+} from "#view/dialogs/add-threat-dialog/add-threat.dialog.tsx";
 
 interface ThreatDialogLocationState {
     threat: ExtendedThreat | undefined;
-    returnToTab?: "MAIN" | "ASSETS" | "MEASURES";
+    returnToTab?: ThreatTab;
 }
 
 /**
@@ -18,9 +21,15 @@ interface ThreatDialogLocationState {
 const ThreatDialogPage = () => {
     const { projectId = "" } = useParams<{ projectId?: string }>();
     const userRole = useAppSelector((state) => state.projects.current?.role);
-    const { state } = useLocation() as Location<ThreatDialogLocationState | undefined>;
+    const { state, pathname } = useLocation() as Location<ThreatDialogLocationState | undefined>;
     const threat = state?.threat;
     const project = useAppSelector((state) => state.projects.current);
+
+    const hostRoute: ThreatDialogHostRoute = pathname.includes("/risk/")
+        ? "risk"
+        : pathname.includes("/measures/")
+          ? "measures"
+          : "threats";
 
     if (threat && project) {
         const returnToTab = state?.returnToTab;
@@ -30,6 +39,7 @@ const ThreatDialogPage = () => {
                 threat={threat}
                 project={project}
                 userRole={userRole}
+                hostRoute={hostRoute}
                 {...(returnToTab !== undefined ? { initialTab: returnToTab } : {})}
             />
         );

--- a/apps/frontend/src/view/pages/threats.page.tsx
+++ b/apps/frontend/src/view/pages/threats.page.tsx
@@ -23,6 +23,7 @@ import { CreatePage } from "#view/components/create-page.component.tsx";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import ThreatDialogPage from "./threat-dialog.page";
 import { MeasureImpactByMeasureDialogPage } from "./measure-impact-by-measure-dialog.page";
+import AddMeasureDialogPage from "./add-measure-dialog.page";
 import { withProject } from "#view/components/with-project.hoc.tsx";
 import { useAppDispatch, useAppSelector } from "#application/hooks/use-app-redux.hook.ts";
 
@@ -520,6 +521,7 @@ const ThreatsPageBody = () => {
                 <Routes>
                     <Route path="edit" element={<ThreatDialogPage />} />
                     <Route path="measureImpacts/edit" element={<MeasureImpactByMeasureDialogPage />} />
+                    <Route path="measures/add" element={<AddMeasureDialogPage />} />
                 </Routes>
             </Page>
         </Box>

--- a/apps/frontend/src/view/pages/threats.page.tsx
+++ b/apps/frontend/src/view/pages/threats.page.tsx
@@ -520,8 +520,9 @@ const ThreatsPageBody = () => {
                 </Box>
                 <Routes>
                     <Route path="edit" element={<ThreatDialogPage />} />
-                    <Route path="measureImpacts/edit" element={<MeasureImpactByMeasureDialogPage />} />
-                    <Route path="measures/add" element={<AddMeasureDialogPage />} />
+                    <Route path="measureImpacts/edit" element={<MeasureImpactByMeasureDialogPage />}>
+                        <Route path="measures/add" element={<AddMeasureDialogPage />} />
+                    </Route>
                 </Routes>
             </Page>
         </Box>


### PR DESCRIPTION
When applying measures to threats, stay on the respective tab in the edit measure / edit threat dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialogs can now reopen with the last selected tab restored, including after navigating to related flows.
  * Threat and measure-related dialogs support opening directly on a specific tab/section.
  * Added support for the new **measures/add** route under the measures area.

* **Bug Fixes**
  * “Apply measure” and “edit measure impact” navigation now resolves the correct destination across different sections and preserves the expected navigation context.
  * Measure selection dropdown behavior is now properly controlled (open/close).

* **Improvements**
  * Measure lists no longer clear during certain refreshes, preserving stale data until new results arrive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->