### PR TITLE
feat(frontend): show project/catalogue and view in browser page title

### DIFF
--- a/apps/frontend/src/application/hooks/use-page-title.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-page-title.hook.test.tsx
@@ -1,0 +1,109 @@
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route, Routes, type InitialEntry } from "react-router";
+import { usePageTitle } from "./use-page-title.hook";
+import { catalogsAdapter } from "#application/adapters/catalogs.adapter.ts";
+import { projectsAdapter } from "#application/adapters/project.adapter.ts";
+import { createStore, type RootState } from "#application/store.ts";
+import { createCatalog, createProject } from "#test-utils/builders.ts";
+
+/**
+ * Renders usePageTitle at a given URL so useParams resolves, with the store
+ * pre-loaded. The route patterns mirror the real ones in App.tsx so the hook's
+ * projectId / catalogId extraction is exercised end to end.
+ */
+const renderUsePageTitle = (
+    viewLabel: string | undefined,
+    { initialEntries, preloadedState }: { initialEntries: InitialEntry[]; preloadedState?: Partial<RootState> }
+) => {
+    const store = createStore(preloadedState);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <Provider store={store}>
+            <MemoryRouter initialEntries={initialEntries}>
+                <Routes>
+                    <Route path="/projects/:projectId/*" element={children} />
+                    <Route path="/catalogs/:catalogId/*" element={children} />
+                    <Route path="/*" element={children} />
+                </Routes>
+            </MemoryRouter>
+        </Provider>
+    );
+    return renderHook(() => usePageTitle(viewLabel), { wrapper });
+};
+
+const projectsStateWith = (...projects: ReturnType<typeof createProject>[]): RootState["projects"] => ({
+    ...projectsAdapter.getInitialState(),
+    ...projectsAdapter.setAll(projectsAdapter.getInitialState(), projects),
+    isPending: false,
+    isLoadingAll: false,
+    current: undefined,
+    deletingProjectId: undefined,
+});
+
+const catalogsStateWith = (...catalogs: ReturnType<typeof createCatalog>[]): RootState["catalogs"] => ({
+    ...catalogsAdapter.getInitialState(),
+    ...catalogsAdapter.setAll(catalogsAdapter.getInitialState(), catalogs),
+    isPending: false,
+    current: undefined,
+});
+
+describe("usePageTitle", () => {
+    afterEach(() => {
+        document.title = "ThreatSea";
+    });
+
+    it("composes app name, project name and view label", () => {
+        renderUsePageTitle("Assets", {
+            initialEntries: ["/projects/5/assets"],
+            preloadedState: { projects: projectsStateWith(createProject({ id: 5, name: "Alpha" })) },
+        });
+
+        expect(document.title).toBe("ThreatSea - Alpha - Assets");
+    });
+
+    it("composes app name, catalogue name and view label on catalogue routes", () => {
+        renderUsePageTitle("Catalogue Editor", {
+            initialEntries: ["/catalogs/7/"],
+            preloadedState: { catalogs: catalogsStateWith(createCatalog({ id: 7, name: "Std" })) },
+        });
+
+        expect(document.title).toBe("ThreatSea - Std - Catalogue Editor");
+    });
+
+    it("drops the name when the entity is not yet in the store", () => {
+        renderUsePageTitle("Assets", {
+            initialEntries: ["/projects/5/assets"],
+            preloadedState: { projects: projectsStateWith() },
+        });
+
+        expect(document.title).toBe("ThreatSea - Assets");
+    });
+
+    it("drops the view label when none is passed", () => {
+        renderUsePageTitle(undefined, {
+            initialEntries: ["/projects/5/assets"],
+            preloadedState: { projects: projectsStateWith(createProject({ id: 5, name: "Alpha" })) },
+        });
+
+        expect(document.title).toBe("ThreatSea - Alpha");
+    });
+
+    it("falls back to the bare app name on a route with no entity", () => {
+        renderUsePageTitle(undefined, { initialEntries: ["/nowhere"] });
+
+        expect(document.title).toBe("ThreatSea");
+    });
+
+    it("resets the title to the app name on unmount", () => {
+        const { unmount } = renderUsePageTitle("Assets", {
+            initialEntries: ["/projects/5/assets"],
+            preloadedState: { projects: projectsStateWith(createProject({ id: 5, name: "Alpha" })) },
+        });
+        expect(document.title).toBe("ThreatSea - Alpha - Assets");
+
+        unmount();
+
+        expect(document.title).toBe("ThreatSea");
+    });
+});

