### PR TITLE
feat(report): generate PDF in a web worker and add spinner in loading message

### DIFF
--- a/apps/frontend/src/application/hooks/use-report-pdf.hook.test.ts
+++ b/apps/frontend/src/application/hooks/use-report-pdf.hook.test.ts
@@ -1,0 +1,192 @@
+import { act, renderHook } from "@testing-library/react";
+import { useReportPdf } from "./use-report-pdf.hook";
+import type { ReportProps } from "#view/report/report.tsx";
+
+/**
+ * A stand-in for the Vite `?worker` import. Each instance records the messages
+ * the hook posts and exposes helpers to drive the handlers the hook assigns
+ * (onmessage / onerror / onmessageerror), letting tests simulate worker replies.
+ */
+const { MockWorker } = vi.hoisted(() => {
+    class MockWorker {
+        static instances: MockWorker[] = [];
+        onmessage: ((event: MessageEvent) => void) | null = null;
+        onerror: ((event: { message: string }) => void) | null = null;
+        onmessageerror: (() => void) | null = null;
+        postMessage = vi.fn();
+        terminate = vi.fn();
+
+        constructor() {
+            MockWorker.instances.push(this);
+        }
+
+        emitMessage(data: unknown) {
+            this.onmessage?.({ data } as MessageEvent);
+        }
+
+        emitError(message: string) {
+            this.onerror?.({ message });
+        }
+
+        emitMessageError() {
+            this.onmessageerror?.();
+        }
+    }
+    return { MockWorker };
+});
+
+vi.mock("#view/report/report.worker.ts?worker", () => ({ default: MockWorker }));
+
+const buildProps = (overrides: Partial<ReportProps> = {}): ReportProps => ({
+    bruttoMatrix: null,
+    nettoMatrix: null,
+    language: "en",
+    data: {} as ReportProps["data"],
+    ...overrides,
+});
+
+const latestWorker = () => MockWorker.instances[MockWorker.instances.length - 1]!;
+
+describe("useReportPdf", () => {
+    beforeEach(() => {
+        MockWorker.instances = [];
+        globalThis.URL.createObjectURL = vi.fn(() => "blob:generated-url");
+        globalThis.URL.revokeObjectURL = vi.fn();
+    });
+
+    it("starts idle with no url, not loading and no error", () => {
+        const { result } = renderHook(() => useReportPdf());
+
+        expect(result.current.url).toBeNull();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+    });
+
+    it("posts the props with an incrementing id and enters the loading state on generate", () => {
+        const { result } = renderHook(() => useReportPdf());
+        const props = buildProps({ language: "de" });
+
+        act(() => result.current.generate(props));
+
+        expect(latestWorker().postMessage).toHaveBeenCalledWith({ id: 1, props });
+        expect(result.current.loading).toBe(true);
+        expect(result.current.url).toBeNull();
+        expect(result.current.error).toBeNull();
+    });
+
+    it("increments the request id on each subsequent generate", () => {
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        act(() => result.current.generate(buildProps()));
+
+        expect(latestWorker().postMessage).toHaveBeenLastCalledWith(expect.objectContaining({ id: 2 }));
+    });
+
+    it("exposes the object url and clears loading when the worker returns a blob", () => {
+        const blob = new Blob(["pdf"]);
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        act(() => latestWorker().emitMessage({ id: 1, blob }));
+
+        expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+        expect(result.current.url).toBe("blob:generated-url");
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+    });
+
+    it("ignores a response whose id has already been superseded", () => {
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        act(() => result.current.generate(buildProps()));
+        // Reply to the first (now stale) request.
+        act(() => latestWorker().emitMessage({ id: 1, blob: new Blob(["stale"]) }));
+
+        expect(result.current.url).toBeNull();
+        expect(result.current.loading).toBe(true);
+        expect(URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the error message when the worker reports an error", () => {
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        act(() => latestWorker().emitMessage({ id: 1, error: "layout blew up" }));
+
+        expect(result.current.error).toBe("layout blew up");
+        expect(result.current.loading).toBe(false);
+        expect(result.current.url).toBeNull();
+    });
+
+    it("falls back to a generic message when the worker returns neither blob nor error", () => {
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        act(() => latestWorker().emitMessage({ id: 1 }));
+
+        expect(result.current.error).toBe("Failed to create the report");
+        expect(result.current.loading).toBe(false);
+    });
+
+    it("revokes the previous object url before creating a new one on the next generate", () => {
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        act(() => latestWorker().emitMessage({ id: 1, blob: new Blob(["first"]) }));
+        act(() => result.current.generate(buildProps()));
+
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:generated-url");
+    });
+
+    it("catches a synchronous postMessage failure and surfaces it as an error", () => {
+        const { result } = renderHook(() => useReportPdf());
+        latestWorker().postMessage.mockImplementation(() => {
+            throw new Error("could not be cloned");
+        });
+
+        act(() => result.current.generate(buildProps()));
+
+        expect(result.current.error).toBe("could not be cloned");
+        expect(result.current.loading).toBe(false);
+    });
+
+    it("stops loading and reports an error when the worker fails to load", () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
+            /* empty */
+        });
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        act(() => latestWorker().emitError("worker boot failed"));
+
+        expect(result.current.error).toBe("worker boot failed");
+        expect(result.current.loading).toBe(false);
+        expect(consoleError).toHaveBeenCalledWith("Report worker failed to load", "worker boot failed");
+        consoleError.mockRestore();
+    });
+
+    it("reports an error when the worker delivers undecodable data", () => {
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        act(() => latestWorker().emitMessageError());
+
+        expect(result.current.error).toBe("The report worker received invalid data");
+        expect(result.current.loading).toBe(false);
+    });
+
+    it("terminates the worker and revokes the outstanding url on unmount", () => {
+        const { result, unmount } = renderHook(() => useReportPdf());
+        const worker = latestWorker();
+
+        act(() => result.current.generate(buildProps()));
+        act(() => worker.emitMessage({ id: 1, blob: new Blob(["pdf"]) }));
+
+        unmount();
+
+        expect(worker.terminate).toHaveBeenCalledTimes(1);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:generated-url");
+    });
+});

--- a/apps/frontend/src/application/hooks/use-report-pdf.hook.test.ts
+++ b/apps/frontend/src/application/hooks/use-report-pdf.hook.test.ts
@@ -167,6 +167,26 @@ describe("useReportPdf", () => {
         consoleError.mockRestore();
     });
 
+    it("replaces a failed worker so the next generate posts to a fresh instance", () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
+            /* empty */
+        });
+        const { result } = renderHook(() => useReportPdf());
+
+        act(() => result.current.generate(buildProps()));
+        const failed = latestWorker();
+        act(() => failed.emitError("worker boot failed"));
+
+        act(() => result.current.generate(buildProps()));
+        const replacement = latestWorker();
+
+        expect(replacement).not.toBe(failed);
+        expect(failed.terminate).toHaveBeenCalled();
+        expect(replacement.postMessage).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }));
+        expect(result.current.loading).toBe(true);
+        consoleError.mockRestore();
+    });
+
     it("reports an error when the worker delivers undecodable data", () => {
         const { result } = renderHook(() => useReportPdf());
 

--- a/apps/frontend/src/application/hooks/use-report-pdf.hook.ts
+++ b/apps/frontend/src/application/hooks/use-report-pdf.hook.ts
@@ -27,7 +27,7 @@ export function useReportPdf() {
         }
     }, []);
 
-    useEffect(() => {
+    const createWorker = useCallback(() => {
         const worker = new ReportPdfWorker();
         workerRef.current = worker;
 
@@ -47,28 +47,35 @@ export function useReportPdf() {
             setState({ url, loading: false, error: null });
         };
 
-        // Without this, a worker that fails to load or throws leaves the spinner hanging forever.
+        // A worker that fails to load cannot recover, so discard it here; otherwise the
+        // next generate() would post to a dead worker and the spinner would hang forever.
         worker.onerror = (event) => {
             console.error("Report worker failed to load", event.message);
+            worker.terminate();
+            if (workerRef.current === worker) {
+                workerRef.current = null;
+            }
             setState({ url: null, loading: false, error: event.message || "The report worker failed to load" });
         };
         worker.onmessageerror = () => {
             setState({ url: null, loading: false, error: "The report worker received invalid data" });
         };
 
+        return worker;
+    }, [revokeUrl]);
+
+    useEffect(() => {
+        createWorker();
         return () => {
-            worker.terminate();
+            workerRef.current?.terminate();
             workerRef.current = null;
             revokeUrl();
         };
-    }, [revokeUrl]);
+    }, [createWorker, revokeUrl]);
 
     const generate = useCallback(
         (props: ReportProps) => {
-            const worker = workerRef.current;
-            if (!worker) {
-                return;
-            }
+            const worker = workerRef.current ?? createWorker();
             const id = requestIdRef.current + 1;
             requestIdRef.current = id;
             revokeUrl();
@@ -82,7 +89,7 @@ export function useReportPdf() {
                 setState({ url: null, loading: false, error: message });
             }
         },
-        [revokeUrl]
+        [createWorker, revokeUrl]
     );
 
     return { ...state, generate };

