### PR TITLE
fix(page_switch): suppress double loading of data

### DIFF
--- a/apps/frontend/src/application/actions/assets.actions.ts
+++ b/apps/frontend/src/application/actions/assets.actions.ts
@@ -19,9 +19,18 @@ export class AssetsActions {
      *      to fetch the assets.
      * @returns Action function for getting the assets.
      */
-    static getAssets = createAsyncThunk("[assets] get assets", async (data: { projectId: number }) => {
-        return await AssetsAPI.getAssets(data);
-    });
+    static getAssets = createAsyncThunk(
+        "[assets] get assets",
+        async (data: { projectId: number }) => {
+            return await AssetsAPI.getAssets(data);
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { assets: { isPending: boolean } };
+                return !state.assets.isPending;
+            },
+        }
+    );
 
     /**
      * Action that creates an asset using the backend api.

--- a/apps/frontend/src/application/actions/catalog-measures.actions.ts
+++ b/apps/frontend/src/application/actions/catalog-measures.actions.ts
@@ -24,6 +24,12 @@ export class CatalogMeasuresActions {
         "[catalog measures] get catalog measures",
         async (data: { catalogId: number }) => {
             return await CatalogMeasuresApi.getCatalogMeasures(data);
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { catalogMeasures: { isPending: boolean } };
+                return !state.catalogMeasures.isPending;
+            },
         }
     );
 

--- a/apps/frontend/src/application/actions/catalog-threats.actions.ts
+++ b/apps/frontend/src/application/actions/catalog-threats.actions.ts
@@ -27,6 +27,12 @@ export class CatalogThreatsActions {
         "[catalog threats] get catalog threats",
         async (data: { catalogId: number }) => {
             return await CatalogThreatsApi.getCatalogThreats(data);
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { catalogThreats: { isPending: boolean } };
+                return !state.catalogThreats.isPending;
+            },
         }
     );
 

--- a/apps/frontend/src/application/actions/measureImpacts.actions.ts
+++ b/apps/frontend/src/application/actions/measureImpacts.actions.ts
@@ -9,6 +9,7 @@ import type {
     MeasureImpact,
     UpdateMeasureImpactRequest,
 } from "#api/types/measure-impact.types.ts";
+import type { RootState } from "#application/store.types.ts";
 
 /**
  * Wrapper class to expose the actions through
@@ -24,15 +25,18 @@ export class MeasureImpactsActions {
      *      to fetch the measures.
      * @returns Action function for getting the measures.
      */
-    static getMeasureImpacts = createAsyncThunk(
+    static getMeasureImpacts = createAsyncThunk<
+        ReturnType<typeof MeasureImpactsApi.getMeasureImpacts>,
+        { projectId: number },
+        { state: RootState }
+    >(
         "[measureImpacts] get measureImpacts",
         async (data: { projectId: number }) => {
             return await MeasureImpactsApi.getMeasureImpacts(data);
         },
         {
             condition: (_, { getState }) => {
-                const state = getState() as { measureImpacts: { isPending: boolean } };
-                return !state.measureImpacts.isPending;
+                return !getState().measureImpacts.isPending;
             },
         }
     );

--- a/apps/frontend/src/application/actions/measureImpacts.actions.ts
+++ b/apps/frontend/src/application/actions/measureImpacts.actions.ts
@@ -28,6 +28,12 @@ export class MeasureImpactsActions {
         "[measureImpacts] get measureImpacts",
         async (data: { projectId: number }) => {
             return await MeasureImpactsApi.getMeasureImpacts(data);
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { measureImpacts: { isPending: boolean } };
+                return !state.measureImpacts.isPending;
+            },
         }
     );
 

