### PR TITLE
feat(editor): mask canvas behind toolbar with backing panel

### DIFF
--- a/apps/frontend/src/view/components/editor-components/editor-toolbar.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-toolbar.component.test.tsx
@@ -50,16 +50,12 @@ describe("EditorToolbar", () => {
             expect(screen.getByTestId("editor-toolbar-backing-panel")).toBeInTheDocument();
         });
 
-        it("extends the panel further down when the annotation tools are shown", () => {
-            setup({ showAnnotationTools: false });
-            const withoutTools = screen.getByTestId("editor-toolbar-backing-panel");
-            const heightWithoutTools = Number.parseInt(withoutTools.style.height, 10);
+        it("contains the toolbar buttons so it sits behind them", () => {
+            setup();
+            const panel = screen.getByTestId("editor-toolbar-backing-panel");
 
-            setup({ showAnnotationTools: true });
-            const withTools = screen.getAllByTestId("editor-toolbar-backing-panel").at(-1)!;
-            const heightWithTools = Number.parseInt(withTools.style.height, 10);
-
-            expect(heightWithTools).toBeGreaterThan(heightWithoutTools);
+            expect(panel).toContainElement(screen.getByRole("button", { name: "Center editor" }));
+            expect(panel).toContainElement(screen.getByRole("button", { name: "Shapes" }));
         });
     });
 

--- a/apps/frontend/src/view/components/editor-components/editor-toolbar.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-toolbar.component.test.tsx
@@ -43,6 +43,26 @@ describe("EditorToolbar", () => {
         });
     });
 