--- a/apps/frontend/src/application/hooks/use-report-pdf.hook.ts
+++ b/apps/frontend/src/application/hooks/use-report-pdf.hook.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import ReportPdfWorker from "#view/report/report.worker.ts?worker";
+import type { RenderRequest, RenderResponse } from "#view/report/report.worker.ts";
+import type { ReportProps } from "#view/report/report.tsx";
+
+interface ReportPdfState {
+    url: string | null;
+    loading: boolean;
+    error: string | null;
+}
+
+const initialState: ReportPdfState = { url: null, loading: false, error: null };
+
+/**
+ * Generates the report PDF in a web worker so the main thread stays responsive.
+ */
+export function useReportPdf() {
+    const workerRef = useRef<Worker | null>(null);
+    const requestIdRef = useRef(0);
+    const urlRef = useRef<string | null>(null);
+    const [state, setState] = useState<ReportPdfState>(initialState);
+
+    const revokeUrl = useCallback(() => {
+        if (urlRef.current) {
+            URL.revokeObjectURL(urlRef.current);
+            urlRef.current = null;
+        }
+    }, []);
+
+    useEffect(() => {
+        const worker = new ReportPdfWorker();
+        workerRef.current = worker;
+
+        worker.onmessage = (event: MessageEvent<RenderResponse>) => {
+            const { id, blob, error } = event.data;
+            // Drop responses from requests the user has already superseded.
+            if (id !== requestIdRef.current) {
+                return;
+            }
+            if (error || !blob) {
+                setState({ url: null, loading: false, error: error ?? "Failed to create the report" });
+                return;
+            }
+            revokeUrl();
+            const url = URL.createObjectURL(blob);
+            urlRef.current = url;
+            setState({ url, loading: false, error: null });
+        };
+
+        // Without this, a worker that fails to load or throws leaves the spinner hanging forever.
+        worker.onerror = (event) => {
+            console.error("Report worker failed to load", event.message);
+            setState({ url: null, loading: false, error: event.message || "The report worker failed to load" });
+        };
+        worker.onmessageerror = () => {
+            setState({ url: null, loading: false, error: "The report worker received invalid data" });
+        };
+
+        return () => {
+            worker.terminate();
+            workerRef.current = null;
+            revokeUrl();
+        };
+    }, [revokeUrl]);
+
+    const generate = useCallback(
+        (props: ReportProps) => {
+            const worker = workerRef.current;
+            if (!worker) {
+                return;
+            }
+            const id = requestIdRef.current + 1;
+            requestIdRef.current = id;
+            revokeUrl();
+            setState({ url: null, loading: true, error: null });
+            const request: RenderRequest = { id, props };
+            try {
+                // Throws synchronously (DataCloneError) if the props are not structured-cloneable.
+                worker.postMessage(request);
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                setState({ url: null, loading: false, error: message });
+            }
+        },
+        [revokeUrl]
+    );
+
+    return { ...state, generate };
+}

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -5,6 +5,7 @@ import type { ExtendedThreat } from "#api/types/threat.types.ts";
 import type { Measure } from "#api/types/measure.types.ts";
 import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
 import type { ThreatMeasure } from "#application/hooks/use-threat-measures-list.hook.ts";
+import type { Milestone } from "#application/hooks/use-report.hook.ts";
 import {
     AnchorOrientation,
     type Annotation,
@@ -203,6 +204,14 @@ export const createMeasure = (overrides: Partial<Measure> = {}): Measure => ({
     catalogMeasureId: null,
     createdAt: new Date("2025-01-01"),
     updatedAt: new Date("2025-01-01"),
+    ...overrides,
+});
+
+export const createReportMilestone = (overrides: Partial<Milestone> = {}): Milestone & { active: boolean } => ({
+    scheduledAt: new Date("2025-01-01"),
+    matrix: null,
+    barGraph: null,
+    active: false,
     ...overrides,
 });
 

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -5,7 +5,6 @@ import type { ExtendedThreat } from "#api/types/threat.types.ts";
 import type { Measure } from "#api/types/measure.types.ts";
 import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
 import type { ThreatMeasure } from "#application/hooks/use-threat-measures-list.hook.ts";
-import type { Milestone } from "#application/hooks/use-report.hook.ts";
 import {
     AnchorOrientation,
     type Annotation,
@@ -25,6 +24,7 @@ import { STANDARD_COMPONENT_TYPES } from "#api/types/standard-component.types.ts
 import { USER_ROLES } from "#api/types/user-roles.types.ts";
 import { CONFIDENTIALITY_LEVELS } from "#utils/confidentiality.ts";
 import { DEFAULT_ANNOTATION_COLOR } from "#view/colors/annotation.colors.ts";
+import type { Milestone } from "#utils/report-risk.ts";
 
 export const createAsset = (overrides: Partial<Asset> = {}): Asset => ({
     id: 1,

--- a/apps/frontend/src/view/components/report-components/output-settings-column.component.test.tsx
+++ b/apps/frontend/src/view/components/report-components/output-settings-column.component.test.tsx
@@ -1,0 +1,73 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+
+// Keep the real module (renderWithProviders needs I18nextProvider) but force t to
+// return the key so we can assert on the untranslated headings directly.
+vi.mock("react-i18next", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("react-i18next")>()),
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { OutputSettingsColumn } from "./output-settings-column.component";
+
+type OutputSettingsColumnProps = ComponentProps<typeof OutputSettingsColumn>;
+
+const defaultProps: OutputSettingsColumnProps = {
+    reportLanguage: "en",
+    onChangeLanguage: vi.fn(),
+    sortBy: "netRisk",
+    onChangeSortBy: vi.fn(),
+    sortDirection: "desc",
+    onChangeSortDirection: vi.fn(),
+    onExport: vi.fn(),
+};
+
+const renderColumn = (props: Partial<OutputSettingsColumnProps> = {}) =>
+    renderWithProviders(<OutputSettingsColumn {...defaultProps} {...props} />);
+
+describe("OutputSettingsColumn", () => {
+    it("renders the language, sort and export headings", () => {
+        renderColumn();
+        expect(screen.getByText("language")).toBeInTheDocument();
+        expect(screen.getByText("sortThreats")).toBeInTheDocument();
+        expect(screen.getByText("export")).toBeInTheDocument();
+    });
+
+    it("calls onChangeLanguage with the picked language", async () => {
+        const onChangeLanguage = vi.fn();
+        renderColumn({ reportLanguage: "en", onChangeLanguage });
+
+        await userEvent.click(screen.getByRole("button", { name: "DE" }));
+
+        expect(onChangeLanguage).toHaveBeenCalledWith(expect.anything(), "de");
+    });
+
+    it("calls onChangeSortBy with the picked sort field", async () => {
+        const onChangeSortBy = vi.fn();
+        renderColumn({ sortBy: "netRisk", onChangeSortBy });
+
+        await userEvent.click(screen.getByRole("button", { name: "risk_gross" }));
+
+        expect(onChangeSortBy).toHaveBeenCalledWith(expect.anything(), "risk");
+    });
+
+    it("calls onChangeSortDirection with the picked direction", async () => {
+        const onChangeSortDirection = vi.fn();
+        renderColumn({ sortDirection: "desc", onChangeSortDirection });
+
+        await userEvent.click(screen.getByTestId("ArrowUpwardIcon"));
+
+        expect(onChangeSortDirection).toHaveBeenCalledWith(expect.anything(), "asc");
+    });
+
+    it("calls onExport when the export button is clicked", async () => {
+        const onExport = vi.fn();
+        renderColumn({ onExport });
+
+        await userEvent.click(screen.getByTestId("FileDownloadIcon"));
+
+        expect(onExport).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/frontend/src/view/components/report-components/output-settings-column.component.tsx
+++ b/apps/frontend/src/view/components/report-components/output-settings-column.component.tsx
@@ -1,0 +1,164 @@
+import { ArrowDownward, ArrowUpward } from "@mui/icons-material";
+import { FormControl, Typography, Box } from "@mui/material";
+import type { SyntheticEvent } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { SortDirection } from "#application/actions/list.actions.ts";
+import { ExportIconButton } from "#view/components/export-icon-button.component.tsx";
+import { ToggleButtons } from "#view/components/toggle-buttons.component.tsx";
+
+interface OutputSettingsColumnProps {
+    reportLanguage: string;
+    onChangeLanguage: (event: SyntheticEvent, value: string | null) => void;
+    sortBy: string;
+    onChangeSortBy: (event: SyntheticEvent, value: string | null) => void;
+    sortDirection: SortDirection;
+    onChangeSortDirection: (event: SyntheticEvent, value: SortDirection | null) => void;
+    onExport: () => void;
+}
+
+export const OutputSettingsColumn = ({
+    reportLanguage,
+    onChangeLanguage,
+    sortBy,
+    onChangeSortBy,
+    sortDirection,
+    onChangeSortDirection,
+    onExport,
+}: OutputSettingsColumnProps) => {
+    const { t } = useTranslation("reportPage");
+
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                width: "30%",
+            }}
+        >
+            <Box
+                sx={{
+                    backgroundColor: "background.paperIntransparent",
+                    padding: 4,
+                    borderRadius: 5,
+                    boxShadow: 1,
+                    marginBottom: 2,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontSize: "0.875rem",
+                        fontWeight: "bold",
+                    }}
+                >
+                    {t("language")}
+                </Typography>
+                <FormControl sx={{ margin: 0, marginTop: 1 }}>
+                    <Box>
+                        <ToggleButtons
+                            onChange={onChangeLanguage}
+                            value={reportLanguage}
+                            buttons={[
+                                {
+                                    text: "EN",
+                                    value: "en",
+                                },
+                                {
+                                    text: "DE",
+                                    value: "de",
+                                },
+                            ]}
+                        />
+                    </Box>
+                </FormControl>
+            </Box>
+
+            <Box
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    backgroundColor: "background.paperIntransparent",
+                    borderRadius: 5,
+                    boxShadow: 1,
+                    padding: 4,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontSize: "0.875rem",
+                        fontWeight: "bold",
+                    }}
+                >
+                    {t("sortThreats")}
+                </Typography>
+                <FormControl sx={{ margin: 0, marginTop: 1 }}>
+                    <Box
+                        sx={{
+                            display: "flex",
+                            alignItems: "center",
+                        }}
+                    >
+                        <ToggleButtons
+                            sx={{ mr: 1 }}
+                            onChange={onChangeSortBy}
+                            value={sortBy}
+                            buttons={[
+                                {
+                                    text: t("risk_net"),
+                                    value: "netRisk",
+                                },
+                                {
+                                    text: t("risk_gross"),
+                                    value: "risk",
+                                },
+                            ]}
+                        />
+                        <ToggleButtons
+                            onChange={onChangeSortDirection}
+                            value={sortDirection}
+                            buttons={[
+                                {
+                                    icon: ArrowUpward,
+                                    value: "asc",
+                                },
+                                {
+                                    icon: ArrowDownward,
+                                    value: "desc",
+                                },
+                            ]}
+                        />
+                    </Box>
+                </FormControl>
+            </Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    backgroundColor: "background.paperIntransparent",
+                    borderRadius: 5,
+                    boxShadow: 1,
+                    padding: 4,
+                    marginTop: 2,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontSize: "0.875rem",
+                        fontWeight: "bold",
+                    }}
+                >
+                    {t("export")}
+                </Typography>
+                <Box
+                    sx={{
+                        display: "flex",
+                        alignItems: "center",
+                    }}
+                >
+                    <Typography sx={{ fontSize: "0.875rem" }}>{t("fullExport")}</Typography>
+                    <ExportIconButton title={t("fullExportBtn")} onClick={onExport} sx={{ color: "text.primary" }} />
+                </Box>
+            </Box>
+        </Box>
+    );
+};

--- a/apps/frontend/src/view/components/report-components/page-settings-column.component.test.tsx
+++ b/apps/frontend/src/view/components/report-components/page-settings-column.component.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// t returns the key so we can assert on the untranslated ids/labels directly.
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { PageSettingsColumn, type PageToggle } from "./page-settings-column.component";
+
+const createToggle = (overrides: Partial<PageToggle> = {}): PageToggle => ({
+    id: "coverPage",
+    checked: false,
+    onChange: vi.fn(),
+    ...overrides,
+});
+
+describe("PageSettingsColumn", () => {
+    it("renders the page-settings heading", () => {
+        render(<PageSettingsColumn toggles={[]} />);
+        expect(screen.getByText("pageSettings")).toBeInTheDocument();
+    });
+
+    it("renders one switch per toggle, labelled by its id", () => {
+        const toggles = [
+            createToggle({ id: "coverPage" }),
+            createToggle({ id: "matrixPage" }),
+            createToggle({ id: "threatsPage" }),
+        ];
+        render(<PageSettingsColumn toggles={toggles} />);
+
+        expect(screen.getAllByRole("switch")).toHaveLength(3);
+        expect(screen.getByLabelText("coverPage")).toBeInTheDocument();
+        expect(screen.getByLabelText("matrixPage")).toBeInTheDocument();
+        expect(screen.getByLabelText("threatsPage")).toBeInTheDocument();
+    });
+
+    it("reflects each toggle's checked state", () => {
+        render(
+            <PageSettingsColumn
+                toggles={[
+                    createToggle({ id: "coverPage", checked: true }),
+                    createToggle({ id: "matrixPage", checked: false }),
+                ]}
+            />
+        );
+
+        expect(screen.getByLabelText("coverPage")).toBeChecked();
+        expect(screen.getByLabelText("matrixPage")).not.toBeChecked();
+    });
+
+    it("calls the toggle's onChange with true when an unchecked switch is clicked", async () => {
+        const onChange = vi.fn();
+        render(<PageSettingsColumn toggles={[createToggle({ id: "coverPage", checked: false, onChange })]} />);
+
+        await userEvent.click(screen.getByLabelText("coverPage"));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith(expect.anything(), true);
+    });
+
+    it("calls the toggle's onChange with false when a checked switch is clicked", async () => {
+        const onChange = vi.fn();
+        render(<PageSettingsColumn toggles={[createToggle({ id: "coverPage", checked: true, onChange })]} />);
+
+        await userEvent.click(screen.getByLabelText("coverPage"));
+
+        expect(onChange).toHaveBeenCalledWith(expect.anything(), false);
+    });
+
+    it("only toggles the clicked switch, leaving the others untouched", async () => {
+        const onChangeCover = vi.fn();
+        const onChangeMatrix = vi.fn();
+        render(
+            <PageSettingsColumn
+                toggles={[
+                    createToggle({ id: "coverPage", onChange: onChangeCover }),
+                    createToggle({ id: "matrixPage", onChange: onChangeMatrix }),
+                ]}
+            />
+        );
+
+        await userEvent.click(screen.getByLabelText("matrixPage"));
+
+        expect(onChangeMatrix).toHaveBeenCalledTimes(1);
+        expect(onChangeCover).not.toHaveBeenCalled();
+    });
+
+    it("renders no switches when the toggles list is empty", () => {
+        render(<PageSettingsColumn toggles={[]} />);
+        expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    });
+});

--- a/apps/frontend/src/view/components/report-components/page-settings-column.component.tsx
+++ b/apps/frontend/src/view/components/report-components/page-settings-column.component.tsx
@@ -1,0 +1,52 @@
+import { FormControl, FormControlLabel, Switch, Typography, Box } from "@mui/material";
+import type { ChangeEvent } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface PageToggle {
+    id: string;
+    checked: boolean;
+    onChange: (event: ChangeEvent<HTMLInputElement>, checked: boolean) => void;
+}
+
+interface PageSettingsColumnProps {
+    toggles: PageToggle[];
+}
+
+export const PageSettingsColumn = ({ toggles }: PageSettingsColumnProps) => {
+    const { t } = useTranslation("reportPage");
+
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "stretch",
+                borderRadius: 5,
+                boxShadow: 1,
+                padding: 4,
+                marginRight: 2,
+                width: "35%",
+                backgroundColor: "background.paperIntransparent",
+            }}
+        >
+            <Typography
+                sx={{
+                    fontSize: "0.875rem",
+                    fontWeight: "bold",
+                    marginBottom: 1,
+                }}
+            >
+                {t("pageSettings")}
+            </Typography>
+            {toggles.map(({ id, checked, onChange }) => (
+                <FormControl key={id} sx={{ margin: 0, marginBottom: 1 }}>
+                    <FormControlLabel
+                        control={<Switch checked={checked} onChange={onChange} />}
+                        label={<Typography sx={{ fontSize: "0.875rem" }}>{t(id)}</Typography>}
+                        labelPlacement="end"
+                    />
+                </FormControl>
+            ))}
+        </Box>
+    );
+};