--- a/apps/frontend/src/application/hooks/use-page-title.hook.ts
+++ b/apps/frontend/src/application/hooks/use-page-title.hook.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useParams } from "react-router";
+import { useAppSelector } from "./use-app-redux.hook";
+
+const APP_NAME = "ThreatSea";
+
+/**
+ * Sets the browser tab title to "ThreatSea - {project/catalogue name} - {view}".
+ * @param viewLabel Already-translated label for the current view (e.g. t("assets")).
+ */
+export const usePageTitle = (viewLabel?: string): void => {
+    const { projectId, catalogId } = useParams<{ projectId?: string; catalogId?: string }>();
+
+    const entityName = useAppSelector((state) => {
+        if (projectId) {
+            return state.projects.entities[Number(projectId)]?.name;
+        }
+        if (catalogId) {
+            return state.catalogs.entities[Number(catalogId)]?.name;
+        }
+        return undefined;
+    });
+
+    const title = [APP_NAME, entityName, viewLabel].filter(Boolean).join(" - ");
+
+    useEffect(() => {
+        document.title = title;
+        return () => {
+            document.title = APP_NAME;
+        };
+    }, [title]);
+};

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -1,4 +1,5 @@
 import type { Asset } from "#api/types/asset.types.ts";
+import type { CatalogWithRole } from "#api/types/catalogs.types.ts";
 import type { ExtendedProject } from "#api/types/project.types.ts";
 import type { ExtendedThreat } from "#api/types/threat.types.ts";
 import type { Measure } from "#api/types/measure.types.ts";
@@ -144,6 +145,16 @@ export const createProject = (overrides: Partial<ExtendedProject> = {}): Extende
     updatedAt: new Date("2025-01-01"),
     role: USER_ROLES.EDITOR,
     image: null,
+    ...overrides,
+});
+
+export const createCatalog = (overrides: Partial<CatalogWithRole> = {}): CatalogWithRole => ({
+    id: 1,
+    name: "Test Catalog",
+    language: "EN",
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    role: USER_ROLES.EDITOR,
     ...overrides,
 });
 

--- a/apps/frontend/src/translations/de/common.de.json
+++ b/apps/frontend/src/translations/de/common.de.json
@@ -63,6 +63,9 @@
   "role": "Rolle",
   "scheduledAt": "Geplant für",
   "system": "System",
+  "member": "Mitglieder",
+  "projects": "Projekte",
+  "catalogueEditor": "Katalog-Editor",
   "title": "Titel",
 
   "addBtn": "Hinzufügen",

--- a/apps/frontend/src/translations/en/common.en.json
+++ b/apps/frontend/src/translations/en/common.en.json
@@ -60,6 +60,10 @@
   "role": "Role",
   "scheduledAt": "Scheduled at",
   "system": "System",
+  "member": "Members",
+  "projects": "Projects",
+  "catalogs": "Catalogs",
+  "catalogueEditor": "Catalogue Editor",
 
   "addBtn": "Add",
   "cancel": "Cancel",

--- a/apps/frontend/src/view/pages/assets.page.tsx
+++ b/apps/frontend/src/view/pages/assets.page.tsx
@@ -26,6 +26,7 @@ import { Page } from "#view/components/page.component.tsx";
 import { SearchField } from "#view/components/search-field.component.tsx";
 import { CustomTableHeaderCell } from "#view/components/table-header.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import { withProject } from "#view/components/with-project.hoc.tsx";
 import AssetDialogPage from "./asset-dialog.page";
@@ -58,6 +59,7 @@ const AssetsPageBody = ({ project }: AssetsPageBodyProps) => {
         t,
         i18n: { language },
     } = useTranslation("assetsPage");
