### PR TITLE
feat(report): add components chapter with linked threat references

### DIFF
--- a/apps/backend/src/services/projects.service.ts
+++ b/apps/backend/src/services/projects.service.ts
@@ -176,6 +176,20 @@ export async function getReportData(projectId: number) {
     // Gets the images of the parsed system.
     const { image = null } = system || {};
 
+    // Gets the components of the parsed system, sorted and tagged with report ids.
+    const componentReportIdsDict = new Map<string, string>();
+    const components = (system?.data?.components ?? [])
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((component, index) => {
+            const reportId = "C." + (index + 1);
+            componentReportIdsDict.set(component.id, reportId);
+            return {
+                ...component,
+                reportId,
+            };
+        });
+
     // Get all the threats of the project.
     let threats = await getThreats(projectId);
 
@@ -187,6 +201,10 @@ export async function getReportData(projectId: number) {
         if (pointOfAttack?.type === "COMMUNICATION_INTERFACES") {
             threat.componentName = pointOfAttack.componentName + " > " + pointOfAttack.name;
         }
+
+        threat.componentReportId = pointOfAttack?.componentId
+            ? (componentReportIdsDict.get(pointOfAttack.componentId) ?? null)
+            : null;
 
         return threat;
     });
@@ -241,6 +259,7 @@ export async function getReportData(projectId: number) {
     return {
         systemImage: image,
         project: project,
+        components: components,
         assets: assetsWithIds,
         threats: threatsWithIds,
         measures: transformMeasures(measuresWithIds, threatsWithIds, measureImpacts),

--- a/apps/backend/src/services/threats.service.ts
+++ b/apps/backend/src/services/threats.service.ts
@@ -38,6 +38,7 @@ export type ExtendedThreat = Threat & {
     assets: Asset[];
     componentName: string | null;
     componentType: number | ComponentType | null;
+    componentReportId?: string | null;
     interfaceName: string | null;
 };
 

--- a/apps/backend/tests/report.test.ts
+++ b/apps/backend/tests/report.test.ts
@@ -17,6 +17,34 @@ const VALID_PROJECT: Omit<InstanceType<typeof CreateProjectRequest>, "catalogId"
     confidentialityLevel: CONFIDENTIALITY_LEVELS.INTERNAL,
 };
 
+function makeSystemBody(componentNames: string[], description?: string) {
+    return {
+        data: {
+            connections: [],
+            pointsOfAttack: [],
+            connectionPoints: [],
+            annotations: [],
+            lastAutoSaveDate: "2025-01-01T00:00:00.000Z",
+            components: componentNames.map((name, index) => ({
+                id: "comp-" + index,
+                name,
+                description,
+                type: 0,
+                x: 0,
+                y: 0,
+                gridX: 0,
+                gridY: 0,
+                width: 80,
+                height: 80,
+                selected: false,
+                projectId: 0,
+                symbol: "",
+            })),
+        },
+        image: "",
+    };
+}
+
 let projectId: number;
 let cookies: string[];
 let csrfToken: string;
@@ -69,5 +97,55 @@ describe("report", () => {
             .set("X-CSRF-TOKEN", csrfToken)
             .set("Cookie", cookies);
         expect(res.statusCode).toEqual(200);
+    });
+
+    it("should include a components array in the report", async () => {
+        const res = await request(app)
+            .get("/api/projects/" + projectId + "/report")
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+        expect(res.statusCode).toEqual(200);
+        expect(Array.isArray(res.body.components)).toBe(true);
+    });
+
+    it("sorts components by name and tags them with sequential report ids", async () => {
+        // Save a system whose components are intentionally out of alphabetical order.
+        await request(app)
+            .put("/api/projects/" + projectId + "/system")
+            .send(makeSystemBody(["Zebra Service", "Alpha Service"]))
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+
+        const res = await request(app)
+            .get("/api/projects/" + projectId + "/report")
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.components.map((component: { name: string }) => component.name)).toEqual([
+            "Alpha Service",
+            "Zebra Service",
+        ]);
+        expect(res.body.components.map((component: { reportId: string }) => component.reportId)).toEqual([
+            "C.1",
+            "C.2",
+        ]);
+    });
+
+    it("carries the component description through into the report", async () => {
+        await request(app)
+            .put("/api/projects/" + projectId + "/system")
+            .send(makeSystemBody(["Only Component"], "A described component."))
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+
+        const res = await request(app)
+            .get("/api/projects/" + projectId + "/report")
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.components).toHaveLength(1);
+        expect(res.body.components[0].description).toEqual("A described component.");
     });
 });