--- a/apps/frontend/src/view/components/report-components/risk-matrix-settings-column.component.test.tsx
+++ b/apps/frontend/src/view/components/report-components/risk-matrix-settings-column.component.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+
+// t returns the key so we can assert on the untranslated headings/labels directly.
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { createReportMilestone } from "#test-utils/builders.ts";
+import { RiskMatrixSettingsColumn } from "./risk-matrix-settings-column.component";
+
+type RiskMatrixSettingsColumnProps = ComponentProps<typeof RiskMatrixSettingsColumn>;
+
+const defaultProps: RiskMatrixSettingsColumnProps = {
+    milestones: null,
+    onChangeMilestone: vi.fn(),
+    fromScheduledAt: null,
+    tillScheduledAt: null,
+    onChangeFromScheduledAt: vi.fn(),
+    onChangeTillScheduledAt: vi.fn(),
+};
+
+const renderColumn = (props: Partial<RiskMatrixSettingsColumnProps> = {}) =>
+    render(<RiskMatrixSettingsColumn {...defaultProps} {...props} />);
+
+describe("RiskMatrixSettingsColumn", () => {
+    it("renders the risk-matrix and scheduled-at headings", () => {
+        renderColumn();
+        expect(screen.getByText("riskMatrixSettings")).toBeInTheDocument();
+        expect(screen.getByText("scheduledAt")).toBeInTheDocument();
+    });
+
+    it("renders one switch per milestone, labelled by its scheduled date", () => {
+        const milestones = [
+            createReportMilestone({ scheduledAt: new Date("2025-01-01") }),
+            createReportMilestone({ scheduledAt: new Date("2025-06-15") }),
+        ];
+        renderColumn({ milestones });
+
+        expect(screen.getByLabelText("2025-01-01")).toBeInTheDocument();
+        expect(screen.getByLabelText("2025-06-15")).toBeInTheDocument();
+    });
+
+    it("reflects each milestone's active state", () => {
+        const milestones = [
+            createReportMilestone({ scheduledAt: new Date("2025-01-01"), active: true }),
+            createReportMilestone({ scheduledAt: new Date("2025-06-15"), active: false }),
+        ];
+        renderColumn({ milestones });
+
+        expect(screen.getByLabelText("2025-01-01")).toBeChecked();
+        expect(screen.getByLabelText("2025-06-15")).not.toBeChecked();
+    });
+
+    it("calls onChangeMilestone with the milestone and its new checked value", async () => {
+        const onChangeMilestone = vi.fn();
+        const milestone = createReportMilestone({ scheduledAt: new Date("2025-01-01"), active: false });
+        renderColumn({ milestones: [milestone], onChangeMilestone });
+
+        await userEvent.click(screen.getByLabelText("2025-01-01"));
+
+        expect(onChangeMilestone).toHaveBeenCalledTimes(1);
+        expect(onChangeMilestone).toHaveBeenCalledWith(milestone, true);
+    });
+
+    it("renders no milestone switches when milestones is null", () => {
+        renderColumn({ milestones: null });
+        expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    });
+
+    it("renders no milestone switches when milestones is empty", () => {
+        renderColumn({ milestones: [] });
+        expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    });
+
+    it("shows the from/till date field values", () => {
+        renderColumn({ fromScheduledAt: "2025-01-01", tillScheduledAt: "2025-12-31" });
+
+        expect(screen.getByLabelText("fromScheduledAt")).toHaveValue("2025-01-01");
+        expect(screen.getByLabelText("tillScheduledAt")).toHaveValue("2025-12-31");
+    });
+
+    it("calls onChangeFromScheduledAt when the from date changes", () => {
+        const onChangeFromScheduledAt = vi.fn();
+        renderColumn({ fromScheduledAt: "2025-01-01", onChangeFromScheduledAt });
+
+        fireEvent.change(screen.getByLabelText("fromScheduledAt"), { target: { value: "2025-02-02" } });
+
+        expect(onChangeFromScheduledAt).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onChangeTillScheduledAt when the till date changes", () => {
+        const onChangeTillScheduledAt = vi.fn();
+        renderColumn({ tillScheduledAt: "2025-12-31", onChangeTillScheduledAt });
+
+        fireEvent.change(screen.getByLabelText("tillScheduledAt"), { target: { value: "2025-11-11" } });
+
+        expect(onChangeTillScheduledAt).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/frontend/src/view/components/report-components/risk-matrix-settings-column.component.tsx
+++ b/apps/frontend/src/view/components/report-components/risk-matrix-settings-column.component.tsx
@@ -1,0 +1,150 @@
+import { FormControl, FormControlLabel, Switch, Typography, Box } from "@mui/material";
+import type { ChangeEvent } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { useReport } from "#application/hooks/use-report.hook.ts";
+import { DialogTextField } from "#view/components/dialog.textfield.component.tsx";
+
+type ReportMilestones = ReturnType<typeof useReport>["milestones"];
+type ReportMilestone = NonNullable<ReportMilestones>[number];
+
+interface RiskMatrixSettingsColumnProps {
+    milestones: ReportMilestones;
+    onChangeMilestone: (milestone: ReportMilestone, checked: boolean) => void;
+    fromScheduledAt: string | null;
+    tillScheduledAt: string | null;
+    onChangeFromScheduledAt: (event: ChangeEvent<HTMLInputElement>) => void;
+    onChangeTillScheduledAt: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const RiskMatrixSettingsColumn = ({
+    milestones,
+    onChangeMilestone,
+    fromScheduledAt,
+    tillScheduledAt,
+    onChangeFromScheduledAt,
+    onChangeTillScheduledAt,
+}: RiskMatrixSettingsColumnProps) => {
+    const { t } = useTranslation("reportPage");
+
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                marginRight: 2,
+                width: "35%",
+            }}
+        >
+            <Box
+                sx={{
+                    flex: 1,
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "stretch",
+                    borderRadius: 5,
+                    boxShadow: 1,
+                    padding: 4,
+                    paddingLeft: 2.5,
+                    overflow: "visible",
+                    maxHeight: "206px",
+                    backgroundColor: "background.paperIntransparent",
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontSize: "0.875rem",
+                        fontWeight: "bold",
+                        marginBottom: 1,
+                        paddingLeft: 1.5,
+                    }}
+                >
+                    {t("riskMatrixSettings")}
+                </Typography>
+                <Box
+                    sx={{
+                        flex: 1,
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "stretch",
+                        overflowY: "auto",
+                        paddingLeft: 1.5,
+                    }}
+                >
+                    {milestones?.map((milestone, i) => {
+                        const { scheduledAt, active } = milestone;
+                        return (
+                            <FormControl
+                                key={i}
+                                fullWidth
+                                sx={{
+                                    margin: 0,
+                                    marginBottom: 1,
+                                }}
+                            >
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            checked={!!active}
+                                            onChange={(_, value) => onChangeMilestone(milestone, value)}
+                                        />
+                                    }
+                                    label={scheduledAt?.toISOString().split("T")[0]}
+                                    labelPlacement="end"
+                                    sx={{
+                                        marginRight: 0,
+                                    }}
+                                />
+                            </FormControl>
+                        );
+                    })}
+                </Box>
+            </Box>
+
+            <Box
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    backgroundColor: "background.paperIntransparent",
+                    borderRadius: 5,
+                    boxShadow: 1,
+                    padding: 4,
+                    marginTop: 2,
+                }}
+            >
+                <Typography
+                    sx={{
+                        fontSize: "0.875rem",
+                        fontWeight: "bold",
+                    }}
+                >
+                    {t("scheduledAt")}
+                </Typography>
+                <Box
+                    sx={{
+                        display: "flex",
+                        flexDirection: "row",
+                    }}
+                >
+                    <DialogTextField
+                        label={t("fromScheduledAt")}
+                        type="date"
+                        onChange={onChangeFromScheduledAt}
+                        value={fromScheduledAt ?? ""}
+                        margin="normal"
+                        fullWidth
+                    />
+                    <DialogTextField
+                        sx={{ ml: 1 }}
+                        label={t("tillScheduledAt")}
+                        type="date"
+                        onChange={onChangeTillScheduledAt}
+                        value={tillScheduledAt ?? ""}
+                        margin="normal"
+                        fullWidth
+                    />
+                </Box>
+            </Box>
+        </Box>
+    );
+};

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -337,8 +337,11 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                                 justifyContent: "flex-end",
                             }}
                         >