+    usePageTitle(t("assets", { ns: "common" }));
 
     const { setSortDirection, setSearchValue, setSortBy, deleteAsset, sortDirection, sortBy, isPending, assets } =
         useAssetsList({

--- a/apps/frontend/src/view/pages/catalog.page.tsx
+++ b/apps/frontend/src/view/pages/catalog.page.tsx
@@ -18,6 +18,7 @@ import { CatalogThreatsListBox } from "#view/components/catalog-threats-list-box
 import { MatrixFilterToggleButtonGroup } from "#view/components/matrix-filter-toggle-button-group.component.tsx";
 import { Page } from "#view/components/page.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import CatalogMeasureDialogPage from "#view/pages/catalog-measure-dialog.page.tsx";
 import CatalogThreatDialogPage from "#view/pages/catalog-threat-dialog.page.tsx";
@@ -32,6 +33,7 @@ const CatalogPageBody = () => {
     const [pointOfAttack, setPointOfAttack] = useState<POINTS_OF_ATTACK | null>(null);
     const navigate = useNavigate();
     const { t } = useTranslation("catalogPage");
+    usePageTitle(t("catalogueEditor", { ns: "common" }));
 
     const dispatch = useAppDispatch();
 

--- a/apps/frontend/src/view/pages/catalogs.page.tsx
+++ b/apps/frontend/src/view/pages/catalogs.page.tsx
@@ -29,6 +29,7 @@ import { Page } from "#view/components/page.component.tsx";
 import { SearchField } from "#view/components/search-field.component.tsx";
 import { ToggleButtons } from "#view/components/toggle-buttons.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import { checkUserRole, USER_ROLES } from "#api/types/user-roles.types.ts";
 import CatalogDialogPage from "./catalog-dialog.page";
@@ -53,6 +54,7 @@ const CatalogsPageBody = () => {
         t,
         i18n: { language },
     } = useTranslation("catalogsPage");
+    usePageTitle(t("catalogs", { ns: "common" }));
 
     const { setSortDirection, setSearchValue, setSortBy, isPending, sortDirection, sortBy, catalogs } =
         useCatalogsList();

--- a/apps/frontend/src/view/pages/editor.page.test.tsx
+++ b/apps/frontend/src/view/pages/editor.page.test.tsx
@@ -108,7 +108,7 @@ const renderEditorPage = ({
         {
             initialEntries,
             preloadedState: {
-                projects: { current: { role } } as never,
+                projects: { ids: [], entities: {}, current: { role } } as never,
                 editor: { stageScale: 1, stagePosition: { x: 0, y: 0 } } as never,
             },
         }

--- a/apps/frontend/src/view/pages/editor.page.tsx
+++ b/apps/frontend/src/view/pages/editor.page.tsx
@@ -19,6 +19,7 @@ import { useEditor, type EditorConnectionAnchor } from "#application/hooks/use-e
 import { useKeyboardComponentMove, type HelpLines } from "#application/hooks/use-keyboard-component-move.hook.ts";
 import { useEditorAnnotations } from "#application/hooks/use-editor-annotations.hook.ts";
 import { useConfirm } from "#application/hooks/use-confirm.hook.ts";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { DEFAULT_ANNOTATION_COLOR } from "#view/colors/annotation.colors.ts";
 import { AnnotationDrawingPreview } from "#view/components/editor-components/annotation-drawing-preview.component.tsx";
 import { ConnectionPreview } from "#view/components/editor-components/connection-preview.component.tsx";
@@ -182,6 +183,7 @@ const EditorPageBody = ({ updateAutoSaveOnClick }: EditorPageBodyProps) => {
         showErrorMessage,
     });
     const { t } = useTranslation("editorPage");
+    usePageTitle(t("system", { ns: "common" }));
 
     const { loadAssets, items } = useAssets({
         projectId,

--- a/apps/frontend/src/view/pages/measures.page.tsx
+++ b/apps/frontend/src/view/pages/measures.page.tsx
@@ -11,6 +11,7 @@ import { NavigationActions } from "#application/actions/navigation.actions.ts";
 import { useConfirm } from "#application/hooks/use-confirm.hook.ts";
 import { Page } from "#view/components/page.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import { withProject } from "#view/components/with-project.hoc.tsx";
 import MeasureDetailsDialogPage from "./measure-details-dialog.page";
@@ -42,6 +43,7 @@ type MeasureDialogState = Omit<Partial<Measure>, "id" | "scheduledAt"> & {
 
 const MeasuresPageBody = ({ project }: MeasuresPageBodyProps) => {
     const { t } = useTranslation("measuresPage");
+    usePageTitle(t("measures", { ns: "common" }));
     const { openConfirm } = useConfirm<Measure>();
     const dispatch = useAppDispatch();
     const navigate = useNavigate();

--- a/apps/frontend/src/view/pages/member.page.tsx
+++ b/apps/frontend/src/view/pages/member.page.tsx
@@ -20,6 +20,7 @@ import { Page } from "#view/components/page.component.tsx";
 import { SearchField } from "#view/components/search-field.component.tsx";
 import { CustomTableHeaderCell } from "#view/components/table-header.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import MemberDialogPage from "./member-dialog.page";
 import { NavigationActions } from "#application/actions/navigation.actions.ts";
@@ -43,6 +44,7 @@ const MemberPageBody = () => {
     const { openConfirm } = useConfirm<DeleteMemberConfirmState>();
     const navigate = useNavigate();
     const { t } = useTranslation("memberPage");
+    usePageTitle(t("member", { ns: "common" }));
     const { projectId, catalogId } = useParams<{ projectId?: string; catalogId?: string }>();
     const [memberRole, setMemberRole] = useState<USER_ROLES | null>(null);
 

--- a/apps/frontend/src/view/pages/projects.page.tsx
+++ b/apps/frontend/src/view/pages/projects.page.tsx
@@ -14,6 +14,7 @@ import { ProjectsGridComponent } from "#view/components/projects-grid.component.
 import { SearchField } from "#view/components/search-field.component.tsx";
 import { ToggleButtons } from "#view/components/toggle-buttons.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import ProjectDialogPage from "./project-dialog.page";
 import { ImportIconButton } from "#view/components/import-icon-button.component.tsx";
@@ -34,6 +35,7 @@ import { IconButton } from "#view/components/icon-button.component.tsx";
 export const ProjectsPage = CreatePage(HeaderUtilityControls, () => {
     const navigate = useNavigate();
     const { t } = useTranslation("projectsPage");
+    usePageTitle(t("projects", { ns: "common" }));
     const { setSortDirection, setSearchValue, setSortBy, deleteProject, sortDirection, sortBy, isPending, projects } =
         useProjectsList();
 

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -17,6 +17,7 @@ import { DialogTextField } from "#view/components/dialog.textfield.component.tsx
 import { Page } from "#view/components/page.component.tsx";
 import { ToggleButtons } from "#view/components/toggle-buttons.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import { Report } from "#view/report/report.tsx";
 import { downloadMarkdownReport } from "#view/report/download-markdown-report.ts";
@@ -64,6 +65,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
         t,
         i18n: { language },
     } = useTranslation("reportPage");
+    usePageTitle(t("report", { ns: "common" }));
 
     const projectId = project.id;
 

--- a/apps/frontend/src/view/pages/risk.page.tsx
+++ b/apps/frontend/src/view/pages/risk.page.tsx
@@ -35,6 +35,7 @@ import { Page } from "#view/components/page.component.tsx";
 import { SearchField } from "#view/components/search-field.component.tsx";
 import { Tooltip } from "#view/components/tooltip.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import { withProject } from "#view/components/with-project.hoc.tsx";
 import { MeasureImpactByMeasureDialogPage } from "./measure-impact-by-measure-dialog.page";
@@ -61,6 +62,7 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
         t,
         i18n: { language },
     } = useTranslation("riskPage");
+    usePageTitle(t("risk", { ns: "common" }));
     const {
         timeline,
         matrix,

--- a/apps/frontend/src/view/pages/threats.page.tsx
+++ b/apps/frontend/src/view/pages/threats.page.tsx
@@ -21,6 +21,7 @@ import { Page } from "#view/components/page.component.tsx";
 import { SearchField } from "#view/components/search-field.component.tsx";
 import { CustomTableHeaderCell } from "#view/components/table-header.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
+import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import ThreatDialogPage from "./threat-dialog.page";
 import { MeasureImpactByMeasureDialogPage } from "./measure-impact-by-measure-dialog.page";
@@ -39,6 +40,7 @@ const ThreatsPageBody = () => {
     const { openConfirm } = useConfirm<ExtendedThreat>();
     const navigate = useNavigate();
     const { t } = useTranslation("threatsPage");
+    usePageTitle(t("threats", { ns: "common" }));
 
     const {
         setSortDirection,


### PR DESCRIPTION
## Summary
  Resolves #862 

  - Browser tab title now reflects context: `ThreatSea - {project/catalogue} - {view}`
  - Covers all project views (System/Assets/Threats/Measures/Risk/Report/Members), catalogue editor + members, and the project/catalogue list pages
  - Falls back to plain `ThreatSea` when no entity/view (login, imprint, privacy, loading)
  
  ## Screenshots
<img width="1548" height="680" alt="Screenshot 2026-07-13 at 12 53 29" src="https://github.com/user-attachments/assets/5f3a6fb2-2872-45dc-9bf0-19af2e0781e1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added descriptive browser titles across projects, catalogs, assets, members, reports, risks, threats, measures, and editor pages.
  - Titles can include the current project or catalog name and the active view.
  - Added English and German labels for newly titled navigation and editor views.

- **Tests**
  - Added coverage for title composition, missing entities, routes without entities, and title reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->