--- a/apps/frontend/src/application/actions/measures.actions.ts
+++ b/apps/frontend/src/application/actions/measures.actions.ts
@@ -20,9 +20,18 @@ export class MeasuresActions {
      *      to fetch the measures.
      * @returns Action function for getting the measures.
      */
-    static getMeasures = createAsyncThunk("[measures] get measures", async (data: { projectId: number }) => {
-        return await MeasuresAPI.getMeasures(data);
-    });
+    static getMeasures = createAsyncThunk(
+        "[measures] get measures",
+        async (data: { projectId: number }) => {
+            return await MeasuresAPI.getMeasures(data);
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { measures: { isPending: boolean } };
+                return !state.measures.isPending;
+            },
+        }
+    );
 
     /**
      * Action that creates a measure using the backend

--- a/apps/frontend/src/application/actions/members.actions.ts
+++ b/apps/frontend/src/application/actions/members.actions.ts
@@ -23,6 +23,12 @@ export class MemberActions {
         "[member] get added members",
         async ({ projectCatalogId, memberPath }: { projectCatalogId: number; memberPath: string }) => {
             return await MemberAPI.getAddedMembers(projectCatalogId, memberPath);
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { members: { pending: { isAddedPending: boolean } } };
+                return !state.members.pending.isAddedPending;
+            },
         }
     );
 
@@ -38,6 +44,12 @@ export class MemberActions {
         "[member] get addable members",
         async ({ projectCatalogId, memberPath }: { projectCatalogId: number; memberPath: string }) => {
             return await MemberAPI.getAddableMembers(projectCatalogId, memberPath);
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { members: { pending: { isAddablePending: boolean } } };
+                return !state.members.pending.isAddablePending;
+            },
         }
     );
 

--- a/apps/frontend/src/application/actions/projects.actions.ts
+++ b/apps/frontend/src/application/actions/projects.actions.ts
@@ -22,9 +22,18 @@ export class ProjectsActions {
      *      to fetch the projects.
      * @returns Action function for getting the projects.
      */
-    static getProjects = createAsyncThunk("[projects] get projects", async () => {
-        return await ProjectsAPI.getProjects();
-    });
+    static getProjects = createAsyncThunk(
+        "[projects] get projects",
+        async () => {
+            return await ProjectsAPI.getProjects();
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { projects: { isLoadingAll: boolean } };
+                return !state.projects.isLoadingAll;
+            },
+        }
+    );
 
     /**
      * Action that fetches the data of a single project with the backend api.

--- a/apps/frontend/src/application/actions/threats.actions.ts
+++ b/apps/frontend/src/application/actions/threats.actions.ts
@@ -18,9 +18,18 @@ export class ThreatsActions {
      *      to fetch the threats.
      * @returns Action function for getting the threats.
      */
-    static getThreats = createAsyncThunk("[threats] get threats", async (data: { projectId: number }) => {
-        return await ThreatsAPI.getThreats(data);
-    });
+    static getThreats = createAsyncThunk(
+        "[threats] get threats",
+        async (data: { projectId: number }) => {
+            return await ThreatsAPI.getThreats(data);
+        },
+        {
+            condition: (_, { getState }) => {
+                const state = getState() as { threats: { isPending: boolean } };
+                return !state.threats.isPending;
+            },
+        }
+    );
 
     /**
      * Action that creates a threat using the backend api.

--- a/apps/frontend/src/application/hooks/use-load-threats-once.hook.ts
+++ b/apps/frontend/src/application/hooks/use-load-threats-once.hook.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Calls `load()` exactly once per mount (or `projectId` change), but only
+ * after `autoSaveStatus` has reached a stable state ("upToDate" or
+ * "uninitialized"). This prevents double-fetches when a system save is still
+ * in-flight at the moment the page mounts.
+ */
+export const useLoadThreatsOnce = ({
+    projectId,
+    autoSaveStatus,
+    load,
+}: {
+    projectId: number;
+    autoSaveStatus: string;
+    load: () => void;
+}): void => {
+    const prevProjectIdRef = useRef(projectId);
+    const loadedRef = useRef(false);
+    useEffect(() => {
+        if (prevProjectIdRef.current !== projectId) {
+            prevProjectIdRef.current = projectId;
+            loadedRef.current = false;
+        }
+        if (loadedRef.current) {
+            return;
+        }
+        if (autoSaveStatus === "upToDate" || autoSaveStatus === "uninitialized") {
+            loadedRef.current = true;
+            load();
+        }
+    }, [projectId, autoSaveStatus, load]);
+};