-                            {isChanged ? (
+                            {isChanged || error ? (
                                 <Box sx={{ marginTop: 2, display: "flex", alignItems: "center" }}>
+                                    {error && (
+                                        <Typography sx={{ marginRight: 1, color: "error.main" }}>{error}</Typography>
+                                    )}
                                     <Button sx={{ marginRight: 1 }} onClick={onClickRefresh}>
                                         {t("createBtn")}
                                     </Button>
@@ -356,9 +359,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                                         marginTop: 2,
                                     }}
                                 >
-                                    {error ? (
-                                        <Typography>{error}</Typography>
-                                    ) : url ? (
+                                    {url ? (
                                         <>
                                             <Button
                                                 component="a"

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -1,8 +1,15 @@
 import { ArrowDownward, ArrowUpward } from "@mui/icons-material";
-import { Backdrop, FormControl, FormControlLabel, LinearProgress, Switch, Typography } from "@mui/material";
+import {
+    Backdrop,
+    CircularProgress,
+    FormControl,
+    FormControlLabel,
+    LinearProgress,
+    Switch,
+    Typography,
+} from "@mui/material";
 import { Box } from "@mui/system";
-import { BlobProvider } from "@react-pdf/renderer";
-import { memo, useEffect, useLayoutEffect, type ChangeEvent, type SyntheticEvent } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, type ChangeEvent, type SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { ExtendedProject } from "#api/types/project.types.ts";
@@ -10,6 +17,7 @@ import type { SortDirection } from "#application/actions/list.actions.ts";
 import { NavigationActions } from "#application/actions/navigation.actions.ts";
 import { useReport } from "#application/hooks/use-report.hook.ts";
 import { useReportExcelExport } from "#application/hooks/use-export.hook.ts";
+import { useReportPdf } from "#application/hooks/use-report-pdf.hook.ts";
 import { useAppDispatch } from "#application/hooks/use-app-redux.hook.ts";
 import logo from "#images/logo_large.png";
 import companyLogo from "#images/MaibornWolff_Logo.png";
@@ -20,7 +28,6 @@ import { ToggleButtons } from "#view/components/toggle-buttons.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
 import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
-import { Report } from "#view/report/report.tsx";
 import { downloadMarkdownReport } from "#view/report/download-markdown-report.ts";
 import { ExportIconButton } from "#view/components/export-icon-button.component.tsx";
 import { withProject } from "#view/components/with-project.hoc.tsx";
@@ -31,35 +38,6 @@ interface ReportPageBodyProps {
 
 type ReportHookReturn = ReturnType<typeof useReport>;
 type ReportMilestone = NonNullable<ReportHookReturn["milestones"]>[number];
-
-type ReportToolbarData = NonNullable<ReportHookReturn["data"]> & {
-    milestones: ReportHookReturn["milestones"];
-    threats: ReportHookReturn["threats"];
-    measures: ReportHookReturn["measures"];
-};
-
-interface PdfDocumentToolbarProps {
-    filename: string;
-    logo: string;
-    companyLogo: string;
-    tillScheduledAt: string | null;
-    showCoverPage: boolean;
-    showTableOfContentsPage: boolean;
-    showMethodExplanation: boolean;
-    showScaleExplanation: boolean;
-    showMatrixPage: boolean;
-    showComponentsPage: boolean;
-    showAssetsPage: boolean;
-    showMeasuresPage: boolean;
-    showThreatListPage: boolean;
-    showThreatsPage: boolean;
-    systemImageOnSeparatePage: boolean;
-    language: string;
-    data: ReportToolbarData;
-    bruttoMatrix: ReportHookReturn["bruttoMatrix"];
-    nettoMatrix: ReportHookReturn["nettoMatrix"];
-    onDownloadMarkdown: () => void;
-}
 
 const ReportPageBody = ({ project }: ReportPageBodyProps) => {
     const {
@@ -121,6 +99,9 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
     const { exportReportAsExcel } = useReportExcelExport();
 
     const dispatch = useAppDispatch();
+
+    // Generates the PDF in a web worker so the main thread stays responsive
+    const { url, loading, error, generate } = useReportPdf();
 
     /**
      * Layout effect to change the header bar
@@ -211,7 +192,30 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
     };
 
     const onClickRefresh = () => {
+        if (!data) {
+            return;
+        }
         setIsChanged(false);
+        generate({
+            tillScheduledAt,
+            showCoverPage,
+            showTableOfContentsPage,
+            showMethodExplanation,
+            showScaleExplanation,
+            showMatrixPage,
+            showComponentsPage,
+            showAssetsPage,
+            showMeasuresPage,
+            showThreatListPage,
+            showThreatsPage,
+            systemImageOnSeparatePage,
+            language: reportLanguage,
+            logo,
+            companyLogo,
+            bruttoMatrix,
+            nettoMatrix,
+            data: { ...data, milestones, threats: threats ?? [], measures: measures ?? [] },
+        });
     };
 
     const onChangeSortDirection = (_event: SyntheticEvent, value: SortDirection | null) => {
@@ -243,7 +247,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
         exportReportAsExcel(project, data);
     };
 
-    const handleDownloadMarkdown = () => {
+    const handleDownloadMarkdown = useCallback(() => {
         downloadMarkdownReport({
             data,
             filename,
@@ -266,7 +270,28 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
             systemImageOnSeparatePage,
             language: reportLanguage,
         });
-    };
+    }, [
+        data,
+        filename,
+        milestones,
+        threats,
+        measures,
+        bruttoMatrix,
+        nettoMatrix,
+        tillScheduledAt,
+        showCoverPage,
+        showTableOfContentsPage,
+        showMethodExplanation,
+        showScaleExplanation,
+        showMatrixPage,
+        showComponentsPage,
+        showAssetsPage,
+        showMeasuresPage,
+        showThreatListPage,
+        showThreatsPage,
+        systemImageOnSeparatePage,
+        reportLanguage,
+    ]);
 
     useEffect(() => {
         setIsChanged(true);
@@ -274,6 +299,21 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
 
     return (
         <Box>
+            <Backdrop open={loading} sx={{ zIndex: 999 }}>
+                <Box
+                    sx={{
+                        p: 2,
+                        borderRadius: 5,
+                        bgcolor: "background.paperIntransparent",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 2,
+                    }}
+                >
+                    <CircularProgress size={24} />
+                    <Typography>{t("reportLoads")}</Typography>
+                </Box>
+            </Backdrop>
             {<LinearProgress sx={{ visibility: data ? "hidden" : "visible" }} />}
             <Page
                 sx={{
@@ -731,106 +771,46 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                                     </Button>
                                 </Box>
                             ) : (
-                                <PdfDocumentToolbar
-                                    filename={filename}
-                                    logo={logo}
-                                    companyLogo={companyLogo}
-                                    tillScheduledAt={tillScheduledAt}
-                                    showCoverPage={showCoverPage}
-                                    showTableOfContentsPage={showTableOfContentsPage}
-                                    showMethodExplanation={showMethodExplanation}
-                                    showScaleExplanation={showScaleExplanation}
-                                    showMatrixPage={showMatrixPage}
-                                    showComponentsPage={showComponentsPage}
-                                    showAssetsPage={showAssetsPage}
-                                    showMeasuresPage={showMeasuresPage}
-                                    showThreatListPage={showThreatListPage}
-                                    showThreatsPage={showThreatsPage}
-                                    systemImageOnSeparatePage={systemImageOnSeparatePage}
-                                    language={reportLanguage}
-                                    data={{
-                                        ...data!,
-                                        milestones,
-                                        threats: threats ?? [],
-                                        measures: measures ?? [],
+                                <Box
+                                    sx={{
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "flex-end",
+                                        width: "100%",
+                                        marginTop: 2,
                                     }}
-                                    bruttoMatrix={bruttoMatrix}
-                                    nettoMatrix={nettoMatrix}
-                                    onDownloadMarkdown={handleDownloadMarkdown}
-                                />
+                                >
+                                    {error ? (
+                                        <Typography>{error}</Typography>
+                                    ) : url ? (
+                                        <>
+                                            <Button
+                                                component="a"
+                                                href={url}
+                                                {...{ target: "_blank" }}
+                                                rel="noreferrer"
+                                                sx={{ marginRight: 1 }}
+                                            >
+                                                {t("openInBrowserBtn")}
+                                            </Button>
+                                            <Button
+                                                component="a"
+                                                href={url}
+                                                {...{ download: `${filename}.pdf` }}
+                                                sx={{ marginRight: 1 }}
+                                            >
+                                                {t("downloadPdfBtn")}
+                                            </Button>
+                                        </>
+                                    ) : null}
+                                    <Button onClick={handleDownloadMarkdown}>{t("downloadMarkdownBtn")}</Button>
+                                </Box>
                             )}
                         </Box>
                     </Box>
                 )}
             </Page>
         </Box>
-    );
-};
-
-const PdfDocumentToolbar = ({ filename, onDownloadMarkdown, ...props }: PdfDocumentToolbarProps) => {
-    const { t } = useTranslation("reportPage");
-
-    return (
-        <BlobProvider document={<Report {...props} />}>
-            {({ url, loading, error }) => {
-                const disabled = url === null || loading;
-                return (
-                    <Box
-                        id="box"
-                        sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "flex-end",
-                            width: "100%",
-                            marginTop: 2,
-                        }}
-                    >
-                        {error ? (
-                            <Typography>{error?.message || "Ein Fehler ist augetreten"}</Typography>
-                        ) : loading ? (
-                            <Backdrop open={true} sx={{ zIndex: 999 }}>
-                                <Box
-                                    sx={{
-                                        p: 2,
-                                        borderRadius: 5,
-                                        bgcolor: "background.paperIntransparent",
-                                    }}
-                                >
-                                    <Typography>{t("reportLoads")}</Typography>
-                                </Box>
-                            </Backdrop>
-                        ) : (
-                            <>
-                                <Button
-                                    component="a"
-                                    href={url ?? ""}
-                                    {...{ target: "_blank" }}
-                                    rel="noreferrer"
-                                    disabled={disabled}
-                                    sx={{
-                                        marginRight: 1,
-                                    }}
-                                >
-                                    {t("openInBrowserBtn")}
-                                </Button>
-                                <Button
-                                    component="a"
-                                    href={url ?? ""}
-                                    {...{ download: `${filename}.pdf` }}
-                                    disabled={disabled}
-                                    sx={{
-                                        marginRight: 1,
-                                    }}
-                                >
-                                    {t("downloadPdfBtn")}
-                                </Button>
-                            </>
-                        )}
-                        <Button onClick={onDownloadMarkdown}>{t("downloadMarkdownBtn")}</Button>
-                    </Box>
-                );
-            }}
-        </BlobProvider>
     );
 };
 

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -10,8 +10,11 @@ import { useReport } from "#application/hooks/use-report.hook.ts";
 import { useReportExcelExport } from "#application/hooks/use-export.hook.ts";
 import { useReportPdf } from "#application/hooks/use-report-pdf.hook.ts";
 import { useAppDispatch } from "#application/hooks/use-app-redux.hook.ts";
-import logo from "#images/logo_large.png";
-import companyLogo from "#images/MaibornWolff_Logo.png";
+// Inlined as data URLs: react-pdf fetches URL images with a bare fetch() during
+// every render, and a stalled request wedges the render with no error (seen
+// intermittently in Firefox). Data URLs need no network at all.
+import logo from "#images/logo_large.png?inline";
+import companyLogo from "#images/MaibornWolff_Logo.png?inline";
 import { Button } from "#view/components/button.component.tsx";
 import { Page } from "#view/components/page.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -1,13 +1,4 @@
-import { ArrowDownward, ArrowUpward } from "@mui/icons-material";
-import {
-    Backdrop,
-    CircularProgress,
-    FormControl,
-    FormControlLabel,
-    LinearProgress,
-    Switch,
-    Typography,
-} from "@mui/material";
+import { Backdrop, CircularProgress, LinearProgress, Typography } from "@mui/material";
 import { Box } from "@mui/system";
 import { memo, useCallback, useEffect, useLayoutEffect, type ChangeEvent, type SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
@@ -22,15 +13,18 @@ import { useAppDispatch } from "#application/hooks/use-app-redux.hook.ts";
 import logo from "#images/logo_large.png";
 import companyLogo from "#images/MaibornWolff_Logo.png";
 import { Button } from "#view/components/button.component.tsx";
-import { DialogTextField } from "#view/components/dialog.textfield.component.tsx";
 import { Page } from "#view/components/page.component.tsx";
-import { ToggleButtons } from "#view/components/toggle-buttons.component.tsx";
 import { CreatePage } from "#view/components/create-page.component.tsx";
 import { usePageTitle } from "#application/hooks/use-page-title.hook.ts";
 import { HeaderUtilityControls } from "#view/components/header-utility-controls.component.tsx";
 import { downloadMarkdownReport } from "#view/report/download-markdown-report.ts";
-import { ExportIconButton } from "#view/components/export-icon-button.component.tsx";
 import { withProject } from "#view/components/with-project.hoc.tsx";
+import {
+    PageSettingsColumn,
+    type PageToggle,
+} from "#view/components/report-components/page-settings-column.component.tsx";
+import { RiskMatrixSettingsColumn } from "#view/components/report-components/risk-matrix-settings-column.component.tsx";
+import { OutputSettingsColumn } from "#view/components/report-components/output-settings-column.component.tsx";
 
 interface ReportPageBodyProps {
     project: ExtendedProject;
@@ -124,60 +118,38 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
         }
     };
 
-    const onChangeShowCoverPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowCoverPage(value);
-        setIsChanged(true);
-    };
+    const handleTogglePage =
+        (setPage: (value: boolean) => void) => (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
+            setPage(value);
+            setIsChanged(true);
+        };
 
-    const onChangeShowTableOfContents = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowTableOfContentsPage(value);
-        setIsChanged(true);
-    };
-
-    const onChangeShowMethodExplanation = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowMethodExplanation(value);
-        setIsChanged(true);
-    };
-
-    const onChangeShowScaleExplanation = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowScaleExplanation(value);
-        setIsChanged(true);
-    };
-
-    const onChangeShowMatrixPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowMatrixPage(value);
-        setIsChanged(true);
-    };
-
-    const onChangeShowComponentsPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowComponentsPage(value);
-        setIsChanged(true);
-    };
-
-    const onChangeShowAssetsPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowAssetsPage(value);
-        setIsChanged(true);
-    };
-
-    const onChangeShowMeasuresPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowMeasuresPage(value);
-        setIsChanged(true);
-    };
-
-    const onChangeShowThreatListPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowThreatListPage(value);
-        setIsChanged(true);
-    };
-
-    const onChangeShowThreatsPage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setShowThreatsPage(value);
-        setIsChanged(true);
-    };
-
-    const onChangeSystemImageOnSeparatePage = (_event: ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setSystemImageOnSeparatePage(value);
-        setIsChanged(true);
-    };
+    // Each entry renders one switch in the page-settings column. The id doubles as the i18n label key.
+    const pageToggles: PageToggle[] = [
+        { id: "coverPage", checked: showCoverPage, onChange: handleTogglePage(setShowCoverPage) },
+        {
+            id: "tableOfContentsPage",
+            checked: showTableOfContentsPage,
+            onChange: handleTogglePage(setShowTableOfContentsPage),
+        },
+        {
+            id: "methodExplanation",
+            checked: showMethodExplanation,
+            onChange: handleTogglePage(setShowMethodExplanation),
+        },
+        { id: "scaleExplanation", checked: showScaleExplanation, onChange: handleTogglePage(setShowScaleExplanation) },
+        { id: "matrixPage", checked: showMatrixPage, onChange: handleTogglePage(setShowMatrixPage) },
+        { id: "componentPage", checked: showComponentsPage, onChange: handleTogglePage(setShowComponentsPage) },
+        { id: "assetPage", checked: showAssetsPage, onChange: handleTogglePage(setShowAssetsPage) },
+        { id: "measuresPage", checked: showMeasuresPage, onChange: handleTogglePage(setShowMeasuresPage) },
+        { id: "threatListPage", checked: showThreatListPage, onChange: handleTogglePage(setShowThreatListPage) },
+        { id: "threatsPage", checked: showThreatsPage, onChange: handleTogglePage(setShowThreatsPage) },
+        {
+            id: "systemImageOnSeparatePage",
+            checked: systemImageOnSeparatePage,
+            onChange: handleTogglePage(setSystemImageOnSeparatePage),
+        },
+    ];
 
     const onChangeFromScheduledAt = (event: ChangeEvent<HTMLInputElement>) => {
         const value = event.currentTarget.value;
@@ -337,422 +309,26 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                                 marginTop: 5,
                             }}
                         >
-                            <Box
-                                sx={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    alignItems: "stretch",
-                                    borderRadius: 5,
-                                    boxShadow: 1,
-                                    padding: 4,
-                                    marginRight: 2,
-                                    width: "35%",
-                                    backgroundColor: "background.paperIntransparent",
-                                }}
-                            >
-                                <Typography
-                                    sx={{
-                                        fontSize: "0.875rem",
-                                        fontWeight: "bold",
-                                        marginBottom: 1,
-                                    }}
-                                >
-                                    {t("pageSettings")}
-                                </Typography>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={<Switch checked={showCoverPage} onChange={onChangeShowCoverPage} />}
-                                        label={<Typography sx={{ fontSize: "0.875rem" }}>{t("coverPage")}</Typography>}
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={showTableOfContentsPage}
-                                                onChange={onChangeShowTableOfContents}
-                                            />
-                                        }
-                                        label={
-                                            <Typography sx={{ fontSize: "0.875rem" }}>
-                                                {t("tableOfContentsPage")}
-                                            </Typography>
-                                        }
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={showMethodExplanation}
-                                                onChange={onChangeShowMethodExplanation}
-                                            />
-                                        }
-                                        label={
-                                            <Typography sx={{ fontSize: "0.875rem" }}>
-                                                {t("methodExplanation")}
-                                            </Typography>
-                                        }
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={showScaleExplanation}
-                                                onChange={onChangeShowScaleExplanation}
-                                            />
-                                        }
-                                        label={
-                                            <Typography sx={{ fontSize: "0.875rem" }}>
-                                                {t("scaleExplanation")}
-                                            </Typography>
-                                        }
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
+                            <PageSettingsColumn toggles={pageToggles} />
 
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={<Switch checked={showMatrixPage} onChange={onChangeShowMatrixPage} />}
-                                        label={<Typography sx={{ fontSize: "0.875rem" }}>{t("matrixPage")}</Typography>}
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={showComponentsPage}
-                                                onChange={onChangeShowComponentsPage}
-                                            />
-                                        }
-                                        label={
-                                            <Typography sx={{ fontSize: "0.875rem" }}>{t("componentPage")}</Typography>
-                                        }
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={<Switch checked={showAssetsPage} onChange={onChangeShowAssetsPage} />}
-                                        label={<Typography sx={{ fontSize: "0.875rem" }}>{t("assetPage")}</Typography>}
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch checked={showMeasuresPage} onChange={onChangeShowMeasuresPage} />
-                                        }
-                                        label={
-                                            <Typography sx={{ fontSize: "0.875rem" }}>{t("measuresPage")}</Typography>
-                                        }
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={showThreatListPage}
-                                                onChange={onChangeShowThreatListPage}
-                                            />
-                                        }
-                                        label={
-                                            <Typography sx={{ fontSize: "0.875rem" }}>{t("threatListPage")}</Typography>
-                                        }
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch checked={showThreatsPage} onChange={onChangeShowThreatsPage} />
-                                        }
-                                        label={
-                                            <Typography sx={{ fontSize: "0.875rem" }}>{t("threatsPage")}</Typography>
-                                        }
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                                <FormControl sx={{ margin: 0, marginBottom: 1 }}>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={systemImageOnSeparatePage}
-                                                onChange={onChangeSystemImageOnSeparatePage}
-                                            />
-                                        }
-                                        label={
-                                            <Typography sx={{ fontSize: "0.875rem" }}>
-                                                {t("systemImageOnSeparatePage")}
-                                            </Typography>
-                                        }
-                                        labelPlacement="end"
-                                    />
-                                </FormControl>
-                            </Box>
+                            <RiskMatrixSettingsColumn
+                                milestones={milestones}
+                                onChangeMilestone={onChangeActiveMilestone}
+                                fromScheduledAt={fromScheduledAt}
+                                tillScheduledAt={tillScheduledAt}
+                                onChangeFromScheduledAt={onChangeFromScheduledAt}
+                                onChangeTillScheduledAt={onChangeTillScheduledAt}
+                            />
 
-                            <Box
-                                sx={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    marginRight: 2,
-                                    width: "35%",
-                                }}
-                            >
-                                <Box
-                                    sx={{
-                                        flex: 1,
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        alignItems: "stretch",
-                                        borderRadius: 5,
-                                        boxShadow: 1,
-                                        padding: 4,
-                                        paddingLeft: 2.5,
-                                        overflow: "visible",
-                                        maxHeight: "206px",
-                                        backgroundColor: "background.paperIntransparent",
-                                    }}
-                                >
-                                    <Typography
-                                        sx={{
-                                            fontSize: "0.875rem",
-                                            fontWeight: "bold",
-                                            marginBottom: 1,
-                                            paddingLeft: 1.5,
-                                        }}
-                                    >
-                                        {t("riskMatrixSettings")}
-                                    </Typography>
-                                    <Box
-                                        sx={{
-                                            flex: 1,
-                                            display: "flex",
-                                            flexDirection: "column",
-                                            alignItems: "stretch",
-                                            overflowY: "auto",
-                                            paddingLeft: 1.5,
-                                        }}
-                                    >
-                                        {milestones?.map((milestone, i) => {
-                                            const { scheduledAt, active } = milestone;
-                                            return (
-                                                <FormControl
-                                                    key={i}
-                                                    fullWidth
-                                                    sx={{
-                                                        margin: 0,
-                                                        marginBottom: 1,
-                                                    }}
-                                                >
-                                                    <FormControlLabel
-                                                        control={
-                                                            <Switch
-                                                                checked={!!active}
-                                                                onChange={(_, value) =>
-                                                                    onChangeActiveMilestone(milestone, value)
-                                                                }
-                                                            />
-                                                        }
-                                                        label={scheduledAt?.toISOString().split("T")[0]}
-                                                        labelPlacement="end"
-                                                        sx={{
-                                                            marginRight: 0,
-                                                        }}
-                                                    />
-                                                </FormControl>
-                                            );
-                                        })}
-                                    </Box>
-                                </Box>
-
-                                <Box
-                                    sx={{
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        backgroundColor: "background.paperIntransparent",
-                                        borderRadius: 5,
-                                        boxShadow: 1,
-                                        padding: 4,
-                                        marginTop: 2,
-                                    }}
-                                >
-                                    <Typography
-                                        sx={{
-                                            fontSize: "0.875rem",
-                                            fontWeight: "bold",
-                                        }}
-                                    >
-                                        {t("scheduledAt")}
-                                    </Typography>
-                                    <Box
-                                        sx={{
-                                            display: "flex",
-                                            flexDirection: "row",
-                                        }}
-                                    >
-                                        <DialogTextField
-                                            label={t("fromScheduledAt")}
-                                            type="date"
-                                            onChange={onChangeFromScheduledAt}
-                                            value={fromScheduledAt}
-                                            margin="normal"
-                                            fullWidth
-                                        />
-                                        <DialogTextField
-                                            sx={{ ml: 1 }}
-                                            label={t("tillScheduledAt")}
-                                            type="date"
-                                            onChange={onChangeTillScheduledAt}
-                                            value={tillScheduledAt}
-                                            margin="normal"
-                                            fullWidth
-                                        />
-                                    </Box>
-                                </Box>
-                            </Box>
-
-                            <Box
-                                sx={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    width: "30%",
-                                }}
-                            >
-                                <Box
-                                    sx={{
-                                        backgroundColor: "background.paperIntransparent",
-                                        padding: 4,
-                                        borderRadius: 5,
-                                        boxShadow: 1,
-                                        marginBottom: 2,
-                                    }}
-                                >
-                                    <Typography
-                                        sx={{
-                                            fontSize: "0.875rem",
-                                            fontWeight: "bold",
-                                        }}
-                                    >
-                                        {t("language")}
-                                    </Typography>
-                                    <FormControl sx={{ margin: 0, marginTop: 1 }}>
-                                        <Box>
-                                            <ToggleButtons
-                                                onChange={onChangeLanguage}
-                                                value={reportLanguage}
-                                                buttons={[
-                                                    {
-                                                        text: "EN",
-                                                        value: "en",
-                                                    },
-                                                    {
-                                                        text: "DE",
-                                                        value: "de",
-                                                    },
-                                                ]}
-                                            />
-                                        </Box>
-                                    </FormControl>
-                                </Box>
-
-                                <Box
-                                    sx={{
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        backgroundColor: "background.paperIntransparent",
-                                        borderRadius: 5,
-                                        boxShadow: 1,
-                                        padding: 4,
-                                    }}
-                                >
-                                    <Typography
-                                        sx={{
-                                            fontSize: "0.875rem",
-                                            fontWeight: "bold",
-                                        }}
-                                    >
-                                        {t("sortThreats")}
-                                    </Typography>
-                                    <FormControl sx={{ margin: 0, marginTop: 1 }}>
-                                        <Box
-                                            sx={{
-                                                display: "flex",
-                                                alignItems: "center",
-                                            }}
-                                        >
-                                            <ToggleButtons
-                                                sx={{ mr: 1 }}
-                                                onChange={onChangeSortBy}
-                                                value={sortBy}
-                                                buttons={[
-                                                    {
-                                                        text: t("risk_net"),
-                                                        value: "netRisk",
-                                                    },
-                                                    {
-                                                        text: t("risk_gross"),
-                                                        value: "risk",
-                                                    },
-                                                ]}
-                                            />
-                                            <ToggleButtons
-                                                onChange={onChangeSortDirection}
-                                                value={sortDirection}
-                                                buttons={[
-                                                    {
-                                                        icon: ArrowUpward,
-                                                        value: "asc",
-                                                    },
-                                                    {
-                                                        icon: ArrowDownward,
-                                                        value: "desc",
-                                                    },
-                                                ]}
-                                            />
-                                        </Box>
-                                    </FormControl>
-                                </Box>
-                                <Box
-                                    sx={{
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        backgroundColor: "background.paperIntransparent",
-                                        borderRadius: 5,
-                                        boxShadow: 1,
-                                        padding: 4,
-                                        marginTop: 2,
-                                    }}
-                                >
-                                    <Typography
-                                        sx={{
-                                            fontSize: "0.875rem",
-                                            fontWeight: "bold",
-                                        }}
-                                    >
-                                        {t("export")}
-                                    </Typography>
-                                    <Box
-                                        sx={{
-                                            display: "flex",
-                                            alignItems: "center",
-                                        }}
-                                    >
-                                        <Typography sx={{ fontSize: "0.875rem" }}>{t("fullExport")}</Typography>
-                                        <ExportIconButton
-                                            title={t("fullExportBtn")}
-                                            onClick={handleExport}
-                                            sx={{ color: "text.primary" }}
-                                        />
-                                    </Box>
-                                </Box>
-                            </Box>
+                            <OutputSettingsColumn
+                                reportLanguage={reportLanguage}
+                                onChangeLanguage={onChangeLanguage}
+                                sortBy={sortBy}
+                                onChangeSortBy={onChangeSortBy}
+                                sortDirection={sortDirection}
+                                onChangeSortDirection={onChangeSortDirection}
+                                onExport={handleExport}
+                            />
                         </Box>
                         <Box
                             sx={{

--- a/apps/frontend/src/view/report/report-md.test.ts
+++ b/apps/frontend/src/view/report/report-md.test.ts
@@ -1,7 +1,7 @@
 import "#utils/translations.ts"; // initialises i18next with all namespaces as a side effect
 import { generateMarkdownReport, type MarkdownReportOptions } from "#view/report/report-md.ts";
 import type { ProjectReport } from "#api/types/project.types.ts";
-import type { RiskMatrix } from "#application/hooks/use-report.hook.ts";
+import type { RiskMatrix } from "#utils/report-risk.ts";
 import fixtureData from "./testData/project-report.fixture.json";
 
 const report = fixtureData as unknown as ProjectReport & { milestones: null };

--- a/apps/frontend/src/view/report/report-worker-shim.ts
+++ b/apps/frontend/src/view/report/report-worker-shim.ts
@@ -1,0 +1,23 @@
+/**
+ * @module report-worker-shim - Globals the report worker needs before react-pdf loads.
+ *
+ * The worker does not run main.tsx, so it must set up the same globals here:
+ *
+ * - `Buffer`: @react-pdf/renderer (via pdfkit) needs Node's Buffer global; Vite does
+ *   not polyfill it. Mirrors the setup in main.tsx. Needed in dev and production.
+ * - `window`: in dev, `@vitejs/plugin-react` injects the React Fast Refresh runtime
+ *   into every JSX module, and that runtime references `window`, which does not exist
+ *   in a worker. Pointing it at the worker global lets the (HMR-guarded, otherwise
+ *   inert) refresh code load without throwing. Not injected in production.
+ *
+ * Must be imported before any JSX or react-pdf module in the worker.
+ */
+
+import { Buffer } from "buffer";
+
+const globalWithBuffer = globalThis as typeof globalThis & { Buffer?: typeof Buffer };
+globalWithBuffer.Buffer ??= Buffer;
+
+if (import.meta.env.DEV) {
+    globalThis.window ??= globalThis as unknown as Window & typeof globalThis;
+}

--- a/apps/frontend/src/view/report/report.tsx
+++ b/apps/frontend/src/view/report/report.tsx
@@ -55,7 +55,7 @@ Font.register({
     ],
 });
 
-interface ReportProps {
+export interface ReportProps {
     tillScheduledAt?: string | null;
     showCoverPage?: boolean;
     showTableOfContentsPage?: boolean;

--- a/apps/frontend/src/view/report/report.worker.test.ts
+++ b/apps/frontend/src/view/report/report.worker.test.ts
@@ -89,12 +89,29 @@ describe("report.worker", () => {
     });
 
     it("caps the number of layout passes so a never-settling document cannot loop forever", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {
+            /* empty */
+        });
         const instance = buildPdfInstance({ blob: new Blob(["pdf"]), dirtyPasses: 99 });
         setNextInstance(instance);
 
         await dispatch({ id: 1, props: buildProps() });
 
         expect(instance.toBlob).toHaveBeenCalledTimes(4);
+        expect(warn).toHaveBeenCalledOnce();
+        warn.mockRestore();
+    });
+
+    it("does not warn when the layout settles within the pass cap", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {
+            /* empty */
+        });
+        setNextInstance(buildPdfInstance({ blob: new Blob(["pdf"]), dirtyPasses: 1 }));
+
+        await dispatch({ id: 1, props: buildProps() });
+
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
     });
 
     it("posts an error response when the render produces no blob", async () => {

--- a/apps/frontend/src/view/report/report.worker.test.ts
+++ b/apps/frontend/src/view/report/report.worker.test.ts
@@ -1,0 +1,117 @@
+import type { ReportProps } from "#view/report/report.tsx";
+import type { RenderRequest, RenderResponse } from "#view/report/report.worker.ts";
+
+/**
+ * The worker renders through `@react-pdf/renderer`'s `pdf()` instance. These
+ * mocks replace it with a controllable fake: `setNextInstance` decides what the
+ * next `pdf()` call returns, so each test scripts the layout/blob behaviour.
+ * `Report` is stubbed out so the heavy react-pdf document tree never loads.
+ */
+const { setNextInstance, pdfMock } = vi.hoisted(() => {
+    let nextInstance: unknown = null;
+    return {
+        setNextInstance: (instance: unknown) => {
+            nextInstance = instance;
+        },
+        pdfMock: () => nextInstance,
+    };
+});
+
+vi.mock("@react-pdf/renderer", () => ({ pdf: pdfMock }));
+vi.mock("#view/report/report.tsx", () => ({ Report: () => null }));
+
+// Importing the module registers `self.onmessage`; grab it after the mocks apply.
+await import("#view/report/report.worker.ts");
+
+/**
+ * Builds a fake pdf() instance. `dirtyPasses` is how many of the first renders
+ * re-emit "change" (simulating react-pdf re-laying out the document), forcing
+ * the worker to render again; after that the layout is considered stable.
+ */
+const buildPdfInstance = ({ blob, dirtyPasses = 0 }: { blob: Blob | undefined; dirtyPasses?: number }) => {
+    let changeListener: (() => void) | null = null;
+    const toBlob = vi.fn(async () => {
+        if (toBlob.mock.calls.length <= dirtyPasses) {
+            changeListener?.();
+        }
+        return blob;
+    });
+    return {
+        on: (event: string, listener: () => void) => {
+            if (event === "change") {
+                changeListener = listener;
+            }
+        },
+        removeListener: vi.fn(),
+        updateContainer: vi.fn(),
+        toBlob,
+    };
+};
+
+const buildProps = (): ReportProps => ({
+    bruttoMatrix: null,
+    nettoMatrix: null,
+    language: "en",
+    data: {} as ReportProps["data"],
+});
+
+const dispatch = async (request: RenderRequest): Promise<RenderResponse> => {
+    const postMessage = vi.fn();
+    self.postMessage = postMessage as typeof self.postMessage;
+    await (self.onmessage as (event: MessageEvent<RenderRequest>) => Promise<void>)({
+        data: request,
+    } as MessageEvent<RenderRequest>);
+    return postMessage.mock.calls[0]![0] as RenderResponse;
+};
+
+describe("report.worker", () => {
+    it("renders once and posts the blob back with the request id when layout is stable", async () => {
+        const blob = new Blob(["pdf"]);
+        const instance = buildPdfInstance({ blob });
+        setNextInstance(instance);
+
+        const response = await dispatch({ id: 7, props: buildProps() });
+
+        expect(instance.toBlob).toHaveBeenCalledTimes(1);
+        expect(response).toEqual({ id: 7, blob });
+    });
+
+    it("re-renders while the layout keeps changing and stops once it settles", async () => {
+        const blob = new Blob(["pdf"]);
+        const instance = buildPdfInstance({ blob, dirtyPasses: 2 });
+        setNextInstance(instance);
+
+        const response = await dispatch({ id: 1, props: buildProps() });
+
+        // 2 dirty re-layouts + 1 final stable pass.
+        expect(instance.toBlob).toHaveBeenCalledTimes(3);
+        expect(response.blob).toBe(blob);
+    });
+
+    it("caps the number of layout passes so a never-settling document cannot loop forever", async () => {
+        const instance = buildPdfInstance({ blob: new Blob(["pdf"]), dirtyPasses: 99 });
+        setNextInstance(instance);
+
+        await dispatch({ id: 1, props: buildProps() });
+
+        expect(instance.toBlob).toHaveBeenCalledTimes(4);
+    });
+
+    it("posts an error response when the render produces no blob", async () => {
+        const instance = buildPdfInstance({ blob: undefined });
+        setNextInstance(instance);
+
+        const response = await dispatch({ id: 3, props: buildProps() });
+
+        expect(response).toEqual({ id: 3, error: "The report produced no output" });
+    });
+
+    it("removes the change listener after rendering", async () => {
+        const instance = buildPdfInstance({ blob: new Blob(["pdf"]) });
+        setNextInstance(instance);
+
+        await dispatch({ id: 1, props: buildProps() });
+
+        expect(instance.removeListener).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/frontend/src/view/report/report.worker.ts
+++ b/apps/frontend/src/view/report/report.worker.ts
@@ -1,0 +1,68 @@
+/**
+ * @module report.worker - Renders the report PDF off the main thread.
+ *
+ * react-pdf lays out the whole document synchronously in JavaScript, which
+ * freezes the UI for large reports. Running it in a worker keeps the main
+ * thread free so the loading spinner stays animated and the app responsive.
+ */
+
+// Must stay first: defines `window` before any JSX module (which pull in the dev-only
+// React Fast Refresh runtime) is evaluated. See report-worker-shim.ts.
+import "#view/report/report-worker-shim.ts";
+import { createElement } from "react";
+import { pdf } from "@react-pdf/renderer";
+import { Report, type ReportProps } from "#view/report/report.tsx";
+
+export interface RenderRequest {
+    id: number;
+    props: ReportProps;
+}
+
+export interface RenderResponse {
+    id: number;
+    blob?: Blob;
+    error?: string;
+}
+
+// Upper bound on layout passes so a misbehaving document can never loop forever.
+const MAX_RENDER_PASSES = 4;
+
+/**
+ * Renders the report to a blob, re-laying out until the tree stops changing.
+ */
+async function renderReport(props: ReportProps): Promise<Blob> {
+    const instance = pdf();
+    let dirty = true;
+    const markDirty = () => {
+        dirty = true;
+    };
+    instance.on("change", markDirty);
+    instance.updateContainer(createElement(Report, props));
+
+    let blob: Blob | undefined;
+    for (let pass = 0; pass < MAX_RENDER_PASSES && dirty; pass++) {
+        dirty = false;
+        blob = await instance.toBlob();
+        // Let React flush any setIndex triggered during layout before checking again.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    instance.removeListener("change", markDirty);
+
+    if (!blob) {
+        throw new Error("The report produced no output");
+    }
+    return blob;
+}
+
+self.onmessage = async (event: MessageEvent<RenderRequest>) => {
+    const { id, props } = event.data;
+    try {
+        const blob = await renderReport(props);
+        const response: RenderResponse = { id, blob };
+        self.postMessage(response);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const response: RenderResponse = { id, error: message };
+        self.postMessage(response);
+    }
+};

--- a/apps/frontend/src/view/report/report.worker.ts
+++ b/apps/frontend/src/view/report/report.worker.ts
@@ -48,6 +48,10 @@ async function renderReport(props: ReportProps): Promise<Blob> {
     }
     instance.removeListener("change", markDirty);
 
+    if (dirty) {
+        console.warn(`Report layout did not settle within ${MAX_RENDER_PASSES} passes; page references may be stale.`);
+    }
+
     if (!blob) {
         throw new Error("The report produced no output");
     }

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -53,5 +53,10 @@ export default defineConfig({
     },
     optimizeDeps: {
         force: true,
+        // react-pdf is only imported from the report web worker. Pre-bundling keeps the worker fast.
+        include: ["@react-pdf/renderer"],
+    },
+    worker: {
+        format: "es",
     },
 });

--- a/patches/png-js.patch
+++ b/patches/png-js.patch
@@ -1,0 +1,53 @@
+diff --git a/lib/png-js.browser.cjs b/lib/png-js.browser.cjs
+index 07a7e40f789124e5ff4c405f20139a8a78f1ca8e..cdfd346485fb690ef2e5eae95dce6905f4f3d06e 100644
+--- a/lib/png-js.browser.cjs
++++ b/lib/png-js.browser.cjs
+@@ -2,7 +2,20 @@
+ 
+ var fflate = require('fflate');
+ 
+-const inflate = fflate.unzlib ;
++// PATCH (ThreatSea): fflate's async unzlib spawns a nested Web Worker, which
++// intermittently never responds inside a Firefox worker, hanging PNG decoding
++// (and any PDF render waiting on it) forever. unzlibSync is the same codec
++// without the worker round-trip.
++const inflate = (data, callback) => {
++  let result;
++  try {
++    result = fflate.unzlibSync(data);
++  } catch (error) {
++    callback(error);
++    return;
++  }
++  callback(null, result);
++};
+ 
+ class PNG {
+   static decode(path, fn) {
+diff --git a/lib/png-js.browser.js b/lib/png-js.browser.js
+index 4c044145b32940d72585d62741096ecef718c57e..c683cb549a01ca9182bc0092bf8f379d8e9f5205 100644
+--- a/lib/png-js.browser.js
++++ b/lib/png-js.browser.js
+@@ -1,6 +1,19 @@
+-import { unzlib } from 'fflate';
+-
+-const inflate = unzlib ;
++import { unzlibSync } from 'fflate';
++
++// PATCH (ThreatSea): fflate's async unzlib spawns a nested Web Worker, which
++// intermittently never responds inside a Firefox worker, hanging PNG decoding
++// (and any PDF render waiting on it) forever. unzlibSync is the same codec
++// without the worker round-trip.
++const inflate = (data, callback) => {
++  let result;
++  try {
++    result = unzlibSync(data);
++  } catch (error) {
++    callback(error);
++    return;
++  }
++  callback(null, result);
++};
+ 
+ class PNG {
+   static decode(path, fn) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ catalogs:
       specifier: 4.1.10
       version: 4.1.10
 
+patchedDependencies:
+  png-js: 15c9d450d22f0091ff0a799b93383f4efbabb42465728c64188c898926887412
+
 importers:
 
   .:
@@ -529,11 +532,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -5752,7 +5755,7 @@ snapshots:
     dependencies:
       '@react-pdf/svg': 1.1.0
       jay-peg: 1.1.1
-      png-js: 2.0.0
+      png-js: 2.0.0(patch_hash=15c9d450d22f0091ff0a799b93383f4efbabb42465728c64188c898926887412)
 
   '@react-pdf/layout@4.6.1':
     dependencies:
@@ -5776,7 +5779,7 @@ snapshots:
       jay-peg: 1.1.1
       js-md5: 0.8.3
       linebreak: 1.1.0
-      png-js: 2.0.0
+      png-js: 2.0.0(patch_hash=15c9d450d22f0091ff0a799b93383f4efbabb42465728c64188c898926887412)
       vite-compatible-readable-stream: 3.6.1
 
   '@react-pdf/primitives@4.3.0': {}
@@ -8072,7 +8075,7 @@ snapshots:
     dependencies:
       queue-lit: 1.5.2
 
-  png-js@2.0.0:
+  png-js@2.0.0(patch_hash=15c9d450d22f0091ff0a799b93383f4efbabb42465728c64188c898926887412):
     dependencies:
       fflate: 0.8.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,5 @@ saveExact: true
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - "semver@6.3.1"
+patchedDependencies:
+  png-js: patches/png-js.patch


### PR DESCRIPTION
## Summary
  Resolves #845 

  - Move report PDF generation off the main thread into a web worker, keeping the UI responsive (spinner stays animated) for large reports.
  - Break the monolithic report settings page into three focused, testable column components (page toggles, risk-matrix settings, output settings).
  - Surface a console warning when the report layout fails to settle within the render-pass cap, instead of silently returning stale page references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moved report PDF creation off the main thread, adding loading/error handling plus “open in browser” and “download PDF” actions.
  * Added new report settings UI columns for page toggles, risk-matrix milestones/date range, language/sorting controls, and export.
* **Tests**
  * Added/expanded test coverage for the PDF worker, the PDF-generation hook (success, failure, stale responses, and cleanup), and the new settings components.
* **Chores**
  * Updated frontend build/worker optimization and applied a patch to prevent potential Firefox PNG decoding hangs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->