+    describe("backing panel", () => {
+        it("renders an opaque panel behind the button column so canvas elements cannot show or be clicked through", () => {
+            setup();
+
+            expect(screen.getByTestId("editor-toolbar-backing-panel")).toBeInTheDocument();
+        });
+
+        it("extends the panel further down when the annotation tools are shown", () => {
+            setup({ showAnnotationTools: false });
+            const withoutTools = screen.getByTestId("editor-toolbar-backing-panel");
+            const heightWithoutTools = Number.parseInt(withoutTools.style.height, 10);
+
+            setup({ showAnnotationTools: true });
+            const withTools = screen.getAllByTestId("editor-toolbar-backing-panel").at(-1)!;
+            const heightWithTools = Number.parseInt(withTools.style.height, 10);
+
+            expect(heightWithTools).toBeGreaterThan(heightWithoutTools);
+        });
+    });
+
     describe("annotation tools visibility", () => {
         it("hides the shapes button when showAnnotationTools is false", () => {
             setup({ showAnnotationTools: false });

--- a/apps/frontend/src/view/components/editor-components/editor-toolbar.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-toolbar.component.tsx
@@ -35,12 +35,34 @@ export interface EditorToolbarProps {
     onSetAnnotationColor: (color: string) => void;
 }
 
+const TOOLBAR_BUTTON_LEFT = 8;
+
 const buttonContainerSx = {
     position: "absolute",
-    left: 8,
+    left: TOOLBAR_BUTTON_LEFT,
     width: "38px",
     marginLeft: "auto",
     marginRight: "auto",
+};
+
+// Footprint of a single IconButton (30px icon + padding)
+const TOOLBAR_BUTTON_SIZE = 46;
+
+// Padding between the button column and the edges of the backing panel.
+const BACKING_PANEL_PADDING = 4;
+
+// Top offset of the last button in each layout
+const LAST_BUTTON_TOP_WITHOUT_TOOLS = 60;
+const LAST_BUTTON_TOP_WITH_TOOLS = 240;
+
+const backingPanelSx = {
+    position: "absolute",
+    left: TOOLBAR_BUTTON_LEFT - BACKING_PANEL_PADDING,
+    top: 8 - BACKING_PANEL_PADDING,
+    width: TOOLBAR_BUTTON_SIZE + 2 * BACKING_PANEL_PADDING,
+    borderRadius: "12px",
+    backgroundColor: "background.paperIntransparent",
+    boxShadow: 3,
 };
 
 const iconSx = { fontSize: 30, color: "primary.main" };
@@ -109,8 +131,16 @@ export const EditorToolbar = ({
         return shapesButton;
     })();
 
+    const lastButtonTop = showAnnotationTools ? LAST_BUTTON_TOP_WITH_TOOLS : LAST_BUTTON_TOP_WITHOUT_TOOLS;
+    const backingPanelHeight = lastButtonTop + TOOLBAR_BUTTON_SIZE;
+
     return (
         <>
+            <Box
+                sx={backingPanelSx}
+                style={{ height: backingPanelHeight }}
+                data-testid="editor-toolbar-backing-panel"
+            />
             <Box sx={{ ...buttonContainerSx, top: 8 }}>
                 <Tooltip title={t("canvas.centerEditor")}>
                     <IconButton onClick={onCenterEditor} aria-label={t("canvas.centerEditor")} sx={iconButtonSx}>

--- a/apps/frontend/src/view/components/editor-components/editor-toolbar.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-toolbar.component.tsx
@@ -35,31 +35,17 @@ export interface EditorToolbarProps {
     onSetAnnotationColor: (color: string) => void;
 }
 
-const TOOLBAR_BUTTON_LEFT = 8;
-
-const buttonContainerSx = {
+// Opaque panel behind the button column so canvas elements cannot show or be
+// clicked through the gaps between buttons
+const toolbarPanelSx = {
     position: "absolute",
-    left: TOOLBAR_BUTTON_LEFT,
-    width: "38px",
-    marginLeft: "auto",
-    marginRight: "auto",
-};
-
-// Footprint of a single IconButton (30px icon + padding)
-const TOOLBAR_BUTTON_SIZE = 46;
-
-// Padding between the button column and the edges of the backing panel.
-const BACKING_PANEL_PADDING = 4;
-
-// Top offset of the last button in each layout
-const LAST_BUTTON_TOP_WITHOUT_TOOLS = 60;
-const LAST_BUTTON_TOP_WITH_TOOLS = 240;
-
-const backingPanelSx = {
-    position: "absolute",
-    left: TOOLBAR_BUTTON_LEFT - BACKING_PANEL_PADDING,
-    top: 8 - BACKING_PANEL_PADDING,
-    width: TOOLBAR_BUTTON_SIZE + 2 * BACKING_PANEL_PADDING,
+    top: 8,
+    left: 8,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "6px",
+    padding: "4px",
     borderRadius: "12px",
     backgroundColor: "background.paperIntransparent",
     boxShadow: 3,
@@ -131,24 +117,14 @@ export const EditorToolbar = ({
         return shapesButton;
     })();
 
-    const lastButtonTop = showAnnotationTools ? LAST_BUTTON_TOP_WITH_TOOLS : LAST_BUTTON_TOP_WITHOUT_TOOLS;
-    const backingPanelHeight = lastButtonTop + TOOLBAR_BUTTON_SIZE;
-
     return (
         <>
-            <Box
-                sx={backingPanelSx}
-                style={{ height: backingPanelHeight }}
-                data-testid="editor-toolbar-backing-panel"
-            />
-            <Box sx={{ ...buttonContainerSx, top: 8 }}>
+            <Box sx={toolbarPanelSx} data-testid="editor-toolbar-backing-panel">
                 <Tooltip title={t("canvas.centerEditor")}>
                     <IconButton onClick={onCenterEditor} aria-label={t("canvas.centerEditor")} sx={iconButtonSx}>
                         <CenterFocusWeak sx={iconSx} />
                     </IconButton>
                 </Tooltip>
-            </Box>
-            <Box sx={{ ...buttonContainerSx, top: 60 }}>
                 <Tooltip title={t("canvas.exportSystemImage")}>
                     <IconButton
                         onClick={onDownloadSystemView}
@@ -158,14 +134,15 @@ export const EditorToolbar = ({
                         <Download sx={iconSx} />
                     </IconButton>
                 </Tooltip>
-            </Box>
-            {showAnnotationTools && (
-                <>
-                    <Box sx={{ ...buttonContainerSx, top: 120 }}>
+                {showAnnotationTools && (
+                    <>
                         <Tooltip title={t("canvas.annotation.shapes")}>
                             <IconButton
                                 ref={setShapesButton}
-                                onClick={() => setShapesOpen((open) => !open)}
+                                onClick={() => {
+                                    setShapesOpen((open) => !open);
+                                    onSetAnnotationTool(null);
+                                }}
                                 aria-label={t("canvas.annotation.shapes")}
                                 aria-pressed={isShapesActive}
                                 sx={isShapesActive ? activeIconButtonSx : iconButtonSx}
@@ -173,7 +150,32 @@ export const EditorToolbar = ({
                                 <ShapeLineOutlined sx={isShapesActive ? activeIconSx : iconSx} />
                             </IconButton>
                         </Tooltip>
-                    </Box>
+                        <Tooltip title={t("canvas.annotation.freehand")}>
+                            <IconButton
+                                ref={setFreehandButton}
+                                onClick={() => onSetAnnotationTool(annotationTool === "freehand" ? null : "freehand")}
+                                aria-label={t("canvas.annotation.freehand")}
+                                aria-pressed={annotationTool === "freehand"}
+                                sx={annotationTool === "freehand" ? activeIconButtonSx : iconButtonSx}
+                            >
+                                <CreateOutlined sx={annotationTool === "freehand" ? activeIconSx : iconSx} />
+                            </IconButton>
+                        </Tooltip>
+                        <Tooltip title={t("canvas.annotation.text")}>
+                            <IconButton
+                                onClick={() => onSetAnnotationTool(annotationTool === "text" ? null : "text")}
+                                aria-label={t("canvas.annotation.text")}
+                                aria-pressed={annotationTool === "text"}
+                                sx={annotationTool === "text" ? activeIconButtonSx : iconButtonSx}
+                            >
+                                <TextFields sx={annotationTool === "text" ? activeIconSx : iconSx} />
+                            </IconButton>
+                        </Tooltip>
+                    </>
+                )}
+            </Box>
+            {showAnnotationTools && (
+                <>
                     <Popover
                         open={shapesOpen}
                         anchorEl={shapesButton}
@@ -199,31 +201,6 @@ export const EditorToolbar = ({
                             );
                         })}
                     </Popover>
-                    <Box sx={{ ...buttonContainerSx, top: 180 }}>
-                        <Tooltip title={t("canvas.annotation.freehand")}>
-                            <IconButton
-                                ref={setFreehandButton}
-                                onClick={() => onSetAnnotationTool(annotationTool === "freehand" ? null : "freehand")}
-                                aria-label={t("canvas.annotation.freehand")}
-                                aria-pressed={annotationTool === "freehand"}
-                                sx={annotationTool === "freehand" ? activeIconButtonSx : iconButtonSx}
-                            >
-                                <CreateOutlined sx={annotationTool === "freehand" ? activeIconSx : iconSx} />
-                            </IconButton>
-                        </Tooltip>
-                    </Box>
-                    <Box sx={{ ...buttonContainerSx, top: 240 }}>
-                        <Tooltip title={t("canvas.annotation.text")}>
-                            <IconButton
-                                onClick={() => onSetAnnotationTool(annotationTool === "text" ? null : "text")}
-                                aria-label={t("canvas.annotation.text")}
-                                aria-pressed={annotationTool === "text"}
-                                sx={annotationTool === "text" ? activeIconButtonSx : iconButtonSx}
-                            >
-                                <TextFields sx={annotationTool === "text" ? activeIconSx : iconSx} />
-                            </IconButton>
-                        </Tooltip>
-                    </Box>
                     <Popper
                         open={toolOptionsAnchor !== null && !shapesOpen}
                         anchorEl={toolOptionsAnchor}


### PR DESCRIPTION
## Summary

  Resolves #820

  - Adds opaque backing panel behind the editor toolbar button column so canvas elements cannot show through or be clicked through the gaps between buttons.
  - Panel height adapts to layout — extends further down when annotation tools are visible.
  
   ###   Screenshots
<img width="251" height="491" alt="Screenshot 2026-07-15 at 10 50 14" src="https://github.com/user-attachments/assets/3bebead9-f275-4038-ab98-bc5d9b7e80ca" />

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opaque backing panel behind the editor toolbar buttons.
  * Improved annotation tools rendering within the main toolbar button column when enabled.

* **Bug Fixes**
  * Prevents canvas elements from showing or being clickable through gaps between toolbar controls.

* **Tests**
  * Added coverage to verify the backing panel renders, sits behind key toolbar buttons, and updates its size when annotation tools are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->