--- a/apps/frontend/src/application/hooks/use-matrix.hook.ts
+++ b/apps/frontend/src/application/hooks/use-matrix.hook.ts
@@ -270,10 +270,6 @@ export const useMatrix = ({ projectId, catalogId }: UseMatrixArgs) => {
     );
 
     useEffect(() => {
-        loadThreats();
-    }, [projectId, loadThreats]);
-
-    useEffect(() => {
         loadCatalogMeasures();
     }, [projectId, loadCatalogMeasures]);
 

--- a/apps/frontend/src/application/hooks/use-report.hook.ts
+++ b/apps/frontend/src/application/hooks/use-report.hook.ts
@@ -112,6 +112,9 @@ export const useReport = ({ projectId }: { projectId: number }) => {
         try {
             const report = await ProjectsAPI.getReport({ projectId });
             setData(report);
+        } catch (error) {
+            console.error("Failed to fetch report", error);
+            showErrorMessage({ message: t("errorMessages.reportFetchFailed") });
         } finally {
             isFetchingRef.current = false;
         }

--- a/apps/frontend/src/application/hooks/use-report.hook.ts
+++ b/apps/frontend/src/application/hooks/use-report.hook.ts
@@ -3,7 +3,7 @@ import type { SortDirection } from "#application/actions/list.actions.ts";
 import { exportAsExcelFile } from "#utils/export.ts";
 import { toDayNumber, createRiskMatrixDesign, addThreatsToRiskMatrix } from "#utils/riskMatrix.ts";
 import { useAlert } from "#application/hooks/use-alert.hook.ts";
-import { useState, useMemo, useEffect, useEffectEvent } from "react";
+import { useState, useMemo, useEffect, useEffectEvent, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { ProjectsAPI } from "#api/projects.api.ts";
 import { calcRiskColour, calcNetRisk } from "#utils/calcRisk.ts";
@@ -102,11 +102,19 @@ export const useReport = ({ projectId }: { projectId: number }) => {
     const threats = data?.threats;
     const measures = data?.measures;
 
+    const isFetchingRef = useRef(false);
+
     const fetchReport = useEffectEvent(async () => {
-        const report = await ProjectsAPI.getReport({
-            projectId,
-        });
-        setData(report);
+        if (isFetchingRef.current) {
+            return;
+        }
+        isFetchingRef.current = true;
+        try {
+            const report = await ProjectsAPI.getReport({ projectId });
+            setData(report);
+        } finally {
+            isFetchingRef.current = false;
+        }
     });
 
     const filename = useMemo(() => {

--- a/apps/frontend/src/application/hooks/use-threats-list.hook.ts
+++ b/apps/frontend/src/application/hooks/use-threats-list.hook.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import type { ExtendedThreat } from "#api/types/threat.types.ts";
 import { useList } from "./use-list.hooks";
 import { useThreats } from "./use-threats.hook";
@@ -32,10 +32,6 @@ export const useThreatsList = ({ projectId }: { projectId: number }) => {
         projectId,
     });
     const { setSortDirection, setSearchValue, setSortBy, sortDirection, searchValue, sortBy } = useList("threats");
-
-    useEffect(() => {
-        loadThreats();
-    }, [projectId, loadThreats]);
 
     const filteredItems: ExtendedThreat[] = useMemo(() => {
         return items.filter((item) => {

--- a/apps/frontend/src/application/middlewares/system/system.middleware.ts
+++ b/apps/frontend/src/application/middlewares/system/system.middleware.ts
@@ -5,7 +5,6 @@ import { AlertActions } from "#application/actions/alert.actions.ts";
 import { EditorActions } from "#application/actions/editor.actions.ts";
 import { PointsOfAttackActions } from "#application/actions/points-of-attack.actions.ts";
 import { SystemActions, trackInFlightSave } from "#application/actions/system.actions.ts";
-import { ProjectsActions } from "#application/actions/projects.actions.ts";
 import type { Connection, SystemComponent, SystemConnection, UpdateSystemRequest } from "#api/types/system.types.ts";
 import type { EditorState } from "#application/reducers/editor.reducer.ts";
 
@@ -103,7 +102,6 @@ const handleUpdateSystemSuccesful: AppMiddleware =
         next(action);
         if (SystemActions.updateSystem.fulfilled.match(action)) {
             dispatch(SystemActions.setHasChanged(false));
-            dispatch(ProjectsActions.getProjects());
         }
     };
 

--- a/apps/frontend/src/application/reducers/projects.reducer.ts
+++ b/apps/frontend/src/application/reducers/projects.reducer.ts
@@ -8,6 +8,7 @@ type ProjectsAdapterState = ReturnType<typeof projectsAdapter.getInitialState>;
 
 export type ProjectsState = ProjectsAdapterState & {
     isPending: boolean;
+    isLoadingAll: boolean;
     current: ExtendedProject | undefined;
     deletingProjectId: number | undefined;
 };
@@ -15,6 +16,7 @@ export type ProjectsState = ProjectsAdapterState & {
 const defaultState: ProjectsState = {
     ...projectsAdapter.getInitialState(),
     isPending: false,
+    isLoadingAll: false,
     current: undefined,
     deletingProjectId: undefined,
 };
@@ -22,15 +24,18 @@ const defaultState: ProjectsState = {
 const projectsReducer = createReducer(defaultState, (builder) => {
     builder.addCase(ProjectsActions.getProjects.pending, (state) => {
         state.isPending = true;
+        state.isLoadingAll = true;
     });
 
     builder.addCase(ProjectsActions.getProjects.fulfilled, (state, action) => {
         projectsAdapter.setAll(state, action);
         state.isPending = false;
+        state.isLoadingAll = false;
     });
 
     builder.addCase(ProjectsActions.getProjects.rejected, (state) => {
         state.isPending = false;
+        state.isLoadingAll = false;
     });
 
     builder.addCase(ProjectsActions.getProjectFromBackend.pending, (state) => {

--- a/apps/frontend/src/translations/de/common.de.json
+++ b/apps/frontend/src/translations/de/common.de.json
@@ -131,7 +131,8 @@
     "componentToCommunicationInfraInvalid": "Clients, Server und Datenbanken können sich nur über Kommunikationsschnittstellen mit der Kommunikationsinfrastruktur verbinden",
     "communicationInfraToComponentInvalid": "Kommunikationsinfrastruktur kann sich nur über Kommunikationsschnittstellen mit Clients, Servern oder Datenbanken verbinden",
     "invalidConnection": "Ungültige Verbindung",
-    "excelExportFailed": "Excel-Export fehlgeschlagen."
+    "excelExportFailed": "Excel-Export fehlgeschlagen.",
+    "reportFetchFailed": "Report kann nicht geladen werden."
   },
 
   "pointsOfAttackList": {

--- a/apps/frontend/src/translations/en/common.en.json
+++ b/apps/frontend/src/translations/en/common.en.json
@@ -128,7 +128,8 @@
     "componentToCommunicationInfraInvalid": "Clients, servers, and databases can only connect to communication infrastructure via communication interfaces",
     "communicationInfraToComponentInvalid": "Communication infrastructure can only connect to clients, servers, or databases via communication interfaces",
     "invalidConnection": "Invalid connection",
-    "excelExportFailed": "Excel export failed."
+    "excelExportFailed": "Excel export failed.",
+    "reportFetchFailed": "Report cannot be loaded."
   },
 
   "pointsOfAttackList": {

--- a/apps/frontend/src/view/components/with-project.hoc.tsx
+++ b/apps/frontend/src/view/components/with-project.hoc.tsx
@@ -20,8 +20,10 @@ export const withProject = <P extends object>(Component: ComponentType<P & Injec
         const project = useAppSelector((state) => projectsSelectors.selectById(state, Number(projectId)));
 
         useEffect(() => {
-            dispatch(ProjectsActions.getProjects());
-        }, [dispatch]);
+            if (!project) {
+                dispatch(ProjectsActions.getProjects());
+            }
+        }, [dispatch, project]);
 
         return project ? <Component project={project} {...props} /> : <LinearProgress />;
     };

--- a/apps/frontend/src/view/pages/asset-dialog.page.test.tsx
+++ b/apps/frontend/src/view/pages/asset-dialog.page.test.tsx
@@ -38,7 +38,14 @@ describe("AssetDialogPage", () => {
             url: "/projects/1/assets/5/edit",
             preloadedState: {
                 assets: { ids: [], entities: {}, isPending: true },
-                projects: { ids: [], entities: {}, isPending: false, current: undefined, deletingProjectId: undefined },
+                projects: {
+                    ids: [],
+                    entities: {},
+                    isLoadingAll: false,
+                    isPending: false,
+                    current: undefined,
+                    deletingProjectId: undefined,
+                },
             },
         });
 
@@ -53,7 +60,14 @@ describe("AssetDialogPage", () => {
             url: "/projects/1/assets/999/edit",
             preloadedState: {
                 assets: { ids: [10], entities: { 10: otherAsset }, isPending: false },
-                projects: { ids: [], entities: {}, isPending: false, current: undefined, deletingProjectId: undefined },
+                projects: {
+                    ids: [],
+                    entities: {},
+                    isLoadingAll: false,
+                    isPending: false,
+                    current: undefined,
+                    deletingProjectId: undefined,
+                },
             },
         });
 
@@ -69,7 +83,14 @@ describe("AssetDialogPage", () => {
             url: "/projects/1/assets/5/edit",
             preloadedState: {
                 assets: { ids: [5], entities: { 5: asset }, isPending: false },
-                projects: { ids: [], entities: {}, isPending: false, current: project, deletingProjectId: undefined },
+                projects: {
+                    ids: [],
+                    entities: {},
+                    isLoadingAll: false,
+                    isPending: false,
+                    current: project,
+                    deletingProjectId: undefined,
+                },
             },
         });
 
@@ -85,7 +106,14 @@ describe("AssetDialogPage", () => {
             url: { pathname: "/projects/1/assets/edit", state: { asset: { name: "New Asset" } } },
             preloadedState: {
                 assets: { ids: [], entities: {}, isPending: false },
-                projects: { ids: [], entities: {}, isPending: false, current: undefined, deletingProjectId: undefined },
+                projects: {
+                    ids: [],
+                    entities: {},
+                    isLoadingAll: false,
+                    isPending: false,
+                    current: undefined,
+                    deletingProjectId: undefined,
+                },
             },
         });
 

--- a/apps/frontend/src/view/pages/risk.page.tsx
+++ b/apps/frontend/src/view/pages/risk.page.tsx
@@ -10,16 +10,7 @@ import {
     TableSortLabel,
     Typography,
 } from "@mui/material";
-import {
-    memo,
-    useEffect,
-    useLayoutEffect,
-    useRef,
-    useState,
-    type ChangeEvent,
-    type ReactNode,
-    type SyntheticEvent,
-} from "react";
+import { memo, useLayoutEffect, useState, type ChangeEvent, type ReactNode, type SyntheticEvent } from "react";
 
 import { useTranslation } from "react-i18next";
 import { Route, Routes, useNavigate, useParams } from "react-router";
@@ -33,6 +24,7 @@ import { checkUserRole, USER_ROLES } from "#api/types/user-roles.types.ts";
 import { NavigationActions } from "#application/actions/navigation.actions.ts";
 import { ProjectsActions } from "#application/actions/projects.actions.ts";
 import { useConfirm } from "#application/hooks/use-confirm.hook.ts";
+import { useLoadThreatsOnce } from "#application/hooks/use-load-threats-once.hook.ts";
 import { useMatrix } from "#application/hooks/use-matrix.hook.ts";
 import { MATRIX_COLOR } from "#view/colors/matrix.ts";
 import { IconButton } from "#view/components/icon-button.component.tsx";
@@ -263,21 +255,7 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
         }
     };
 
-    const prevProjectIdRef = useRef(projectId);
-    const loadedRef = useRef(false);
-    useEffect(() => {
-        if (prevProjectIdRef.current !== projectId) {
-            prevProjectIdRef.current = projectId;
-            loadedRef.current = false;
-        }
-        if (loadedRef.current) {
-            return;
-        }
-        if (autoSaveStatus === "upToDate" || autoSaveStatus === "uninitialized") {
-            loadedRef.current = true;
-            loadThreats();
-        }
-    }, [projectId, autoSaveStatus, loadThreats]);
+    useLoadThreatsOnce({ projectId, autoSaveStatus, load: loadThreats });
 
     return (
         <Page sx={{ boxSizing: "border-box" }}>

--- a/apps/frontend/src/view/pages/risk.page.tsx
+++ b/apps/frontend/src/view/pages/risk.page.tsx
@@ -14,6 +14,7 @@ import {
     memo,
     useEffect,
     useLayoutEffect,
+    useRef,
     useState,
     type ChangeEvent,
     type ReactNode,
@@ -262,8 +263,11 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
         }
     };
 
+    const prevAutoSaveStatusRef = useRef(autoSaveStatus);
     useEffect(() => {
-        if (autoSaveStatus === "upToDate") {
+        const prev = prevAutoSaveStatusRef.current;
+        prevAutoSaveStatusRef.current = autoSaveStatus;
+        if (autoSaveStatus === "upToDate" && prev !== "upToDate") {
             loadThreats();
         }
     }, [autoSaveStatus, loadThreats]);

--- a/apps/frontend/src/view/pages/risk.page.tsx
+++ b/apps/frontend/src/view/pages/risk.page.tsx
@@ -263,14 +263,21 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
         }
     };
 
-    const prevAutoSaveStatusRef = useRef(autoSaveStatus);
+    const prevProjectIdRef = useRef(projectId);
+    const loadedRef = useRef(false);
     useEffect(() => {
-        const prev = prevAutoSaveStatusRef.current;
-        prevAutoSaveStatusRef.current = autoSaveStatus;
-        if (autoSaveStatus === "upToDate" && prev !== "upToDate") {
+        if (prevProjectIdRef.current !== projectId) {
+            prevProjectIdRef.current = projectId;
+            loadedRef.current = false;
+        }
+        if (loadedRef.current) {
+            return;
+        }
+        if (autoSaveStatus === "upToDate" || autoSaveStatus === "uninitialized") {
+            loadedRef.current = true;
             loadThreats();
         }
-    }, [autoSaveStatus, loadThreats]);
+    }, [projectId, autoSaveStatus, loadThreats]);
 
     return (
         <Page sx={{ boxSizing: "border-box" }}>

--- a/apps/frontend/src/view/pages/threats.page.tsx
+++ b/apps/frontend/src/view/pages/threats.page.tsx
@@ -6,7 +6,7 @@ import TableCell, { type TableCellProps } from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import { memo, useEffect, useLayoutEffect, useState, type ChangeEvent, type SyntheticEvent } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Route, Routes, useNavigate, useParams } from "react-router";
 import type { ExtendedThreat } from "#api/types/threat.types.ts";
@@ -124,8 +124,11 @@ const ThreatsPageBody = () => {
         });
     };
 
+    const prevAutoSaveStatusRef = useRef(autoSaveStatus);
     useEffect(() => {
-        if (autoSaveStatus === "upToDate") {
+        const prev = prevAutoSaveStatusRef.current;
+        prevAutoSaveStatusRef.current = autoSaveStatus;
+        if (autoSaveStatus === "upToDate" && prev !== "upToDate") {
             loadThreats();
         }
     }, [autoSaveStatus, loadThreats]);

--- a/apps/frontend/src/view/pages/threats.page.tsx
+++ b/apps/frontend/src/view/pages/threats.page.tsx
@@ -6,7 +6,7 @@ import TableCell, { type TableCellProps } from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import { memo, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type SyntheticEvent } from "react";
+import { memo, useLayoutEffect, useState, type ChangeEvent, type SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Route, Routes, useNavigate, useParams } from "react-router";
 import type { ExtendedThreat } from "#api/types/threat.types.ts";
@@ -14,6 +14,7 @@ import { checkUserRole, USER_ROLES } from "#api/types/user-roles.types.ts";
 import { NavigationActions } from "#application/actions/navigation.actions.ts";
 import { useConfirm } from "#application/hooks/use-confirm.hook.ts";
 import { useEditor } from "#application/hooks/use-editor.hook.ts";
+import { useLoadThreatsOnce } from "#application/hooks/use-load-threats-once.hook.ts";
 import { useThreatsList, type ThreatListItem } from "#application/hooks/use-threats-list.hook.ts";
 import { IconButton } from "#view/components/icon-button.component.tsx";
 import { Page } from "#view/components/page.component.tsx";
@@ -124,21 +125,7 @@ const ThreatsPageBody = () => {
         });
     };
 
-    const prevProjectIdRef = useRef(projectId);
-    const loadedRef = useRef(false);
-    useEffect(() => {
-        if (prevProjectIdRef.current !== projectId) {
-            prevProjectIdRef.current = projectId;
-            loadedRef.current = false;
-        }
-        if (loadedRef.current) {
-            return;
-        }
-        if (autoSaveStatus === "upToDate" || autoSaveStatus === "uninitialized") {
-            loadedRef.current = true;
-            loadThreats();
-        }
-    }, [projectId, autoSaveStatus, loadThreats]);
+    useLoadThreatsOnce({ projectId, autoSaveStatus, load: loadThreats });
 
     const [assetAnchorEl, setAssetAnchorEl] = useState<HTMLElement | null>(null);
     const [currentAssetList, setCurrentAssetList] = useState<ExtendedThreat["assets"] | null>(null);

--- a/apps/frontend/src/view/pages/threats.page.tsx
+++ b/apps/frontend/src/view/pages/threats.page.tsx
@@ -469,7 +469,7 @@ const ThreatsPageBody = () => {
                                                             >
                                                                 {checkUserRole(userRole, USER_ROLES.EDITOR) && [
                                                                     <IconButton
-                                                                        key={threat.id}
+                                                                        key={`${threat.id}-duplicate`}
                                                                         title={t("duplicateThreat")}
                                                                         onClick={(e) =>
                                                                             handleDuplicateThreat(e, threat)
@@ -482,7 +482,7 @@ const ThreatsPageBody = () => {
                                                                         />
                                                                     </IconButton>,
                                                                     <IconButton
-                                                                        key={threat.id}
+                                                                        key={`${threat.id}-delete`}
                                                                         title={t("deleteThreat")}
                                                                         hoverColor="error"
                                                                         onClick={(e) => handleDeleteThreat(e, threat)}

--- a/apps/frontend/src/view/pages/threats.page.tsx
+++ b/apps/frontend/src/view/pages/threats.page.tsx
@@ -124,14 +124,21 @@ const ThreatsPageBody = () => {
         });
     };
 
-    const prevAutoSaveStatusRef = useRef(autoSaveStatus);
+    const prevProjectIdRef = useRef(projectId);
+    const loadedRef = useRef(false);
     useEffect(() => {
-        const prev = prevAutoSaveStatusRef.current;
-        prevAutoSaveStatusRef.current = autoSaveStatus;
-        if (autoSaveStatus === "upToDate" && prev !== "upToDate") {
+        if (prevProjectIdRef.current !== projectId) {
+            prevProjectIdRef.current = projectId;
+            loadedRef.current = false;
+        }
+        if (loadedRef.current) {
+            return;
+        }
+        if (autoSaveStatus === "upToDate" || autoSaveStatus === "uninitialized") {
+            loadedRef.current = true;
             loadThreats();
         }
-    }, [autoSaveStatus, loadThreats]);
+    }, [projectId, autoSaveStatus, loadThreats]);
 
     const [assetAnchorEl, setAssetAnchorEl] = useState<HTMLElement | null>(null);
     const [currentAssetList, setCurrentAssetList] = useState<ExtendedThreat["assets"] | null>(null);


### PR DESCRIPTION
- Suppress double loading of data when switching tabs.
- Fixed duplicate ids on threats tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate in-flight requests across screens by gating async loads when related state is already pending.
  * Improved report loading to avoid concurrent fetches and load threats only when appropriate after status changes.
  * Reduced unnecessary project refetches by fetching only when missing and removing automatic refetch after system updates.
  * Fixed duplicate/delete button key stability in the threats table.
* **Tests**
  * Updated page test Redux store setup for the updated projects state shape.
* **Documentation**
  * Added new English/German user-facing error text for report load failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->