### PR TITLE
chore: renovate adjustment and frontend type-check fix

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,25 @@
 {
+  "lsp": {
+    "oxlint": {
+      "initialization_options": {
+        "settings": {
+          "configPath": "./.oxlintrc.json",
+          "run": "onType",
+          "disableNestedConfig": false,
+          "fixKind": "safe_fix",
+          "typeAware": true,
+          "unusedDisableDirectives": "deny"
+        }
+      }
+    },
+    "oxfmt": {
+      "initialization_options": {
+        "settings": {
+          "configPath": "./.oxfmtrc.json"
+        }
+      }
+    }
+  },
   "formatter": [
     {
       "language_server": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,7 +29,7 @@
     "cookie-parser": "1.4.7",
     "cors": "2.8.6",
     "csrf-sync": "4.2.1",
-    "dotenv": "17.4.2",
+    "dotenv": "catalog:",
     "drizzle-orm": "0.45.2",
     "express": "5.2.1",
     "express-rate-limit": "8.5.2",
@@ -49,18 +49,18 @@
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",
     "@types/express-session": "1.19.0",
-    "@types/node": "24.13.3",
+    "@types/node": "catalog:",
     "@types/pg": "8.20.0",
     "@types/supertest": "7.2.0",
-    "@vitest/coverage-v8": "4.1.10",
+    "@vitest/coverage-v8": "catalog:",
     "drizzle-kit": "0.31.10",
     "nanoid": "5.1.16",
-    "oxlint": "1.73.0",
-    "oxlint-tsgolint": "0.24.0",
+    "oxlint": "catalog:",
+    "oxlint-tsgolint": "catalog:",
     "supertest": "7.2.2",
     "tsc-alias": "1.9.0",
     "tsx": "4.23.0",
-    "vitest": "4.1.10"
+    "vitest": "catalog:"
   },
   "lint-staged": {
     "*.{cjs,js,jsx,mjs,ts,tsx}": [

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -10,9 +10,9 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b tsconfig.app.json && vite build",
     "preview": "vite preview",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc -b --noEmit",
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",
     "test": "vitest run",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -58,18 +58,18 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
-    "@types/node": "24.13.3",
+    "@types/node": "catalog:",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.3",
-    "@vitest/coverage-v8": "4.1.10",
-    "dotenv": "17.4.2",
+    "@vitest/coverage-v8": "catalog:",
+    "dotenv": "catalog:",
     "jsdom": "29.1.1",
-    "oxlint": "1.73.0",
-    "oxlint-tsgolint": "0.24.0",
+    "oxlint": "catalog:",
+    "oxlint-tsgolint": "catalog:",
     "vite": "8.1.4",
     "vite-plugin-svgr": "5.2.0",
-    "vitest": "4.1.10"
+    "vitest": "catalog:"
   },
   "lint-staged": {
     "*.{cjs,js,jsx,mjs,ts,tsx}": [

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -10,8 +10,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "compilerOptions": {
-    "types": ["node", "vite/client", "@testing-library/jest-dom"]
-  }
+  ]
 }

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "vitest.setup.ts"],
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.d.ts", "vitest.setup.ts"],
   "exclude": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,27 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@types/node':
+      specifier: 24.13.3
+      version: 24.13.3
+    '@vitest/coverage-v8':
+      specifier: 4.1.10
+      version: 4.1.10
+    dotenv:
+      specifier: 17.4.2
+      version: 17.4.2
+    oxlint:
+      specifier: 1.73.0
+      version: 1.73.0
+    oxlint-tsgolint:
+      specifier: 0.24.0
+      version: 0.24.0
+    vitest:
+      specifier: 4.1.10
+      version: 4.1.10
+
 importers:
 
   .:
@@ -63,7 +84,7 @@ importers:
         specifier: 4.2.1
         version: 4.2.1
       dotenv:
-        specifier: 17.4.2
+        specifier: 'catalog:'
         version: 17.4.2
       drizzle-orm:
         specifier: 0.45.2
@@ -118,7 +139,7 @@ importers:
         specifier: 1.19.0
         version: 1.19.0
       '@types/node':
-        specifier: 24.13.3
+        specifier: 'catalog:'
         version: 24.13.3
       '@types/pg':
         specifier: 8.20.0
@@ -127,7 +148,7 @@ importers:
         specifier: 7.2.0
         version: 7.2.0
       '@vitest/coverage-v8':
-        specifier: 4.1.10
+        specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
       drizzle-kit:
         specifier: 0.31.10
@@ -136,10 +157,10 @@ importers:
         specifier: 5.1.16
         version: 5.1.16
       oxlint:
-        specifier: 1.73.0
+        specifier: 'catalog:'
         version: 1.73.0(oxlint-tsgolint@0.24.0)
       oxlint-tsgolint:
-        specifier: 0.24.0
+        specifier: 'catalog:'
         version: 0.24.0
       supertest:
         specifier: 7.2.2
@@ -151,7 +172,7 @@ importers:
         specifier: 4.23.0
         version: 4.23.0
       vitest:
-        specifier: 4.1.10
+        specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/frontend:
@@ -251,7 +272,7 @@ importers:
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
-        specifier: 24.13.3
+        specifier: 'catalog:'
         version: 24.13.3
       '@types/react':
         specifier: 19.2.17
@@ -263,19 +284,19 @@ importers:
         specifier: 6.0.3
         version: 6.0.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
-        specifier: 4.1.10
+        specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
       dotenv:
-        specifier: 17.4.2
+        specifier: 'catalog:'
         version: 17.4.2
       jsdom:
         specifier: 29.1.1
         version: 29.1.1(@noble/hashes@1.8.0)
       oxlint:
-        specifier: 1.73.0
+        specifier: 'catalog:'
         version: 1.73.0(oxlint-tsgolint@0.24.0)
       oxlint-tsgolint:
-        specifier: 0.24.0
+        specifier: 'catalog:'
         version: 0.24.0
       vite:
         specifier: 8.1.4
@@ -284,7 +305,7 @@ importers:
         specifier: 5.2.0
         version: 5.2.0(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
-        specifier: 4.1.10
+        specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/typescript-config: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,14 @@ packages:
   - "apps/*"
   - "packages/*"
 
+catalog:
+  "@types/node": 24.13.3
+  "@vitest/coverage-v8": 4.1.10
+  dotenv: 17.4.2
+  oxlint: 1.73.0
+  oxlint-tsgolint: 0.24.0
+  vitest: 4.1.10
+
 allowBuilds:
   esbuild: false
 publicHoistPattern:

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,12 @@
     "enabled": true
   },
   "minimumReleaseAge": "72 hours",
-  "rebaseWhen": "behind-base-branch"
+  "rebaseWhen": "behind-base-branch",
+  "packageRules": [
+    {
+      "description": "minimumReleaseAge cannot be enforced for these update types (the package manager performs the resolution); without this they would be filtered as permanently pending and never raised as PRs",
+      "matchUpdateTypes": ["lockFileMaintenance", "pin", "replacement"],
+      "minimumReleaseAge": null
+    }
+  ]
 }


### PR DESCRIPTION
- chore(renovate): exclude lockfile maintenance from renovate config
- fix(frontend): add -b flag to type-check script to run with solution-style tsconfig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated frontend TypeScript build and type-check workflows to use TypeScript project build mode for more consistent validation.
  * Refined TypeScript configurations for tests and streamlined the main frontend tsconfig.
  * Updated dependency version sourcing across frontend and backend to use the shared catalog approach.
  * Adjusted maintenance automation so certain routine lockfile updates aren’t blocked by release-age filtering.
* **Developer Experience**
  * Added editor language-server settings for linting and formatting (oxlint/oxfmt).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->