### PR TITLE
feat(test): cover seven untested components

### DIFF
--- a/apps/frontend/src/view/components/alert.component.test.tsx
+++ b/apps/frontend/src/view/components/alert.component.test.tsx
@@ -1,0 +1,99 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { mockUseAlert } from "#test-utils/mock-hooks.ts";
+import {
+    errorDefaultState,
+    ERR_TYPE_API,
+    ERR_TYPE_PROJECT_CATALOG_EXISTANCE,
+} from "#application/reducers/error.reducer.ts";
+
+const navigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react-router")>();
+    return { ...actual, useNavigate: () => navigate };
+});
+
+import { Alert } from "./alert.component";
+
+const errorState = (overrides: Partial<typeof errorDefaultState> = {}) => ({ ...errorDefaultState, ...overrides });
+
+describe("Alert — visibility", () => {
+    it("renders nothing while not visible", () => {
+        mockUseAlert({ visible: false, text: "Saved" });
+
+        renderWithProviders(<Alert />);
+
+        expect(screen.queryByText("Saved")).not.toBeInTheDocument();
+    });
+
+    it("renders the message text when visible", () => {
+        mockUseAlert({ visible: true, text: "Saved successfully", type: "success" });
+
+        renderWithProviders(<Alert />);
+
+        expect(screen.getByText("Saved successfully")).toBeInTheDocument();
+    });
+
+    it("invokes close when the close button is clicked", async () => {
+        const close = vi.fn();
+        mockUseAlert({ visible: true, text: "Saved", type: "success", close });
+        const user = userEvent.setup();
+
+        renderWithProviders(<Alert />);
+        await user.click(screen.getByRole("button", { name: /close/i }));
+
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("Alert — error side effects", () => {
+    it("does nothing when there is no error", () => {
+        const showErrorMessage = vi.fn();
+        mockUseAlert({ visible: false, showErrorMessage });
+
+        renderWithProviders(<Alert />, { preloadedState: { error: errorState() } });
+
+        expect(navigate).not.toHaveBeenCalled();
+        expect(showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it("redirects to /login and surfaces the message on an authentication error", () => {
+        const showErrorMessage = vi.fn();
+        mockUseAlert({ visible: false, showErrorMessage });
+
+        renderWithProviders(<Alert />, {
+            preloadedState: { error: errorState({ type: ERR_TYPE_API, message: "Session expired" }) },
+            initialEntries: ["/projects"],
+        });
+
+        expect(navigate).toHaveBeenCalledWith("/login", { replace: true });
+        expect(showErrorMessage).toHaveBeenCalledWith({ message: "Session expired" });
+    });
+
+    it("does not redirect again when already on the login page", () => {
+        const showErrorMessage = vi.fn();
+        mockUseAlert({ visible: false, showErrorMessage });
+
+        renderWithProviders(<Alert />, {
+            preloadedState: { error: errorState({ type: ERR_TYPE_API, message: "Session expired" }) },
+            initialEntries: ["/login"],
+        });
+
+        expect(navigate).not.toHaveBeenCalled();
+        expect(showErrorMessage).toHaveBeenCalledWith({ message: "Session expired" });
+    });
+
+    it("redirects to /projects on a project/catalog existence error", () => {
+        const showErrorMessage = vi.fn();
+        mockUseAlert({ visible: false, showErrorMessage });
+
+        renderWithProviders(<Alert />, {
+            preloadedState: { error: errorState({ type: ERR_TYPE_PROJECT_CATALOG_EXISTANCE, message: "Gone" }) },
+            initialEntries: ["/projects/1"],
+        });
+
+        expect(navigate).toHaveBeenCalledWith("/projects", { replace: true });
+        expect(showErrorMessage).toHaveBeenCalledWith({ message: "Gone" });
+    });
+});

--- a/apps/frontend/src/view/components/alert.component.test.tsx
+++ b/apps/frontend/src/view/components/alert.component.test.tsx
@@ -80,10 +80,9 @@ describe("Alert — error side effects", () => {
     });
 
     it("redirects to /projects on a project/catalog existence error", () => {
-        const { showErrorMessage } = setupError(
-            { type: ERR_TYPE_PROJECT_CATALOG_EXISTANCE, message: "Gone" },
-            ["/projects/1"]
-        );
+        const { showErrorMessage } = setupError({ type: ERR_TYPE_PROJECT_CATALOG_EXISTANCE, message: "Gone" }, [
+            "/projects/1",
+        ]);
 
         expect(navigate).toHaveBeenCalledWith("/projects", { replace: true });
         expect(showErrorMessage).toHaveBeenCalledWith({ message: "Gone" });

--- a/apps/frontend/src/view/components/alert.component.test.tsx
+++ b/apps/frontend/src/view/components/alert.component.test.tsx
@@ -18,6 +18,16 @@ import { Alert } from "./alert.component";
 
 const errorState = (overrides: Partial<typeof errorDefaultState> = {}) => ({ ...errorDefaultState, ...overrides });
 
+const setupError = (error: Partial<typeof errorDefaultState>, initialEntries?: string[]) => {
+    const showErrorMessage = vi.fn();
+    mockUseAlert({ visible: false, showErrorMessage });
+    renderWithProviders(<Alert />, {
+        preloadedState: { error: errorState(error) },
+        ...(initialEntries && { initialEntries }),
+    });
+    return { showErrorMessage };
+};
+
 describe("Alert — visibility", () => {
     it("renders nothing while not visible", () => {
         mockUseAlert({ visible: false, text: "Saved" });
@@ -49,49 +59,31 @@ describe("Alert — visibility", () => {
 
 describe("Alert — error side effects", () => {
     it("does nothing when there is no error", () => {
-        const showErrorMessage = vi.fn();
-        mockUseAlert({ visible: false, showErrorMessage });
-
-        renderWithProviders(<Alert />, { preloadedState: { error: errorState() } });
+        const { showErrorMessage } = setupError({});
 
         expect(navigate).not.toHaveBeenCalled();
         expect(showErrorMessage).not.toHaveBeenCalled();
     });
 
     it("redirects to /login and surfaces the message on an authentication error", () => {
-        const showErrorMessage = vi.fn();
-        mockUseAlert({ visible: false, showErrorMessage });
-
-        renderWithProviders(<Alert />, {
-            preloadedState: { error: errorState({ type: ERR_TYPE_API, message: "Session expired" }) },
-            initialEntries: ["/projects"],
-        });
+        const { showErrorMessage } = setupError({ type: ERR_TYPE_API, message: "Session expired" }, ["/projects"]);
 
         expect(navigate).toHaveBeenCalledWith("/login", { replace: true });
         expect(showErrorMessage).toHaveBeenCalledWith({ message: "Session expired" });
     });
 
     it("does not redirect again when already on the login page", () => {
-        const showErrorMessage = vi.fn();
-        mockUseAlert({ visible: false, showErrorMessage });
-
-        renderWithProviders(<Alert />, {
-            preloadedState: { error: errorState({ type: ERR_TYPE_API, message: "Session expired" }) },
-            initialEntries: ["/login"],
-        });
+        const { showErrorMessage } = setupError({ type: ERR_TYPE_API, message: "Session expired" }, ["/login"]);
 
         expect(navigate).not.toHaveBeenCalled();
         expect(showErrorMessage).toHaveBeenCalledWith({ message: "Session expired" });
     });
 
     it("redirects to /projects on a project/catalog existence error", () => {
-        const showErrorMessage = vi.fn();
-        mockUseAlert({ visible: false, showErrorMessage });
-
-        renderWithProviders(<Alert />, {
-            preloadedState: { error: errorState({ type: ERR_TYPE_PROJECT_CATALOG_EXISTANCE, message: "Gone" }) },
-            initialEntries: ["/projects/1"],
-        });
+        const { showErrorMessage } = setupError(
+            { type: ERR_TYPE_PROJECT_CATALOG_EXISTANCE, message: "Gone" },
+            ["/projects/1"]
+        );
 
         expect(navigate).toHaveBeenCalledWith("/projects", { replace: true });
         expect(showErrorMessage).toHaveBeenCalledWith({ message: "Gone" });

--- a/apps/frontend/src/view/components/confirm.component.test.tsx
+++ b/apps/frontend/src/view/components/confirm.component.test.tsx
@@ -4,20 +4,21 @@ import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { mockUseConfirm } from "#test-utils/mock-hooks.ts";
 import { Confirm } from "./confirm.component";
 
+const renderConfirm = (config: Parameters<typeof mockUseConfirm>[0]) => {
+    mockUseConfirm(config);
+    return renderWithProviders(<Confirm />);
+};
+
 describe("Confirm", () => {
     it("renders nothing while closed", () => {
-        mockUseConfirm({ open: false, message: "Are you sure?", acceptText: "OK" });
-
-        renderWithProviders(<Confirm />);
+        renderConfirm({ open: false, message: "Are you sure?", acceptText: "OK" });
 
         expect(screen.queryByText("Are you sure?")).not.toBeInTheDocument();
         expect(screen.queryByTestId("confirm-button")).not.toBeInTheDocument();
     });
 
     it("renders the message and accept button when open", () => {
-        mockUseConfirm({ open: true, message: "Delete this item?", acceptText: "Delete", cancelText: null });
-
-        renderWithProviders(<Confirm />);
+        renderConfirm({ open: true, message: "Delete this item?", acceptText: "Delete", cancelText: null });
 
         expect(screen.getByText("Delete this item?")).toBeInTheDocument();
         expect(screen.getByTestId("confirm-button")).toHaveTextContent("Delete");
@@ -25,10 +26,9 @@ describe("Confirm", () => {
 
     it("invokes acceptConfirm when the accept button is clicked", async () => {
         const acceptConfirm = vi.fn();
-        mockUseConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: null, acceptConfirm });
+        renderConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: null, acceptConfirm });
         const user = userEvent.setup();
 
-        renderWithProviders(<Confirm />);
         await user.click(screen.getByTestId("confirm-button"));
 
         expect(acceptConfirm).toHaveBeenCalledTimes(1);
@@ -36,10 +36,9 @@ describe("Confirm", () => {
 
     it("renders and wires the cancel button when cancelText is provided", async () => {
         const cancelConfirm = vi.fn();
-        mockUseConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: "Cancel", cancelConfirm });
+        renderConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: "Cancel", cancelConfirm });
         const user = userEvent.setup();
 
-        renderWithProviders(<Confirm />);
         const cancelButton = screen.getByTestId("cancel-button");
         expect(cancelButton).toHaveTextContent("Cancel");
 
@@ -49,15 +48,13 @@ describe("Confirm", () => {
     });
 
     it("omits the cancel button when cancelText is null", () => {
-        mockUseConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: null });
-
-        renderWithProviders(<Confirm />);
+        renderConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: null });
 
         expect(screen.queryByTestId("cancel-button")).not.toBeInTheDocument();
     });
 
     it("renders an object message with the highlighted part in bold, surrounded by plain text", () => {
-        mockUseConfirm({
+        renderConfirm({
             open: true,
             acceptText: "Delete",
             cancelText: null,
@@ -68,8 +65,6 @@ describe("Confirm", () => {
             },
         });
 
-        renderWithProviders(<Confirm />);
-
         const highlighted = screen.getByText("Project X");
         expect(highlighted.tagName).toBe("SPAN");
         expect(highlighted).toHaveStyle("font-weight: bold");
@@ -78,10 +73,9 @@ describe("Confirm", () => {
 
     it("cancels when the backdrop is clicked", async () => {
         const cancelConfirm = vi.fn();
-        mockUseConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: "Cancel", cancelConfirm });
+        renderConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: "Cancel", cancelConfirm });
         const user = userEvent.setup();
 
-        renderWithProviders(<Confirm />);
         const backdrop = document.querySelector(".MuiBackdrop-root");
         expect(backdrop).not.toBeNull();
 

--- a/apps/frontend/src/view/components/confirm.component.test.tsx
+++ b/apps/frontend/src/view/components/confirm.component.test.tsx
@@ -1,0 +1,92 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { mockUseConfirm } from "#test-utils/mock-hooks.ts";
+import { Confirm } from "./confirm.component";
+
+describe("Confirm", () => {
+    it("renders nothing while closed", () => {
+        mockUseConfirm({ open: false, message: "Are you sure?", acceptText: "OK" });
+
+        renderWithProviders(<Confirm />);
+
+        expect(screen.queryByText("Are you sure?")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("confirm-button")).not.toBeInTheDocument();
+    });
+
+    it("renders the message and accept button when open", () => {
+        mockUseConfirm({ open: true, message: "Delete this item?", acceptText: "Delete", cancelText: null });
+
+        renderWithProviders(<Confirm />);
+
+        expect(screen.getByText("Delete this item?")).toBeInTheDocument();
+        expect(screen.getByTestId("confirm-button")).toHaveTextContent("Delete");
+    });
+
+    it("invokes acceptConfirm when the accept button is clicked", async () => {
+        const acceptConfirm = vi.fn();
+        mockUseConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: null, acceptConfirm });
+        const user = userEvent.setup();
+
+        renderWithProviders(<Confirm />);
+        await user.click(screen.getByTestId("confirm-button"));
+
+        expect(acceptConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders and wires the cancel button when cancelText is provided", async () => {
+        const cancelConfirm = vi.fn();
+        mockUseConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: "Cancel", cancelConfirm });
+        const user = userEvent.setup();
+
+        renderWithProviders(<Confirm />);
+        const cancelButton = screen.getByTestId("cancel-button");
+        expect(cancelButton).toHaveTextContent("Cancel");
+
+        await user.click(cancelButton);
+
+        expect(cancelConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it("omits the cancel button when cancelText is null", () => {
+        mockUseConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: null });
+
+        renderWithProviders(<Confirm />);
+
+        expect(screen.queryByTestId("cancel-button")).not.toBeInTheDocument();
+    });
+
+    it("renders an object message with the highlighted part in bold, surrounded by plain text", () => {
+        mockUseConfirm({
+            open: true,
+            acceptText: "Delete",
+            cancelText: null,
+            message: {
+                preHighlightText: "Delete ",
+                highlightedText: "Project X",
+                afterHighlightText: " permanently?",
+            },
+        });
+
+        renderWithProviders(<Confirm />);
+
+        const highlighted = screen.getByText("Project X");
+        expect(highlighted.tagName).toBe("SPAN");
+        expect(highlighted).toHaveStyle("font-weight: bold");
+        expect(highlighted.parentElement).toHaveTextContent("Delete Project X permanently?");
+    });
+
+    it("cancels when the backdrop is clicked", async () => {
+        const cancelConfirm = vi.fn();
+        mockUseConfirm({ open: true, message: "Delete?", acceptText: "Delete", cancelText: "Cancel", cancelConfirm });
+        const user = userEvent.setup();
+
+        renderWithProviders(<Confirm />);
+        const backdrop = document.querySelector(".MuiBackdrop-root");
+        expect(backdrop).not.toBeNull();
+
+        await user.click(backdrop as Element);
+
+        expect(cancelConfirm).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/frontend/src/view/components/icon-selector.component.test.tsx
+++ b/apps/frontend/src/view/components/icon-selector.component.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { IconSelector } from "./icon-selector.component";
+
+describe("IconSelector", () => {
+    it("renders the helper text", () => {
+        renderWithProviders(<IconSelector label="Icon" onChange={vi.fn()} helperText="Pick an icon" />);
+
+        expect(screen.getByText("Pick an icon")).toBeInTheDocument();
+    });
+
+    it("reflects the pre-selected icon in the closed control", () => {
+        renderWithProviders(<IconSelector label="Icon" value="Bluetooth" onChange={vi.fn()} />);
+
+        expect(screen.getByTestId("BluetoothIcon")).toBeInTheDocument();
+    });
+
+    it("calls onChange with the chosen icon name when an icon is picked", async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        renderWithProviders(<IconSelector label="Icon" onChange={onChange} />);
+
+        await user.click(screen.getByRole("combobox"));
+        await user.click(screen.getByTestId("WifiIcon"));
+
+        expect(onChange).toHaveBeenCalledWith("Wifi");
+    });
+
+    it("filters the icon grid by the search term", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<IconSelector label="Icon" onChange={vi.fn()} />);
+
+        await user.click(screen.getByRole("combobox"));
+        expect(screen.getByTestId("RouterIcon")).toBeInTheDocument();
+
+        await user.type(screen.getByPlaceholderText("Search icons..."), "usb");
+
+        expect(await screen.findByTestId("UsbIcon")).toBeInTheDocument();
+        expect(screen.queryByTestId("RouterIcon")).not.toBeInTheDocument();
+    });
+});

--- a/apps/frontend/src/view/components/line-of-tolerance-selector.component.test.tsx
+++ b/apps/frontend/src/view/components/line-of-tolerance-selector.component.test.tsx
@@ -1,0 +1,87 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { createProject } from "#test-utils/builders.ts";
+import projectsReducer from "#application/reducers/projects.reducer.ts";
+import { LineOfToleranceSelector } from "./line-of-tolerance-selector.component";
+
+const preloadedWithRole = (role?: USER_ROLES) => ({
+    projects: {
+        ...projectsReducer(undefined, { type: "@@INIT" }),
+        current: role ? createProject({ role }) : undefined,
+    },
+});
+
+const setup = (role: USER_ROLES | undefined, props: Partial<ComponentProps<typeof LineOfToleranceSelector>> = {}) => {
+    const onLoTChange = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+        <LineOfToleranceSelector
+            title="Line of Tolerance"
+            greenValue={3}
+            redValue={6}
+            onLoTChange={onLoTChange}
+            {...props}
+        />,
+        { preloadedState: preloadedWithRole(role) }
+    );
+
+    return { onLoTChange, user };
+};
+
+describe("LineOfToleranceSelector — rendering & role gating", () => {
+    it("renders the title", () => {
+        setup(USER_ROLES.EDITOR);
+
+        expect(screen.getByText("Line of Tolerance")).toBeInTheDocument();
+    });
+
+    it("enables the slider for an owner", () => {
+        setup(USER_ROLES.OWNER);
+
+        for (const thumb of screen.getAllByRole("slider")) {
+            expect(thumb).toBeEnabled();
+        }
+    });
+
+    it("enables the slider for an editor", () => {
+        setup(USER_ROLES.EDITOR);
+
+        for (const thumb of screen.getAllByRole("slider")) {
+            expect(thumb).toBeEnabled();
+        }
+    });
+
+    it("disables the slider for a viewer", () => {
+        setup(USER_ROLES.VIEWER);
+
+        for (const thumb of screen.getAllByRole("slider")) {
+            expect(thumb).toBeDisabled();
+        }
+    });
+
+    it("disables the slider when there is no current project role", () => {
+        setup(undefined);
+
+        for (const thumb of screen.getAllByRole("slider")) {
+            expect(thumb).toBeDisabled();
+        }
+    });
+});
+
+describe("LineOfToleranceSelector — value conversion", () => {
+    it("reports converted risk values when the green thumb is moved up one step", async () => {
+        // greenValue 3 sits on slider index 3; one step right lands on index 4 → risk value 4.
+        // redValue 6 stays on index 6 → risk value 6.
+        const { onLoTChange, user } = setup(USER_ROLES.EDITOR);
+        const [greenThumb] = screen.getAllByRole("slider");
+
+        greenThumb!.focus();
+        await user.keyboard("{ArrowRight}");
+
+        expect(onLoTChange).toHaveBeenCalledWith([4, 6], expect.any(Boolean));
+    });
+});

--- a/apps/frontend/src/view/components/line-of-tolerance-selector.component.test.tsx
+++ b/apps/frontend/src/view/components/line-of-tolerance-selector.component.test.tsx
@@ -32,6 +32,16 @@ const setup = (role: USER_ROLES | undefined, props: Partial<ComponentProps<typeo
     return { onLoTChange, user };
 };
 
+const expectSliderDisabled = (disabled: boolean) => {
+    for (const thumb of screen.getAllByRole("slider")) {
+        if (disabled) {
+            expect(thumb).toBeDisabled();
+        } else {
+            expect(thumb).toBeEnabled();
+        }
+    }
+};
+
 describe("LineOfToleranceSelector — rendering & role gating", () => {
     it("renders the title", () => {
         setup(USER_ROLES.EDITOR);
@@ -42,33 +52,25 @@ describe("LineOfToleranceSelector — rendering & role gating", () => {
     it("enables the slider for an owner", () => {
         setup(USER_ROLES.OWNER);
 
-        for (const thumb of screen.getAllByRole("slider")) {
-            expect(thumb).toBeEnabled();
-        }
+        expectSliderDisabled(false);
     });
 
     it("enables the slider for an editor", () => {
         setup(USER_ROLES.EDITOR);
 
-        for (const thumb of screen.getAllByRole("slider")) {
-            expect(thumb).toBeEnabled();
-        }
+        expectSliderDisabled(false);
     });
 
     it("disables the slider for a viewer", () => {
         setup(USER_ROLES.VIEWER);
 
-        for (const thumb of screen.getAllByRole("slider")) {
-            expect(thumb).toBeDisabled();
-        }
+        expectSliderDisabled(true);
     });
 
     it("disables the slider when there is no current project role", () => {
         setup(undefined);
 
-        for (const thumb of screen.getAllByRole("slider")) {
-            expect(thumb).toBeDisabled();
-        }
+        expectSliderDisabled(true);
     });
 });
 

--- a/apps/frontend/src/view/components/list-box.component.test.tsx
+++ b/apps/frontend/src/view/components/list-box.component.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { ListBox } from "./list-box.component";
+
+describe("ListBox", () => {
+    it("renders its children", () => {
+        renderWithProviders(
+            <ListBox>
+                <span>panel content</span>
+            </ListBox>
+        );
+
+        expect(screen.getByText("panel content")).toBeInTheDocument();
+    });
+
+    it("forwards arbitrary box props such as data-testid", () => {
+        renderWithProviders(<ListBox data-testid="my-list-box">x</ListBox>);
+
+        expect(screen.getByTestId("my-list-box")).toBeInTheDocument();
+    });
+
+    it("forwards event handlers to the underlying box", async () => {
+        const onClick = vi.fn();
+        const user = userEvent.setup();
+
+        renderWithProviders(
+            <ListBox data-testid="clickable-box" onClick={onClick}>
+                x
+            </ListBox>
+        );
+        await user.click(screen.getByTestId("clickable-box"));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/frontend/src/view/components/matrix.component.test.tsx
+++ b/apps/frontend/src/view/components/matrix.component.test.tsx
@@ -1,0 +1,53 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { translationUtil } from "#utils/translations.ts";
+import type { MatrixGrid } from "#application/hooks/use-matrix.hook.ts";
+import { Matrix } from "./matrix.component";
+
+// A 1x1 grid. The top-left cell maps to probabilityAxis[0] = 5 and damageAxis[0] = 1.
+const singleCell = (cell: { amount?: number; selected?: boolean } = {}): MatrixGrid =>
+    [[{ color: "red", ...cell }]] as MatrixGrid;
+
+describe("Matrix", () => {
+    it("renders the probability and damage axis titles", () => {
+        renderWithProviders(<Matrix matrix={singleCell({ amount: 3 })} onSelectCell={vi.fn()} />);
+
+        expect(screen.getByText(translationUtil.t("probabilityAxis", { ns: "riskPage" }))).toBeInTheDocument();
+        expect(screen.getByText(translationUtil.t("damageAxis", { ns: "riskPage" }))).toBeInTheDocument();
+    });
+
+    it("renders the amount held by a cell", () => {
+        renderWithProviders(<Matrix matrix={singleCell({ amount: 7 })} onSelectCell={vi.fn()} />);
+
+        expect(screen.getByText("7")).toBeInTheDocument();
+    });
+
+    it("renders no amount label for an empty cell", () => {
+        renderWithProviders(<Matrix matrix={singleCell()} onSelectCell={vi.fn()} />);
+
+        expect(screen.queryByText("7")).not.toBeInTheDocument();
+    });
+
+    it("reports the clicked cell's probability and damage", async () => {
+        const onSelectCell = vi.fn();
+        const user = userEvent.setup();
+
+        renderWithProviders(<Matrix matrix={singleCell({ amount: 7 })} onSelectCell={onSelectCell} />);
+        await user.click(screen.getByText("7"));
+
+        expect(onSelectCell).toHaveBeenCalledTimes(1);
+        expect(onSelectCell).toHaveBeenCalledWith(expect.anything(), { probability: 5, damage: 1 });
+    });
+
+    it("reports null when an already-selected cell is clicked (toggle off)", async () => {
+        const onSelectCell = vi.fn();
+        const user = userEvent.setup();
+
+        renderWithProviders(<Matrix matrix={singleCell({ amount: 7, selected: true })} onSelectCell={onSelectCell} />);
+        await user.click(screen.getByText("7"));
+
+        expect(onSelectCell).toHaveBeenCalledTimes(1);
+        expect(onSelectCell).toHaveBeenCalledWith(expect.anything(), null);
+    });
+});

--- a/apps/frontend/src/view/components/user-panel.component.test.tsx
+++ b/apps/frontend/src/view/components/user-panel.component.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { userDefaultState, type UserState } from "#application/reducers/user.reducer.ts";
+import { UserActions } from "#application/actions/user.actions.ts";
+import UserPanel from "./user-panel.component";
+
+const renderPanel = (user: Partial<UserState> = {}) =>
+    renderWithProviders(<UserPanel />, {
+        preloadedState: { user: { ...userDefaultState, ...user } },
+    });
+
+describe("UserPanel — avatar initials", () => {
+    it("shows first and last initials when both names are present", () => {
+        renderPanel({ firstname: "Alice", lastname: "Bob" });
+
+        expect(screen.getByText("AB")).toBeInTheDocument();
+    });
+
+    it("falls back to the display name initial when no first/last name is set", () => {
+        renderPanel({ displayName: "Zorro" });
+
+        expect(screen.getByText("Z")).toBeInTheDocument();
+    });
+
+    it("uses the first name initial when only the first name is set", () => {
+        renderPanel({ firstname: "Alice" });
+
+        expect(screen.getByText("A")).toBeInTheDocument();
+    });
+
+    it("uses the last name initial when only the last name is set", () => {
+        renderPanel({ lastname: "Bob" });
+
+        expect(screen.getByText("B")).toBeInTheDocument();
+    });
+
+    it("ignores whitespace-only names and renders an empty avatar", () => {
+        renderPanel({ firstname: "   ", lastname: "\t" });
+
+        expect(screen.getByTestId("navigation-header_account-button").textContent).toBe("");
+    });
+});
+
+describe("UserPanel — account menu", () => {
+    it("keeps the menu closed until the account button is clicked", async () => {
+        const user = userEvent.setup();
+        renderPanel({ firstname: "Alice", lastname: "Bob" });
+
+        expect(screen.queryByTestId("account-menu_username")).not.toBeInTheDocument();
+
+        await user.click(screen.getByTestId("navigation-header_account-button"));
+
+        expect(screen.getByTestId("account-menu_username")).toHaveTextContent("Alice Bob");
+    });
+
+    it("dispatches the logout action when the logout item is clicked", async () => {
+        const logOut = vi.spyOn(UserActions, "logOut").mockReturnValue((() => Promise.resolve()) as never);
+        const user = userEvent.setup();
+        renderPanel({ firstname: "Alice", lastname: "Bob" });
+
+        await user.click(screen.getByTestId("navigation-header_account-button"));
+        await user.click(screen.getByTestId("account-menu_logout-button"));
+
+        expect(logOut).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
<head></head><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(18, 19, 20); text-decoration-color: initial;">Summary</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(18, 19, 20); text-decoration-color: initial;">Adds unit tests for seven previously untested small view components. No production code is changed — this PR is test-only.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(18, 19, 20); text-decoration-color: initial;">Frontend unit-test coverage rises from <strong>38.5% → 40.6%</strong> statements (branches 28.0% → 30.4%).</p><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(18, 19, 20); text-decoration-color: initial;">Components covered (all were at 0%)</h2>
Component | What is tested
-- | --
confirm.component.tsx | accept/cancel callbacks, conditional cancel button, string vs. highlighted-object message, backdrop cancel
user-panel.component.tsx | avatar-initials fallbacks (all branches), account menu open, logout dispatch
list-box.component.tsx | children rendering, box prop and event-handler forwarding
matrix.component.tsx | axis titles, cell amount, cell-click payload (probability/damage), toggle-off on a selected cell
alert.component.tsx | visibility gate, close callback, error-driven redirects (/login on auth error, no re-redirect when already there, /projects on existence error)
icon-selector.component.tsx | helper text, pre-selected icon reflection, onChange with chosen icon, search-term filtering
line-of-tolerance-selector.component.tsx | title, role gating (enabled for owner/editor, disabled for viewer / no role), linear-index → risk-value conversion

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(18, 19, 20); text-decoration-color: initial;"><strong>39 tests total.</strong> Shared <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">setup</code>/assertion helpers keep the files DRY, following the existing <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">project-card</code>/<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">create-page</code> test conventions.</p><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(18, 19, 20); text-decoration-color: initial;">Notes</h2><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(18, 19, 20); text-decoration-color: initial;"><li>Tests use the existing<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">renderWithProviders</code><span> </span>harness and the<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mock-hooks</code><span> </span>spies; no new test infrastructure.</li><li>Behavior-focused assertions only (no snapshot tests, no assertions on internal styles/mechanisms).</li><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pnpm --filter threatsea_fe test:unit</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">type-check</code>, and<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">lint</code><span> </span>all pass.</li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(18, 19, 20); text-decoration-color: initial;">🤖 Generated with <a href="https://claude.com/claude-code" target="_blank" rel="noopener noreferrer" style="color: rgb(72, 160, 199); text-decoration: rgb(72, 160, 199);">Claude Code</a></p>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new frontend test coverage for multiple components, including confirmation dialogs, list boxes, user panels, alerts, icon selection, line-of-tolerance sliders, and matrices.
  * Verified key user interactions: open/close and backdrop/cancel/confirm flows; forwarded props and click handling; avatar/menus and logout action wiring; alert visibility plus close and conditional navigation behavior; icon helper text, filtering, and selection; role-based slider enablement and value conversion; and matrix cell select/toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->