### PR TITLE
feat(editor): add arrow-key event for selected component

### DIFF
--- a/apps/frontend/src/application/hooks/use-keyboard-component-move.hook.test.ts
+++ b/apps/frontend/src/application/hooks/use-keyboard-component-move.hook.test.ts
@@ -1,0 +1,270 @@
+import { act, renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+import type { Component } from "#api/types/system.types.ts";
+import { createComponentPayload } from "#test-utils/builders.ts";
+import { useKeyboardComponentMove, type HelpLines } from "./use-keyboard-component-move.hook";
+
+const makeComponent = (overrides: Partial<Component> = {}): Component =>
+    ({
+        ...createComponentPayload(),
+        width: 80,
+        height: 80,
+        selected: true,
+        ...overrides,
+    }) as Component;
+
+const makeKeyEvent = (key: string, target: EventTarget | null = null) =>
+    ({
+        key,
+        target,
+        preventDefault: vi.fn(),
+    }) as unknown as KeyboardEvent & { preventDefault: ReturnType<typeof vi.fn> };
+
+const setup = (overrides: Partial<Parameters<typeof useKeyboardComponentMove>[0]> = {}) => {
+    const moveComponent = vi.fn();
+    const updateConnectionsOfComponent = vi.fn();
+    const setShowHelpLines = vi.fn();
+    const currentHelpLinesRef: RefObject<HelpLines | null> = { current: null };
+
+    const utils = renderHook((props: Partial<Parameters<typeof useKeyboardComponentMove>[0]>) =>
+        useKeyboardComponentMove({
+            selectedComponent: makeComponent({ x: 100, y: 100 }),
+            isEditor: true,
+            isAnyComponentInUse: false,
+            layerPosition: { x: 0, y: 0 },
+            gridSizeX: 20,
+            gridSizeY: 20,
+            currentHelpLinesRef,
+            moveComponent,
+            updateConnectionsOfComponent,
+            setShowHelpLines,
+            ...overrides,
+            ...props,
+        })
+    );
+
+    return { ...utils, moveComponent, updateConnectionsOfComponent, setShowHelpLines, currentHelpLinesRef };
+};
+
+describe("useKeyboardComponentMove", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
+
+    describe("handleKeyDown guards", () => {
+        it("ignores non-arrow keys without moving or preventing default", () => {
+            const { result, moveComponent, setShowHelpLines } = setup();
+            const event = makeKeyEvent("Enter");
+
+            act(() => {
+                result.current.handleKeyDown(event);
+            });
+
+            expect(moveComponent).not.toHaveBeenCalled();
+            expect(setShowHelpLines).not.toHaveBeenCalled();
+            expect(event.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it.each(["INPUT", "TEXTAREA", "SELECT"])(
+            "ignores arrow keys originating from a focused %s element",
+            (tagName) => {
+                const { result, moveComponent } = setup();
+                const target = document.createElement(tagName.toLowerCase());
+                const event = makeKeyEvent("ArrowUp", target);
+
+                act(() => {
+                    result.current.handleKeyDown(event);
+                });
+
+                expect(moveComponent).not.toHaveBeenCalled();
+                expect(event.preventDefault).not.toHaveBeenCalled();
+            }
+        );
+
+        it("ignores arrow keys originating from a contentEditable element", () => {
+            const { result, moveComponent } = setup();
+            const target = document.createElement("div");
+            // jsdom does not derive isContentEditable from the attribute, so set it directly.
+            Object.defineProperty(target, "isContentEditable", { value: true });
+            const event = makeKeyEvent("ArrowUp", target);
+
+            act(() => {
+                result.current.handleKeyDown(event);
+            });
+
+            expect(moveComponent).not.toHaveBeenCalled();
+        });
+
+        it("does nothing when not in editor mode", () => {
+            const { result, moveComponent } = setup({ isEditor: false });
+            const event = makeKeyEvent("ArrowUp");
+
+            act(() => {
+                result.current.handleKeyDown(event);
+            });
+
+            expect(moveComponent).not.toHaveBeenCalled();
+            expect(event.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it("does nothing when no component is selected", () => {
+            const { result, moveComponent } = setup({ selectedComponent: undefined });
+            const event = makeKeyEvent("ArrowUp");
+
+            act(() => {
+                result.current.handleKeyDown(event);
+            });
+
+            expect(moveComponent).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("nudging the selected component", () => {
+        it.each([
+            ["ArrowLeft", { x: 80, y: 100, gridX: 4, gridY: 5 }],
+            ["ArrowRight", { x: 120, y: 100, gridX: 6, gridY: 5 }],
+            ["ArrowUp", { x: 100, y: 80, gridX: 5, gridY: 4 }],
+            ["ArrowDown", { x: 100, y: 120, gridX: 5, gridY: 6 }],
+        ] as const)("moves the component one grid step on %s", (key, expected) => {
+            const { result, moveComponent } = setup();
+            const event = makeKeyEvent(key);
+
+            act(() => {
+                result.current.handleKeyDown(event);
+            });
+
+            expect(moveComponent).toHaveBeenCalledWith({
+                id: "comp-1",
+                ...expected,
+            });
+            expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        });
+
+        it("floors the grid position toward negative infinity for negative coordinates", () => {
+            const { result, moveComponent } = setup({ selectedComponent: makeComponent({ x: 10, y: 100 }) });
+
+            act(() => {
+                result.current.handleKeyDown(makeKeyEvent("ArrowLeft"));
+            });
+
+            // newx = 10 - 20 = -10; floor(-10 / 20) = -1 (not 0)
+            expect(moveComponent).toHaveBeenCalledWith({
+                id: "comp-1",
+                x: -10,
+                y: 100,
+                gridX: -1,
+                gridY: 5,
+            });
+        });
+
+        it("shows the help lines and seeds their positions with the layer offset", () => {
+            const { result, setShowHelpLines, currentHelpLinesRef } = setup({ layerPosition: { x: 30, y: 40 } });
+
+            act(() => {
+                result.current.handleKeyDown(makeKeyEvent("ArrowRight"));
+            });
+
+            // newx = 120, newy = 100
+            expect(setShowHelpLines).toHaveBeenCalledWith(true);
+            expect(currentHelpLinesRef.current).toEqual({
+                x: 120 + 9 + 30,
+                x2: 120 + 71 + 30,
+                y: 100 + 9 + 40,
+                y2: 100 + 71 + 40,
+            });
+        });
+    });
+
+    describe("deferred connection recalculation and help-line fade", () => {
+        it("recalculates connections once after the settle delay, not on each keypress", () => {
+            const { result, updateConnectionsOfComponent } = setup();
+
+            act(() => {
+                result.current.handleKeyDown(makeKeyEvent("ArrowRight"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(200);
+            });
+            // Second press before the first recalc fires resets the timer
+            act(() => {
+                result.current.handleKeyDown(makeKeyEvent("ArrowRight"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(200);
+            });
+            expect(updateConnectionsOfComponent).not.toHaveBeenCalled();
+
+            act(() => {
+                vi.advanceTimersByTime(50);
+            });
+            expect(updateConnectionsOfComponent).toHaveBeenCalledTimes(1);
+        });
+
+        it("hides the help lines after the fade delay when no drag is in progress", () => {
+            const { result, setShowHelpLines } = setup({ isAnyComponentInUse: false });
+
+            act(() => {
+                result.current.handleKeyDown(makeKeyEvent("ArrowUp"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(900);
+            });
+
+            expect(setShowHelpLines).toHaveBeenCalledWith(false);
+        });
+
+        it("keeps the help lines when a mouse drag is still in progress", () => {
+            const { result, setShowHelpLines } = setup({ isAnyComponentInUse: true });
+
+            act(() => {
+                result.current.handleKeyDown(makeKeyEvent("ArrowUp"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(900);
+            });
+
+            expect(setShowHelpLines).not.toHaveBeenCalledWith(false);
+        });
+    });
+
+    describe("clearKeyboardNudgeTimeouts", () => {
+        it("cancels the pending recalc and fade so neither fires", () => {
+            const { result, updateConnectionsOfComponent, setShowHelpLines } = setup();
+
+            act(() => {
+                result.current.handleKeyDown(makeKeyEvent("ArrowUp"));
+            });
+            act(() => {
+                result.current.clearKeyboardNudgeTimeouts();
+            });
+            act(() => {
+                vi.advanceTimersByTime(2000);
+            });
+
+            expect(updateConnectionsOfComponent).not.toHaveBeenCalled();
+            expect(setShowHelpLines).not.toHaveBeenCalledWith(false);
+        });
+    });
+
+    describe("cleanup on unmount", () => {
+        it("clears pending timers so no callback runs after unmount", () => {
+            const { result, unmount, updateConnectionsOfComponent, setShowHelpLines } = setup();
+
+            act(() => {
+                result.current.handleKeyDown(makeKeyEvent("ArrowUp"));
+            });
+            unmount();
+            act(() => {
+                vi.advanceTimersByTime(2000);
+            });
+
+            expect(updateConnectionsOfComponent).not.toHaveBeenCalled();
+            expect(setShowHelpLines).not.toHaveBeenCalledWith(false);
+        });
+    });
+});

--- a/apps/frontend/src/application/hooks/use-keyboard-component-move.hook.ts
+++ b/apps/frontend/src/application/hooks/use-keyboard-component-move.hook.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+import type { Component, Coordinate } from "#api/types/system.types.ts";
+
+export interface HelpLines {
+    x: number;
+    y: number;
+    x2: number;
+    y2: number;
+}
+
+interface UseKeyboardComponentMoveArgs {
+    selectedComponent: Component | undefined;
+    isEditor: boolean;
+    isAnyComponentInUse: boolean;
+    layerPosition: Coordinate;
+    gridSizeX: number;
+    gridSizeY: number;
+    currentHelpLinesRef: RefObject<HelpLines | null>;
+    moveComponent: (component: Pick<Component, "id" | "x" | "y" | "gridX" | "gridY">) => void;
+    updateConnectionsOfComponent: () => void;
+    setShowHelpLines: (value: boolean) => void;
+}
+
+// True when a keyboard event originated from a focused text input, so arrow-key
+// nudging is skipped while the user is typing in a field.
+const isEditableEventTarget = (target: EventTarget | null): boolean => {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+    if (target.isContentEditable) {
+        return true;
+    }
+    const tag = target.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+};
+
+export const useKeyboardComponentMove = ({
+    selectedComponent,
+    isEditor,
+    isAnyComponentInUse,
+    layerPosition,
+    gridSizeX,
+    gridSizeY,
+    currentHelpLinesRef,
+    moveComponent,
+    updateConnectionsOfComponent,
+    setShowHelpLines,
+}: UseKeyboardComponentMoveArgs) => {
+    const keyboardRecalcTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const helpLineHideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const isAnyComponentInUseRef = useRef(false);
+
+    const clearKeyboardNudgeTimeouts = useCallback((): void => {
+        if (keyboardRecalcTimeoutRef.current) {
+            clearTimeout(keyboardRecalcTimeoutRef.current);
+            keyboardRecalcTimeoutRef.current = null;
+        }
+        if (helpLineHideTimeoutRef.current) {
+            clearTimeout(helpLineHideTimeoutRef.current);
+            helpLineHideTimeoutRef.current = null;
+        }
+    }, []);
+
+    useEffect(() => {
+        isAnyComponentInUseRef.current = isAnyComponentInUse;
+    }, [isAnyComponentInUse]);
+
+    useEffect(() => {
+        return () => {
+            clearKeyboardNudgeTimeouts();
+        };
+    }, [clearKeyboardNudgeTimeouts]);
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+        const { key } = event;
+        const isArrowKey = key === "ArrowUp" || key === "ArrowDown" || key === "ArrowLeft" || key === "ArrowRight";
+        if (!isArrowKey) {
+            return;
+        }
+
+        // Skip when the keystroke came from an editable field or the user cannot edit.
+        if (isEditableEventTarget(event.target)) {
+            return;
+        }
+        if (!isEditor || selectedComponent == null) {
+            return;
+        }
+
+        // Keep the arrow key from scrolling the page while nudging a component.
+        event.preventDefault();
+
+        const deltaX = key === "ArrowLeft" ? -gridSizeX : key === "ArrowRight" ? gridSizeX : 0;
+        const deltaY = key === "ArrowUp" ? -gridSizeY : key === "ArrowDown" ? gridSizeY : 0;
+
+        const newx = selectedComponent.x + deltaX;
+        const newy = selectedComponent.y + deltaY;
+        const gridPositionX = Math.floor(newx / gridSizeX);
+        const gridPositionY = Math.floor(newy / gridSizeY);
+
+        moveComponent({
+            id: selectedComponent.id,
+            x: newx,
+            y: newy,
+            gridX: gridPositionX,
+            gridY: gridPositionY,
+        });
+
+        currentHelpLinesRef.current = {
+            x: newx + 9 + layerPosition.x,
+            x2: newx + 71 + layerPosition.x,
+            y: newy + 9 + layerPosition.y,
+            y2: newy + 71 + layerPosition.y,
+        };
+        setShowHelpLines(true);
+
+        // Recalculating connection routing is expensive, so defer it until the nudging
+        // settles instead of rerouting on every keypress (mirrors how drag recalcs once
+        // at drag-end).
+        clearKeyboardNudgeTimeouts();
+        keyboardRecalcTimeoutRef.current = setTimeout(() => {
+            updateConnectionsOfComponent();
+        }, 250);
+        helpLineHideTimeoutRef.current = setTimeout(() => {
+            if (!isAnyComponentInUseRef.current) {
+                setShowHelpLines(false);
+            }
+        }, 900);
+    };
+
+    return { handleKeyDown, clearKeyboardNudgeTimeouts };
+};

--- a/apps/frontend/src/view/components/editor-components/editor-stage.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-stage.component.tsx
@@ -20,6 +20,7 @@ interface EditorStageProps {
     handleMouseUp: (event: KonvaEventObject<MouseEvent>) => void;
     onMouseLeave: (event: KonvaEventObject<MouseEvent>) => void;
     onKeyUp: (event: KeyboardEvent) => void;
+    onKeyDown: (event: KeyboardEvent) => void;
     onScale: (scale: number, position: Coordinate) => void;
     scale: number;
     position: Coordinate;
@@ -41,6 +42,7 @@ export const EditorStage = ({
     handleMouseUp,
     onMouseLeave,
     onKeyUp,
+    onKeyDown,
     onScale,
     scale,
     position,
@@ -167,6 +169,13 @@ export const EditorStage = ({
             window.onkeyup = null;
         };
     }, [onKeyUp]);
+
+    useEffect(() => {
+        window.onkeydown = onKeyDown;
+        return () => {
+            window.onkeydown = null;
+        };
+    }, [onKeyDown]);
 
     useEffect(() => {
         const stage = stageRef.current;

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -16,6 +16,7 @@ import { useAssets } from "#application/hooks/use-assets.hook.ts";
 import { useAutoSavePreview } from "#application/hooks/use-auto-save-preview.hook.ts";
 import { useAnnotationDrawing, ANNOTATION_STROKE_WIDTH } from "#application/hooks/use-annotation-drawing.hook.ts";
 import { useEditor, type EditorConnectionAnchor } from "#application/hooks/use-editor.hook.ts";
+import { useKeyboardComponentMove, type HelpLines } from "#application/hooks/use-keyboard-component-move.hook.ts";
 import { useEditorAnnotations } from "#application/hooks/use-editor-annotations.hook.ts";
 import { useConfirm } from "#application/hooks/use-confirm.hook.ts";
 import { DEFAULT_ANNOTATION_COLOR } from "#view/colors/annotation.colors.ts";
@@ -87,13 +88,6 @@ const isEditableEventTarget = (target: EventTarget | null): boolean => {
     const tag = target.tagName;
     return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
 };
-
-interface HelpLines {
-    x: number;
-    y: number;
-    x2: number;
-    y2: number;
-}
 
 interface EditorPageBodyProps {
     updateAutoSaveOnClick?: (handler: (() => void) | undefined) => void;
@@ -306,6 +300,19 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
     // Add ref to store current help lines position
     const currentHelpLinesRef = useRef<HelpLines | null>(null);
 
+    const { handleKeyDown, clearKeyboardNudgeTimeouts } = useKeyboardComponentMove({
+        selectedComponent,
+        isEditor,
+        isAnyComponentInUse,
+        layerPosition,
+        gridSizeX: GRID_CONFIG.gridSizeX,
+        gridSizeY: GRID_CONFIG.gridSizeY,
+        currentHelpLinesRef,
+        moveComponent,
+        updateConnectionsOfComponent,
+        setShowHelpLines,
+    });
+
     const newConnectionPreviewComponent = useMemo(() => {
         if (!newConnection) {
             return undefined;
@@ -352,6 +359,8 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
     }, [loadedProjectId, projectId, lastCenteredProjectId, dispatch, navigate, location.pathname, location.state]);
 
     const handleComponentDragStart = (_event: KonvaEventObject<DragEvent>, componentId: string): void => {
+        // Cancel any pending keyboard-nudge hide so it can't clear the drag's help lines.
+        clearKeyboardNudgeTimeouts();
         addInUseComponent(componentId);
         selectComponent(componentId);
         deselectConnection();
@@ -1231,6 +1240,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
                         onContextMenuAction={handleContextMenuAction}
                         onMouseLeave={handleMouseOut}
                         onKeyUp={handleKeyUp}
+                        onKeyDown={handleKeyDown}
                         onScale={onStageScale}
                         scale={stageScale}
                         position={stagePosition}


### PR DESCRIPTION
  - Adds arrow-key nudging: move the selected editor component one grid cell per keypress (Up/Down/Left/Right)
  
  - Skips nudging while typing in a field (INPUT/TEXTAREA/SELECT/contentEditable) and when not in editor mode
  
  - Defers expensive connection re-routing until nudging settles (250 ms debounce), mirroring drag-end recalc behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Move selected editor components precisely with the keyboard arrow keys.
  * Display directional help lines while nudging components.
  * Automatically update component connections after keyboard movement.

* **Bug Fixes**
  * Keyboard movement no longer interferes with typing in text fields or editable areas.
  * Pending keyboard movement updates are canceled appropriately when dragging or leaving the editor.
  * Arrow-key movement now handles negative grid positions accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->