--- a/apps/frontend/src/api/types/project.types.ts
+++ b/apps/frontend/src/api/types/project.types.ts
@@ -5,6 +5,7 @@ import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
 import type { Measure } from "#api/types/measure.types.ts";
 import type { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 import type { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
+import type { Component } from "#api/types/system.types.ts";
 import type { Threat } from "#api/types/threat.types.ts";
 import type { USER_ROLES } from "#api/types/user-roles.types.ts";
 import type { MatrixColorKey } from "#view/colors/matrix.ts";
@@ -40,10 +41,12 @@ export interface ExtendedProject extends Project {
 export interface ProjectReport {
     systemImage: string | null;
     project: Project;
+    components: (Component & { reportId: string })[];
     assets: (Asset & { reportId: string })[];
     threats: (Threat & {
         componentName: string | null;
         componentType: number | STANDARD_COMPONENT_TYPES | null;
+        componentReportId: string | null;
         interfaceName: string | null;
         damage: number;
         risk: number;

--- a/apps/frontend/src/api/types/system.types.ts
+++ b/apps/frontend/src/api/types/system.types.ts
@@ -1,5 +1,5 @@
+import type { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
 import type { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts";
-import type { POINTS_OF_ATTACK } from "./points-of-attack.types";
 
 export interface UpdateSystemRequest {
     projectId: number;

--- a/apps/frontend/src/application/hooks/use-report.hook.ts
+++ b/apps/frontend/src/application/hooks/use-report.hook.ts
@@ -89,6 +89,7 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     const [showMethodExplanation, setShowMethodExplanation] = useState<boolean>(true);
     const [showScaleExplanation, setShowScaleExplanation] = useState<boolean>(true);
     const [showMatrixPage, setShowMatrixPage] = useState<boolean>(true);
+    const [showComponentsPage, setShowComponentsPage] = useState<boolean>(true);
     const [showAssetsPage, setShowAssetsPage] = useState<boolean>(true);
     const [showMeasuresPage, setShowMeasuresPage] = useState<boolean>(true);
     const [showThreatListPage, setShowThreatListPage] = useState<boolean>(true);
@@ -582,6 +583,7 @@ export const useReport = ({ projectId }: { projectId: number }) => {
         showMethodExplanation,
         showScaleExplanation,
         showMatrixPage,
+        showComponentsPage,
         showAssetsPage,
         showMeasuresPage,
         showThreatListPage,
@@ -601,6 +603,7 @@ export const useReport = ({ projectId }: { projectId: number }) => {
         setShowMethodExplanation,
         setShowScaleExplanation,
         setShowMatrixPage,
+        setShowComponentsPage,
         setShowAssetsPage,
         setShowMeasuresPage,
         setShowThreatListPage,

--- a/apps/frontend/src/translations/de/report-page.de.json
+++ b/apps/frontend/src/translations/de/report-page.de.json
@@ -5,6 +5,7 @@
   "methodExplanation": "Methodikerklärung anzeigen",
   "scaleExplanation": "Stufenerklärung für Schaden und Wahrscheinlichkeit anzeigen",
   "matrixPage": "Matrixseite anzeigen",
+  "componentPage": "Komponentenseite anzeigen",
   "assetPage": "Assetseite anzeigen",
   "measuresPage": "Maßnahmenseite anzeigen",
   "threatListPage": "Bedrohungsliste anzeigen",

--- a/apps/frontend/src/translations/de/report.de.json
+++ b/apps/frontend/src/translations/de/report.de.json
@@ -2,6 +2,7 @@
   "attackersHeader": "Angreifer",
   "pointsOfAttackHeader": "Angriffspunkte",
   "component": "Komponente",
+  "components": "Komponenten",
   "systemImage": "Systembild",
   "protectionNeeds": "Schutzbedarf",
   "riskList": "Auflistung der Bedrohungen",

--- a/apps/frontend/src/translations/en/report-page.en.json
+++ b/apps/frontend/src/translations/en/report-page.en.json
@@ -5,6 +5,7 @@
   "methodExplanation": "Show Method Explanation",
   "scaleExplanation": "Show Damage And Probability Scale Explanation",
   "matrixPage": "Show Matrix Page",
+  "componentPage": "Show Component Page",
   "assetPage": "Show Asset Page",
   "measuresPage": "Show Measures Page",
   "threatListPage": "Show List Of Threats",

--- a/apps/frontend/src/translations/en/report.en.json
+++ b/apps/frontend/src/translations/en/report.en.json
@@ -2,6 +2,7 @@
   "attackersHeader": "Attackers",
   "pointsOfAttackHeader": "Points Of Attack",
   "component": "Component",
+  "components": "Components",
   "systemImage": "System Image",
   "protectionNeeds": "Protection Needs",
   "riskList": "List of Threats",

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -46,6 +46,7 @@ interface PdfDocumentToolbarProps {
     showMethodExplanation: boolean;
     showScaleExplanation: boolean;
     showMatrixPage: boolean;
+    showComponentsPage: boolean;
     showAssetsPage: boolean;
     showMeasuresPage: boolean;
     showThreatListPage: boolean;
@@ -83,6 +84,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
         showMethodExplanation,
         showScaleExplanation,
         showMatrixPage,
+        showComponentsPage,
         showAssetsPage,
         showMeasuresPage,
         showThreatListPage,
@@ -102,6 +104,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
         setShowMethodExplanation,
         setShowScaleExplanation,
         setShowMatrixPage,
+        setShowComponentsPage,
         setShowAssetsPage,
         setShowMeasuresPage,
         setShowThreatListPage,
@@ -158,6 +161,11 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
 
     const onChangeShowMatrixPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
         setShowMatrixPage(value);
+        setIsChanged(true);
+    };
+
+    const onChangeShowComponentsPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
+        setShowComponentsPage(value);
         setIsChanged(true);
     };
 
@@ -246,6 +254,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
             showMethodExplanation,
             showScaleExplanation,
             showMatrixPage,
+            showComponentsPage,
             showAssetsPage,
             showMeasuresPage,
             showThreatListPage,
@@ -366,6 +375,20 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                                     <FormControlLabel
                                         control={<Switch checked={showMatrixPage} onChange={onChangeShowMatrixPage} />}
                                         label={<Typography sx={{ fontSize: "0.875rem" }}>{t("matrixPage")}</Typography>}
+                                        labelPlacement="end"
+                                    />
+                                </FormControl>
+                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
+                                    <FormControlLabel
+                                        control={
+                                            <Switch
+                                                checked={showComponentsPage}
+                                                onChange={onChangeShowComponentsPage}
+                                            />
+                                        }
+                                        label={
+                                            <Typography sx={{ fontSize: "0.875rem" }}>{t("componentPage")}</Typography>
+                                        }
                                         labelPlacement="end"
                                     />
                                 </FormControl>
@@ -714,6 +737,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                                     showMethodExplanation={showMethodExplanation}
                                     showScaleExplanation={showScaleExplanation}
                                     showMatrixPage={showMatrixPage}
+                                    showComponentsPage={showComponentsPage}
                                     showAssetsPage={showAssetsPage}
                                     showMeasuresPage={showMeasuresPage}
                                     showThreatListPage={showThreatListPage}

--- a/apps/frontend/src/view/report/download-markdown-report.ts
+++ b/apps/frontend/src/view/report/download-markdown-report.ts
@@ -21,6 +21,7 @@ interface MarkdownDownloadState {
     showMethodExplanation?: boolean;
     showScaleExplanation?: boolean;
     showMatrixPage?: boolean;
+    showComponentsPage?: boolean;
     showAssetsPage?: boolean;
     showMeasuresPage?: boolean;
     showThreatListPage?: boolean;
@@ -47,6 +48,7 @@ export function downloadMarkdownReport({
     showMethodExplanation,
     showScaleExplanation,
     showMatrixPage,
+    showComponentsPage,
     showAssetsPage,
     showMeasuresPage,
     showThreatListPage,
@@ -67,6 +69,7 @@ export function downloadMarkdownReport({
         showMethodExplanation,
         showScaleExplanation,
         showMatrixPage,
+        showComponentsPage,
         showAssetsPage,
         showMeasuresPage,
         showThreatListPage,

--- a/apps/frontend/src/view/report/pages/componentsDetails.report.page.tsx
+++ b/apps/frontend/src/view/report/pages/componentsDetails.report.page.tsx
@@ -1,0 +1,107 @@
+import { View } from "@react-pdf/renderer";
+import type { IndexCallback, Project, ProjectReport } from "#api/types/project.types.ts";
+import { backgroundColor, s1 } from "#view/report/report.style.ts";
+import { Page } from "#view/report/components/page.report.component.tsx";
+import { useTranslation } from "react-i18next";
+import { Text } from "#view/report/components/text.report.component.tsx";
+import { colors } from "#view/wrappers/color-tokens.ts";
+
+type ComponentWithReportId = ProjectReport["components"][number];
+
+interface ComponentsDetailsPageProps {
+    indexCallback: IndexCallback;
+    language: string;
+    project: Project;
+    logo?: string;
+    date: string;
+    components: ComponentWithReportId[];
+}
+
+interface ComponentCardProps extends ComponentWithReportId {
+    language: string;
+}
+
+export const ComponentsDetailsPage = ({
+    indexCallback,
+    language,
+    project,
+    logo,
+    date,
+    components,
+}: ComponentsDetailsPageProps) => {
+    const linkId = "componentsDetails";
+    const { t } = useTranslation("report", { lng: language });
+    return (
+        <Page
+            logo={logo}
+            projectName={project.name}
+            date={date}
+            confidentialityLevel={t("confidentialityLevels." + project.confidentialityLevel)}
+        >
+            <View
+                render={({ pageNumber }) => {
+                    indexCallback(pageNumber, t("components"), linkId);
+                    return null;
+                }}
+            />
+            <Text
+                id={`chapter-${linkId}`}
+                size="header"
+                style={{
+                    marginBottom: s1,
+                }}
+            >
+                {t("components")}
+            </Text>
+            {components.map((component, i) => {
+                return <ComponentCard key={i} language={language} {...component} />;
+            })}
+        </Page>
+    );
+};
+
+const ComponentCard = ({ name, description, reportId, language }: ComponentCardProps) => {
+    const { t } = useTranslation("report", { lng: language });
+    return (
+        <View
+            id={reportId}
+            wrap={false}
+            style={{
+                backgroundColor,
+                padding: s1,
+                marginBottom: s1,
+                borderRadius: 10,
+            }}
+        >
+            <View
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "stretch",
+                    backgroundColor: colors.surface.paperWhite,
+                    borderRadius: 10,
+                    padding: s1,
+                }}
+            >
+                <Text style={{ fontWeight: 600 }}>
+                    {reportId} {name}
+                </Text>
+                {description && (
+                    <View
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "stretch",
+                            marginTop: s1,
+                        }}
+                    >
+                        <Text size="small" style={{ fontWeight: 600 }}>
+                            {t("description")}:
+                        </Text>
+                        <Text size="small">{description}</Text>
+                    </View>
+                )}
+            </View>
+        </View>
+    );
+};

--- a/apps/frontend/src/view/report/pages/threatsDetails.report.page.tsx
+++ b/apps/frontend/src/view/report/pages/threatsDetails.report.page.tsx
@@ -21,10 +21,16 @@ interface ThreatsDetailsPageProps {
     logo: string | undefined;
     date: string;
     threats: ThreatReport[];
+    showComponentsPage: boolean;
+    showAssetsPage: boolean;
+    showMeasuresPage: boolean;
 }
 
 interface ThreatCardProps extends ThreatReport {
     language: string;
+    showComponentsPage: boolean;
+    showAssetsPage: boolean;
+    showMeasuresPage: boolean;
 }
 
 interface RiskInfoProps {
@@ -52,6 +58,7 @@ interface HeaderProps {
 interface InformationsProps {
     componentName: ReportThreat["componentName"];
     componentReportId: ReportThreat["componentReportId"];
+    showComponentsPage: boolean;
     attacker: ReportThreat["attacker"];
     pointOfAttack: ReportThreat["pointOfAttack"];
     language: string;
@@ -65,12 +72,14 @@ interface DescriptionProps {
 
 interface AssetsListProps {
     assets: ThreatAsset[];
+    showAssetsPage: boolean;
 }
 
 interface MeasuresListProps {
     measures: ThreatMeasure[];
     style?: Style;
     language: string;
+    showMeasuresPage: boolean;
 }
 
 const LIST_BREAKPOINT = 30;
@@ -82,6 +91,9 @@ export const ThreatsDetailsPage = ({
     logo,
     date,
     threats,
+    showComponentsPage,
+    showAssetsPage,
+    showMeasuresPage,
 }: ThreatsDetailsPageProps) => {
     const linkId = "riskDetails";
     const { t } = useTranslation("report", { lng: language });
@@ -108,7 +120,16 @@ export const ThreatsDetailsPage = ({
                 {t("threats")}
             </Text>
             {threats.map((threat, i) => {
-                return <ThreatCard key={i} language={language} {...threat} />;
+                return (
+                    <ThreatCard
+                        key={i}
+                        language={language}
+                        showComponentsPage={showComponentsPage}
+                        showAssetsPage={showAssetsPage}
+                        showMeasuresPage={showMeasuresPage}
+                        {...threat}
+                    />
+                );
             })}
         </Page>
     );
@@ -129,6 +150,9 @@ const ThreatCard = ({
     attacker,
     pointOfAttack,
     language,
+    showComponentsPage,
+    showAssetsPage,
+    showMeasuresPage,
     bruttoColor,
     nettoColor,
     damage,
@@ -210,19 +234,25 @@ const ThreatCard = ({
                         <Informations
                             componentName={componentName}
                             componentReportId={componentReportId}
+                            showComponentsPage={showComponentsPage}
                             attacker={attacker}
                             pointOfAttack={pointOfAttack}
                             {...props}
                             language={language}
                         />
-                        <AssetsList assets={assets} />
+                        <AssetsList assets={assets} showAssetsPage={showAssetsPage} />
                     </View>
                     <Description style={{ flex: 1, marginLeft: s1 }} language={language}>
                         {description}
                     </Description>
                 </View>
                 {measures && measures.length > 0 && (
-                    <MeasuresList measures={measures} language={language} style={{ marginTop: s1 }} />
+                    <MeasuresList
+                        measures={measures}
+                        language={language}
+                        showMeasuresPage={showMeasuresPage}
+                        style={{ marginTop: s1 }}
+                    />
                 )}
             </View>
         </View>
@@ -447,7 +477,14 @@ const Header = ({ language, reportId, id, name, confidentiality, integrity, avai
     );
 };
 
-const Informations = ({ componentName, componentReportId, attacker, pointOfAttack, language }: InformationsProps) => {
+const Informations = ({
+    componentName,
+    componentReportId,
+    showComponentsPage,
+    attacker,
+    pointOfAttack,
+    language,
+}: InformationsProps) => {
     const { t } = useTranslation("report", { lng: language });
     return (
         <View
@@ -461,7 +498,7 @@ const Informations = ({ componentName, componentReportId, attacker, pointOfAttac
             <Text size="small" style={{ fontWeight: 600 }}>
                 {t("component")}
             </Text>
-            {componentReportId ? (
+            {componentReportId && showComponentsPage ? (
                 <Link src={`#${componentReportId}`} style={{ textDecoration: "none" }}>
                     <Text size="small" style={{ marginLeft: s2 }}>
                         {componentReportId} {componentName}
@@ -507,38 +544,31 @@ const Description = ({ style, children, language }: DescriptionProps) => {
     );
 };
 
-const AssetsList = ({ assets }: AssetsListProps) => {
+const AssetsList = ({ assets, showAssetsPage }: AssetsListProps) => {
     return (
         <View>
             <Text size="small" style={{ fontWeight: 600 }}>
                 Assets
             </Text>
             {assets.map((asset, j) => {
-                return (
-                    <Link
-                        key={asset.id}
-                        src={`#${asset.reportId}`}
-                        style={{
-                            textDecoration: "none",
-                        }}
-                    >
-                        <Text
-                            size="small"
-                            key={j}
-                            style={{
-                                marginTop: s1 / 4,
-                            }}
-                        >
-                            {asset.reportId} {asset.name}
-                        </Text>
+                const label = (
+                    <Text size="small" key={j} style={{ marginTop: s1 / 4 }}>
+                        {asset.reportId} {asset.name}
+                    </Text>
+                );
+                return showAssetsPage ? (
+                    <Link key={asset.id} src={`#${asset.reportId}`} style={{ textDecoration: "none" }}>
+                        {label}
                     </Link>
+                ) : (
+                    <View key={asset.id}>{label}</View>
                 );
             })}
         </View>
     );
 };
 
-const MeasuresList = ({ measures, style, language }: MeasuresListProps) => {
+const MeasuresList = ({ measures, style, language, showMeasuresPage }: MeasuresListProps) => {
     const { t } = useTranslation("report", { lng: language });
     return (
         <View {...style}>
@@ -547,6 +577,11 @@ const MeasuresList = ({ measures, style, language }: MeasuresListProps) => {
             </Text>
             {measures.map((measure, i) => {
                 const { reportId, name, description } = measure;
+                const label = (
+                    <Text size="small" style={{ marginTop: s1 / 4 }}>
+                        {`${reportId} ${name}`}
+                    </Text>
+                );
                 return (
                     <View
                         key={i}
@@ -556,17 +591,13 @@ const MeasuresList = ({ measures, style, language }: MeasuresListProps) => {
                             marginTop: s1 / 2,
                         }}
                     >
-                        <Link
-                            style={{
-                                color: fontColor,
-                                textDecoration: "none",
-                            }}
-                            src={`#measure-${reportId}`}
-                        >
-                            <Text size="small" style={{ marginTop: s1 / 4 }}>
-                                {`${reportId} ${name}`}
-                            </Text>
-                        </Link>
+                        {showMeasuresPage ? (
+                            <Link style={{ color: fontColor, textDecoration: "none" }} src={`#measure-${reportId}`}>
+                                {label}
+                            </Link>
+                        ) : (
+                            label
+                        )}
                         <Text size="small" style={{ marginLeft: s2, fontStyle: "italic" }}>
                             {description}
                         </Text>

--- a/apps/frontend/src/view/report/pages/threatsDetails.report.page.tsx
+++ b/apps/frontend/src/view/report/pages/threatsDetails.report.page.tsx
@@ -51,6 +51,7 @@ interface HeaderProps {
 
 interface InformationsProps {
     componentName: ReportThreat["componentName"];
+    componentReportId: ReportThreat["componentReportId"];
     attacker: ReportThreat["attacker"];
     pointOfAttack: ReportThreat["pointOfAttack"];
     language: string;
@@ -124,6 +125,7 @@ const ThreatCard = ({
     measures,
     assets,
     componentName,
+    componentReportId,
     attacker,
     pointOfAttack,
     language,
@@ -207,6 +209,7 @@ const ThreatCard = ({
                     >
                         <Informations
                             componentName={componentName}
+                            componentReportId={componentReportId}
                             attacker={attacker}
                             pointOfAttack={pointOfAttack}
                             {...props}
@@ -444,7 +447,7 @@ const Header = ({ language, reportId, id, name, confidentiality, integrity, avai
     );
 };
 
-const Informations = ({ componentName, attacker, pointOfAttack, language }: InformationsProps) => {
+const Informations = ({ componentName, componentReportId, attacker, pointOfAttack, language }: InformationsProps) => {
     const { t } = useTranslation("report", { lng: language });
     return (
         <View
@@ -458,9 +461,17 @@ const Informations = ({ componentName, attacker, pointOfAttack, language }: Info
             <Text size="small" style={{ fontWeight: 600 }}>
                 {t("component")}
             </Text>
-            <Text size="small" style={{ marginLeft: s2 }}>
-                {componentName}
-            </Text>
+            {componentReportId ? (
+                <Link src={`#${componentReportId}`} style={{ textDecoration: "none" }}>
+                    <Text size="small" style={{ marginLeft: s2 }}>
+                        {componentReportId} {componentName}
+                    </Text>
+                </Link>
+            ) : (
+                <Text size="small" style={{ marginLeft: s2 }}>
+                    {componentName}
+                </Text>
+            )}
             <Text size="small" style={{ fontWeight: 600 }}>
                 {t("attackersHeader")}
             </Text>

--- a/apps/frontend/src/view/report/report-md.test.ts
+++ b/apps/frontend/src/view/report/report-md.test.ts
@@ -145,6 +145,57 @@ describe("generateMarkdownReport – line break preservation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Components section
+// ---------------------------------------------------------------------------
+
+describe("generateMarkdownReport – components section", () => {
+    it("omits the components section when showComponentsPage is false", () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", showComponentsPage: false });
+        expect(md).not.toContain("chapter-componentsDetails");
+    });
+
+    it("omits the components section when there are no components", () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", data: { ...report, components: [] } });
+        // The section heading (not the table-of-contents entry) is what gets suppressed on an empty list.
+        expect(md).not.toContain(`## <a id="chapter-componentsDetails"></a>`);
+        expect(md).not.toContain(`<a id="component-`);
+    });
+
+    it("renders a component heading with its report id, name and anchor", () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en" });
+        expect(md).toContain(`### <a id="component-C.1"></a>C.1 Database Server`);
+    });
+
+    it("links a threat to its component when componentReportId is set", () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en" });
+        expect(md).toContain("**Component:** [C.1 Database Server](#component-C.1)");
+    });
+
+    it("renders the threat component as plain text (no dangling link) when showComponentsPage is false", () => {
+        const md = generateMarkdownReport({ ...BASE_OPTIONS, language: "en", showComponentsPage: false });
+        expect(md).toContain("**Component:** Database Server");
+        expect(md).not.toContain("(#component-C.1)");
+    });
+
+    it("renders a component heading but no description block when the component has no description", () => {
+        const component = { ...report.components[0]!, description: "" };
+        const md = generateMarkdownReport({
+            ...BASE_OPTIONS,
+            language: "en",
+            data: { ...report, components: [component] },
+            // Disable sibling sections so the only "**Description:**" that could appear is the component's.
+            showCoverPage: false,
+            showAssetsPage: false,
+            showMeasuresPage: false,
+            showThreatListPage: false,
+            showThreatsPage: false,
+        });
+        expect(md).toContain(`### <a id="component-C.1"></a>C.1 Database Server`);
+        expect(md).not.toContain("**Description:**");
+    });
+});
+
+// ---------------------------------------------------------------------------
 // Matrix rendering
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -641,8 +641,6 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[], linkOpti
         );
         lines.push("");
 
-        // Only link to the components chapter when it is actually rendered; otherwise the "C.x"
-        // report id has no target and no meaning, so fall back to the plain component name.
         if (threat.componentReportId && linkOptions.linkComponents) {
             const componentLinkText = escapeLinkText(`${threat.componentReportId} ${threat.componentName ?? ""}`);
             const componentLink = `[${componentLinkText}](#${componentAnchorId(threat.componentReportId)})`;

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -15,6 +15,7 @@ type ReportMeasure = Omit<ProjectReport["measures"][number], "scheduledAt"> & {
     reportId?: string;
 };
 type AssetWithReportId = ProjectReport["assets"][number];
+type ComponentWithReportId = ProjectReport["components"][number];
 
 export interface MarkdownReportOptions {
     data: ProjectReport & { milestones?: Milestone[] | null | undefined };
@@ -27,6 +28,7 @@ export interface MarkdownReportOptions {
     showMethodExplanation?: boolean | undefined;
     showScaleExplanation?: boolean | undefined;
     showMatrixPage?: boolean | undefined;
+    showComponentsPage?: boolean | undefined;
     showAssetsPage?: boolean | undefined;
     showMeasuresPage?: boolean | undefined;
     showThreatListPage?: boolean | undefined;
@@ -65,6 +67,7 @@ interface Translations {
     threats: string;
     name: string;
     component: string;
+    components: string;
     description: string;
     confidentiality: string;
     integrity: string;
@@ -128,6 +131,7 @@ function buildTranslations(language: string): Translations {
         threats: t("threats"),
         name: t("name"),
         component: t("component"),
+        components: t("components"),
         description: t("description"),
         confidentiality: t("confidentiality"),
         integrity: t("integrity"),
@@ -247,6 +251,10 @@ function threatAnchorId(reportId: string): string {
 
 function assetAnchorId(reportId: string): string {
     return `asset-${reportId}`;
+}
+
+function componentAnchorId(reportId: string): string {
+    return `component-${reportId}`;
 }
 
 function measureAnchorId(reportId: string): string {
@@ -460,6 +468,28 @@ function matrixSection(
     return lines.join("\n");
 }
 
+function componentsSection(T: Translations, components: ComponentWithReportId[]): string {
+    const lines: string[] = [];
+    lines.push(`## ${anchor("chapter-componentsDetails")}${T.components}`);
+    lines.push("");
+
+    components.forEach((component) => {
+        lines.push(
+            `### ${anchor(componentAnchorId(component.reportId))}${escapeInline(component.reportId)} ${escapeInline(component.name)}`
+        );
+        lines.push("");
+
+        if (component.description) {
+            lines.push(`**${T.description}:**`);
+            lines.push("");
+            lines.push(escapeBlock(component.description));
+            lines.push("");
+        }
+    });
+
+    return lines.join("\n");
+}
+
 function assetsSection(T: Translations, assets: AssetWithReportId[]): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-assetsDetails")}${T.assets}`);
@@ -567,7 +597,13 @@ function threatsListSection(T: Translations, threats: ThreatReport[]): string {
     return lines.join("\n");
 }
 
-function threatsDetailSection(T: Translations, threats: ThreatReport[]): string {
+interface ThreatLinkOptions {
+    linkComponents: boolean;
+    linkAssets: boolean;
+    linkMeasures: boolean;
+}
+
+function threatsDetailSection(T: Translations, threats: ThreatReport[], linkOptions: ThreatLinkOptions): string {
     const lines: string[] = [];
     lines.push(`## ${anchor("chapter-riskDetails")}${T.threats}`);
     lines.push("");
@@ -605,7 +641,15 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
         );
         lines.push("");
 
-        lines.push(`**${T.component}:** ${escapeInline(threat.componentName ?? "–")}`);
+        // Only link to the components chapter when it is actually rendered; otherwise the "C.x"
+        // report id has no target and no meaning, so fall back to the plain component name.
+        if (threat.componentReportId && linkOptions.linkComponents) {
+            const componentLinkText = escapeLinkText(`${threat.componentReportId} ${threat.componentName ?? ""}`);
+            const componentLink = `[${componentLinkText}](#${componentAnchorId(threat.componentReportId)})`;
+            lines.push(`**${T.component}:** ${componentLink}`);
+        } else {
+            lines.push(`**${T.component}:** ${escapeInline(threat.componentName ?? "–")}`);
+        }
         lines.push("");
         lines.push(`**${T.attackersHeader}:** ${attackerName}`);
         lines.push("");
@@ -624,9 +668,12 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
             lines.push("");
             threat.assets.forEach((asset) => {
                 const assetRid = asset.reportId ?? String(asset.id);
-                const linkText = escapeLinkText(`${assetRid} ${asset.name ?? ""}`);
-                const link = `[${linkText}](#${assetAnchorId(assetRid)})`;
-                lines.push(`- ${link}`);
+                const label = `${assetRid} ${asset.name ?? ""}`;
+                if (linkOptions.linkAssets) {
+                    lines.push(`- [${escapeLinkText(label)}](#${assetAnchorId(assetRid)})`);
+                } else {
+                    lines.push(`- ${escapeInline(label)}`);
+                }
             });
             lines.push("");
         }
@@ -636,12 +683,14 @@ function threatsDetailSection(T: Translations, threats: ThreatReport[]): string 
             lines.push("");
             threat.measures.forEach((measure) => {
                 const mRid = measure.reportId ?? String(measure.measureId);
-                const linkText = escapeLinkText(`${mRid} ${measure.name ?? ""}`);
-                const link = `[${linkText}](#${measureAnchorId(mRid)})`;
+                const label = `${mRid} ${measure.name ?? ""}`;
+                const rendered = linkOptions.linkMeasures
+                    ? `[${escapeLinkText(label)}](#${measureAnchorId(mRid)})`
+                    : escapeInline(label);
                 if (measure.description) {
-                    lines.push(`- ${link}<br>*${escapeInline(measure.description)}*`);
+                    lines.push(`- ${rendered}<br>*${escapeInline(measure.description)}*`);
                 } else {
-                    lines.push(`- ${link}`);
+                    lines.push(`- ${rendered}`);
                 }
             });
             lines.push("");
@@ -667,6 +716,7 @@ export function generateMarkdownReport(options: MarkdownReportOptions): string {
         showMethodExplanation = true,
         showScaleExplanation = true,
         showMatrixPage = true,
+        showComponentsPage = true,
         showAssetsPage = true,
         showMeasuresPage = true,
         showThreatListPage = true,
@@ -692,6 +742,9 @@ export function generateMarkdownReport(options: MarkdownReportOptions): string {
     }
     if (showMatrixPage) {
         chapters.push({ label: T.riskMatrices, id: "chapter-matrix" });
+    }
+    if (showComponentsPage) {
+        chapters.push({ label: T.components, id: "chapter-componentsDetails" });
     }
     if (showAssetsPage) {
         chapters.push({ label: T.assets, id: "chapter-assetsDetails" });
@@ -732,6 +785,10 @@ export function generateMarkdownReport(options: MarkdownReportOptions): string {
         sections.push(matrixSection(T, bruttoMatrix, nettoMatrix, tillScheduledAt, data.milestones));
     }
 
+    if (showComponentsPage && data.components.length > 0) {
+        sections.push(componentsSection(T, data.components));
+    }
+
     if (showAssetsPage && data.assets.length > 0) {
         sections.push(assetsSection(T, data.assets));
     }
@@ -745,7 +802,13 @@ export function generateMarkdownReport(options: MarkdownReportOptions): string {
     }
 
     if (showThreatsPage && data.threats.length > 0) {
-        sections.push(threatsDetailSection(T, data.threats));
+        sections.push(
+            threatsDetailSection(T, data.threats, {
+                linkComponents: showComponentsPage && data.components.length > 0,
+                linkAssets: showAssetsPage && data.assets.length > 0,
+                linkMeasures: showMeasuresPage && data.measures.length > 0,
+            })
+        );
     }
 
     return sections.join(`\n${hr()}\n`);

--- a/apps/frontend/src/view/report/report.tsx
+++ b/apps/frontend/src/view/report/report.tsx
@@ -189,6 +189,9 @@ export const Report: FC<ReportProps> = ({
                         logo={logo}
                         indexCallback={addToIndex}
                         date={date}
+                        showComponentsPage={showComponentsPage}
+                        showAssetsPage={showAssetsPage}
+                        showMeasuresPage={showMeasuresPage}
                         {...data}
                     />
                 )}

--- a/apps/frontend/src/view/report/report.tsx
+++ b/apps/frontend/src/view/report/report.tsx
@@ -16,6 +16,7 @@ import poppinsSemiBold from "./font/Poppins_SemiBold_600.ttf";
 import poppinsBold from "./font/Poppins_Bold_700.ttf";
 import poppinsExtraBold from "./font/Poppins_ExtraBold_800.ttf";
 import { AssetsDetailsPage } from "./pages/assetsDetails.report.page";
+import { ComponentsDetailsPage } from "./pages/componentsDetails.report.page";
 import { MeasuresDetailsPage } from "./pages/measures.report.page";
 import { Translations } from "#view/wrappers/translations.wrapper.tsx";
 import type { Index, ProjectReport } from "#api/types/project.types.ts";
@@ -61,6 +62,7 @@ interface ReportProps {
     showMethodExplanation?: boolean;
     showScaleExplanation?: boolean;
     showMatrixPage?: boolean;
+    showComponentsPage?: boolean;
     showAssetsPage?: boolean;
     showMeasuresPage?: boolean;
     showThreatListPage?: boolean;
@@ -81,6 +83,7 @@ export const Report: FC<ReportProps> = ({
     showMethodExplanation = true,
     showScaleExplanation = true,
     showMatrixPage = true,
+    showComponentsPage = true,
     showAssetsPage = true,
     showMeasuresPage = true,
     showThreatListPage = true,
@@ -162,6 +165,9 @@ export const Report: FC<ReportProps> = ({
                         nettoMatrix={nettoMatrix}
                         {...data}
                     />
+                )}
+                {showComponentsPage && (
+                    <ComponentsDetailsPage indexCallback={addToIndex} language={language} date={date} {...data} />
                 )}
                 {showAssetsPage && (
                     <AssetsDetailsPage indexCallback={addToIndex} language={language} date={date} {...data} />

--- a/apps/frontend/src/view/report/testData/expected-report.de.md
+++ b/apps/frontend/src/view/report/testData/expected-report.de.md
@@ -20,10 +20,11 @@ With line breaks.
 1. [Die 4x6 Methodik](#chapter-methodExplanation)
 2. [Erklärung der Wahrscheinlichkeits- und Schadensskala](#chapter-explanationScale)
 3. [Risiko Matrizen](#chapter-matrix)
-4. [Assets](#chapter-assetsDetails)
-5. [Maßnahmen](#chapter-measuresDetails)
-6. [Auflistung der Bedrohungen](#chapter-riskList)
-7. [Bedrohungen](#chapter-riskDetails)
+4. [Komponenten](#chapter-componentsDetails)
+5. [Assets](#chapter-assetsDetails)
+6. [Maßnahmen](#chapter-measuresDetails)
+7. [Auflistung der Bedrohungen](#chapter-riskList)
+8. [Bedrohungen](#chapter-riskDetails)
 
 ---
 
@@ -110,6 +111,23 @@ Für die Existenz des Unternehmens
 ---
 
 ## <a id="chapter-matrix"></a>Risiko Matrizen
+
+
+---
+
+## <a id="chapter-componentsDetails"></a>Komponenten
+
+### <a id="component-C.1"></a>C.1 Database Server
+
+**Beschreibung:**
+
+Central PostgreSQL database storing all customer and order records.
+
+### <a id="component-C.2"></a>C.2 Login Form
+
+**Beschreibung:**
+
+Public-facing web form handling user authentication.
 
 
 ---
@@ -209,7 +227,7 @@ Use parameterised queries and input sanitisation to prevent injection attacks.
 | brutto | 3 | 4 | 12 |
 | netto | 2 | 4 | 8 |
 
-**Komponente:** Database Server
+**Komponente:** [C.1 Database Server](#component-C.1)
 
 **Angreifer:** Dritte
 
@@ -239,7 +257,7 @@ This can lead to data exfiltration or destruction.
 | brutto | 4 | 3 | 12 |
 | netto | 2 | 3 | 6 |
 
-**Komponente:** Login Form
+**Komponente:** [C.2 Login Form](#component-C.2)
 
 **Angreifer:** Dritte
 

--- a/apps/frontend/src/view/report/testData/expected-report.en.md
+++ b/apps/frontend/src/view/report/testData/expected-report.en.md
@@ -20,10 +20,11 @@ With line breaks.
 1. [The 4x6 Methodology](#chapter-methodExplanation)
 2. [Explanation of Probability and Damage Scale](#chapter-explanationScale)
 3. [Risk Matrices](#chapter-matrix)
-4. [Assets](#chapter-assetsDetails)
-5. [Measures](#chapter-measuresDetails)
-6. [List of Threats](#chapter-riskList)
-7. [Threats](#chapter-riskDetails)
+4. [Components](#chapter-componentsDetails)
+5. [Assets](#chapter-assetsDetails)
+6. [Measures](#chapter-measuresDetails)
+7. [List of Threats](#chapter-riskList)
+8. [Threats](#chapter-riskDetails)
 
 ---
 
@@ -110,6 +111,23 @@ For the existence of the company
 ---
 
 ## <a id="chapter-matrix"></a>Risk Matrices
+
+
+---
+
+## <a id="chapter-componentsDetails"></a>Components
+
+### <a id="component-C.1"></a>C.1 Database Server
+
+**Description:**
+
+Central PostgreSQL database storing all customer and order records.
+
+### <a id="component-C.2"></a>C.2 Login Form
+
+**Description:**
+
+Public-facing web form handling user authentication.
 
 
 ---
@@ -209,7 +227,7 @@ Use parameterised queries and input sanitisation to prevent injection attacks.
 | gross | 3 | 4 | 12 |
 | net | 2 | 4 | 8 |
 
-**Component:** Database Server
+**Component:** [C.1 Database Server](#component-C.1)
 
 **Attackers:** Unauthorised Parties
 
@@ -239,7 +257,7 @@ This can lead to data exfiltration or destruction.
 | gross | 4 | 3 | 12 |
 | net | 2 | 3 | 6 |
 
-**Component:** Login Form
+**Component:** [C.2 Login Form](#component-C.2)
 
 **Attackers:** Unauthorised Parties
 

--- a/apps/frontend/src/view/report/testData/project-report.fixture.json
+++ b/apps/frontend/src/view/report/testData/project-report.fixture.json
@@ -44,6 +44,40 @@
             "updatedAt": "2024-01-01T00:00:00.000Z"
         }
     ],
+    "components": [
+        {
+            "id": "comp-1",
+            "name": "Database Server",
+            "description": "Central PostgreSQL database storing all customer and order records.",
+            "type": 0,
+            "x": 100,
+            "y": 100,
+            "gridX": 5,
+            "gridY": 5,
+            "width": 80,
+            "height": 80,
+            "selected": false,
+            "projectId": 1,
+            "symbol": null,
+            "reportId": "C.1"
+        },
+        {
+            "id": "comp-2",
+            "name": "Login Form",
+            "description": "Public-facing web form handling user authentication.",
+            "type": 0,
+            "x": 300,
+            "y": 100,
+            "gridX": 15,
+            "gridY": 5,
+            "width": 80,
+            "height": 80,
+            "selected": false,
+            "projectId": 1,
+            "symbol": null,
+            "reportId": "C.2"
+        }
+    ],
     "threats": [
         {
             "id": 1,
@@ -71,7 +105,11 @@
             "bruttoColor": "red",
             "nettoColor": "yellow",
             "assets": [
-                { "id": 1, "name": "Customer Database", "reportId": "A-01" }
+                {
+                    "id": 1,
+                    "name": "Customer Database",
+                    "reportId": "A-01"
+                }
             ],
             "measures": [
                 {
@@ -93,7 +131,8 @@
                 }
             ],
             "createdAt": "2024-01-01T00:00:00.000Z",
-            "updatedAt": "2024-01-01T00:00:00.000Z"
+            "updatedAt": "2024-01-01T00:00:00.000Z",
+            "componentReportId": "C.1"
         },
         {
             "id": 2,
@@ -121,11 +160,16 @@
             "bruttoColor": "red",
             "nettoColor": "green",
             "assets": [
-                { "id": 2, "name": "Authentication Service", "reportId": "A-02" }
+                {
+                    "id": 2,
+                    "name": "Authentication Service",
+                    "reportId": "A-02"
+                }
             ],
             "measures": [],
             "createdAt": "2024-01-01T00:00:00.000Z",
-            "updatedAt": "2024-01-01T00:00:00.000Z"
+            "updatedAt": "2024-01-01T00:00:00.000Z",
+            "componentReportId": "C.2"
         }
     ],
     "measures": [
@@ -138,7 +182,11 @@
             "catalogMeasureId": null,
             "reportId": "M-01",
             "threats": [
-                { "id": 1, "reportId": "T-01", "name": "SQL Injection" }
+                {
+                    "id": 1,
+                    "reportId": "T-01",
+                    "name": "SQL Injection"
+                }
             ],
             "createdAt": "2024-01-01T00:00:00.000Z",
             "updatedAt": "2024-01-01T00:00:00.000Z"

--- a/gh-pages/User Manual.md
+++ b/gh-pages/User Manual.md
@@ -633,6 +633,7 @@ The "Page Settings" panel provides the user with the possibility to select which
 - **Show Table of Contents:** Table of contents for the report sections
 - **Show Method Explanation:** A short explanation of the 4x6 methodology
 - **Show Matrix Page:** At least gross and net risk matrices for the whole threat model. With the "Risk Matrix for Milestones" switches, matrices for the different points in the timeline can be added to this section
+- **Show Component Page:** A list of all system components together with their descriptions. Each threat in the threat details links to the component it affects on this page
 - **Show Asset Page:** A list of all analyzed assets together with their description and their protection need
 - **Show Measures Page:** A list of all (planned) measures together with their descriptions, their (planned) implementation date and the threats to which they are applied
 - **Show List of Threats:** A list overview of all threats and the component to which they apply, color-coded according to their gross or net risk value. This behaviour can be changed in the "Sort (Threats)" section. The list of threats also serves as a table of contents for the threat details.


### PR DESCRIPTION
## Summary
  Resolves #861

  - Add a "Components" chapter to the project report (PDF + Markdown) listing each component with its description.
  - Assign stable report ids (`C.1`, `C.2`, …) to components, sorted by name, and cross-link threats to their component.
  - Add a "Show Component Page" toggle to the report toolbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Components page to reports, including component descriptions and stable component anchors/IDs.
  * Threat details now link to the relevant component section when the Components page is enabled.
  * Added a “Show Component Page” toggle that controls Components visibility in both PDF and Markdown exports.
* **Bug Fixes**
  * Reports now include a sorted, correctly numbered Components section and consistent component linking across exports.
* **Documentation**
  * Updated the user manual and report UI translations to include the new Components page option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->