### PR TITLE
fix(measure): change type of scheduledat from timestamp to date

### DIFF
--- a/apps/backend/drizzle/0005_change_measures_scheduled_at_to_date.sql
+++ b/apps/backend/drizzle/0005_change_measures_scheduled_at_to_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "measures" ALTER COLUMN "scheduledAt" SET DATA TYPE date USING ("scheduledAt" AT TIME ZONE 'UTC')::date;

--- a/apps/backend/drizzle/meta/0005_snapshot.json
+++ b/apps/backend/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1776 @@
+{
+  "id": "439fc15d-8efa-484c-ad34-59c9f32a6070",
+  "prevId": "d299876d-edfd-4d00-b3c4-01c7e8042d99",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "assets_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentialityJustification": {
+          "name": "confidentialityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrityJustification": {
+          "name": "integrityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availabilityJustification": {
+          "name": "availabilityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_project_id": {
+          "name": "assets_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_name": {
+          "name": "assets_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_projectId_projects_id_fk": {
+          "name": "assets_projectId_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assets_name_not_empty": {
+          "name": "assets_name_not_empty",
+          "value": "\"assets\".\"name\" <> ''"
+        },
+        "assets_confidentiality_min_max": {
+          "name": "assets_confidentiality_min_max",
+          "value": "\"assets\".\"confidentiality\" between 1 and 5"
+        },
+        "assets_integrity_min_max": {
+          "name": "assets_integrity_min_max",
+          "value": "\"assets\".\"integrity\" between 1 and 5"
+        },
+        "assets_availability_min_max": {
+          "name": "assets_availability_min_max",
+          "value": "\"assets\".\"availability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_measures": {
+      "name": "catalog_measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalog_measures_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_measures_catalog_id": {
+          "name": "catalog_measures_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_name": {
+          "name": "catalog_measures_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_point_of_attack": {
+          "name": "catalog_measures_point_of_attack",
+          "columns": [
+            {
+              "expression": "pointOfAttack",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_attacker": {
+          "name": "catalog_measures_attacker",
+          "columns": [
+            {
+              "expression": "attacker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_measures_catalogId_catalogs_id_fk": {
+          "name": "catalog_measures_catalogId_catalogs_id_fk",
+          "tableFrom": "catalog_measures",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_measures_probability_min_max": {
+          "name": "catalog_measures_probability_min_max",
+          "value": "\"catalog_measures\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_threats": {
+      "name": "catalog_threats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalog_threats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_threats_catalog_id": {
+          "name": "catalog_threats_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_name": {
+          "name": "catalog_threats_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_point_of_attack": {
+          "name": "catalog_threats_point_of_attack",
+          "columns": [
+            {
+              "expression": "pointOfAttack",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_attacker": {
+          "name": "catalog_threats_attacker",
+          "columns": [
+            {
+              "expression": "attacker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_threats_catalogId_catalogs_id_fk": {
+          "name": "catalog_threats_catalogId_catalogs_id_fk",
+          "tableFrom": "catalog_threats",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_threats_probability_min_max": {
+          "name": "catalog_threats_probability_min_max",
+          "value": "\"catalog_threats\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalogs": {
+      "name": "catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalogs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catalogs_name": {
+          "name": "catalogs_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalogs_name_not_empty": {
+          "name": "catalogs_name_not_empty",
+          "value": "\"catalogs\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.component_types": {
+      "name": "component_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "component_types_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointsOfAttack": {
+          "name": "pointsOfAttack",
+          "type": "point_of_attack[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standardIcon": {
+          "name": "standardIcon",
+          "type": "standard_icon",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "component_types_project_id": {
+          "name": "component_types_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "component_types_projectId_projects_id_fk": {
+          "name": "component_types_projectId_projects_id_fk",
+          "tableFrom": "component_types",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "component_types_icon_not_both_set": {
+          "name": "component_types_icon_not_both_set",
+          "value": "not (\"component_types\".\"symbol\" is not null and \"component_types\".\"standardIcon\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.measure_impacts": {
+      "name": "measure_impacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "measure_impacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setsOutOfScope": {
+          "name": "setsOutOfScope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impactsProbability": {
+          "name": "impactsProbability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impactsDamage": {
+          "name": "impactsDamage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage": {
+          "name": "damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "threatId": {
+          "name": "threatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measureId": {
+          "name": "measureId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "measure_impacts_measure_id_threat_id": {
+          "name": "measure_impacts_measure_id_threat_id",
+          "columns": [
+            {
+              "expression": "measureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "measure_impacts_threatId_threats_id_fk": {
+          "name": "measure_impacts_threatId_threats_id_fk",
+          "tableFrom": "measure_impacts",
+          "tableTo": "threats",
+          "columnsFrom": ["threatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "measure_impacts_measureId_measures_id_fk": {
+          "name": "measure_impacts_measureId_measures_id_fk",
+          "tableFrom": "measure_impacts",
+          "tableTo": "measures",
+          "columnsFrom": ["measureId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "measure_impacts_measure_id_threat_id_unique": {
+          "name": "measure_impacts_measure_id_threat_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["measureId", "threatId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "measure_impacts_probability_min_max": {
+          "name": "measure_impacts_probability_min_max",
+          "value": "\"measure_impacts\".\"probability\" between 1 and 5"
+        },
+        "measure_impacts_probability": {
+          "name": "measure_impacts_probability",
+          "value": "\"measure_impacts\".\"impactsProbability\" = false OR \"measure_impacts\".\"probability\" IS NOT NULL"
+        },
+        "measure_impacts_damage_min_max": {
+          "name": "measure_impacts_damage_min_max",
+          "value": "\"measure_impacts\".\"damage\" between 1 and 5"
+        },
+        "measure_impacts_damage": {
+          "name": "measure_impacts_damage",
+          "value": "\"measure_impacts\".\"impactsDamage\" = false OR \"measure_impacts\".\"damage\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.measures": {
+      "name": "measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "measures_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledAt": {
+          "name": "scheduledAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalogMeasureId": {
+          "name": "catalogMeasureId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "measures_catalog_measure_id": {
+          "name": "measures_catalog_measure_id",
+          "columns": [
+            {
+              "expression": "catalogMeasureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "measures_project_id": {
+          "name": "measures_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "measures_catalogMeasureId_catalog_measures_id_fk": {
+          "name": "measures_catalogMeasureId_catalog_measures_id_fk",
+          "tableFrom": "measures",
+          "tableTo": "catalog_measures",
+          "columnsFrom": ["catalogMeasureId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "measures_projectId_projects_id_fk": {
+          "name": "measures_projectId_projects_id_fk",
+          "tableFrom": "measures",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "measures_name_not_empty": {
+          "name": "measures_name_not_empty",
+          "value": "\"measures\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "projects_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentialityLevel": {
+          "name": "confidentialityLevel",
+          "type": "confidentiality_level",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INTERNAL'"
+        },
+        "lineOfToleranceGreen": {
+          "name": "lineOfToleranceGreen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "lineOfToleranceRed": {
+          "name": "lineOfToleranceRed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_catalog_id": {
+          "name": "projects_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name": {
+          "name": "projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_catalogId_catalogs_id_fk": {
+          "name": "projects_catalogId_catalogs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_name_not_empty": {
+          "name": "projects_name_not_empty",
+          "value": "\"projects\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.systems": {
+      "name": "systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "systems_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "systems_projectId_projects_id_fk": {
+          "name": "systems_projectId_projects_id_fk",
+          "tableFrom": "systems",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_id": {
+          "name": "project_id",
+          "nullsNotDistinct": false,
+          "columns": ["projectId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threats": {
+      "name": "threats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "threats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "pointOfAttackId": {
+          "name": "pointOfAttackId",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doneEditing": {
+          "name": "doneEditing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogThreatId": {
+          "name": "catalogThreatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "threats_catalog_threat_id": {
+          "name": "threats_catalog_threat_id",
+          "columns": [
+            {
+              "expression": "catalogThreatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threats_project_id": {
+          "name": "threats_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "threats_catalogThreatId_catalog_threats_id_fk": {
+          "name": "threats_catalogThreatId_catalog_threats_id_fk",
+          "tableFrom": "threats",
+          "tableTo": "catalog_threats",
+          "columnsFrom": ["catalogThreatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "threats_projectId_projects_id_fk": {
+          "name": "threats_projectId_projects_id_fk",
+          "tableFrom": "threats",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "threats_name_not_empty": {
+          "name": "threats_name_not_empty",
+          "value": "\"threats\".\"name\" <> ''"
+        },
+        "threats_probability_min_max": {
+          "name": "threats_probability_min_max",
+          "value": "\"threats\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tokens_token": {
+          "name": "tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastname": {
+          "name": "lastname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email": {
+          "name": "users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_oidc_sub": {
+          "name": "users_oidc_sub",
+          "columns": [
+            {
+              "expression": "oidc_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_catalogs": {
+      "name": "users_catalogs",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_catalogs_catalog_id": {
+          "name": "users_catalogs_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_catalogs_user_id_catalog_id": {
+          "name": "users_catalogs_user_id_catalog_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_catalogs_userId_users_id_fk": {
+          "name": "users_catalogs_userId_users_id_fk",
+          "tableFrom": "users_catalogs",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "users_catalogs_catalogId_catalogs_id_fk": {
+          "name": "users_catalogs_catalogId_catalogs_id_fk",
+          "tableFrom": "users_catalogs",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_projects": {
+      "name": "users_projects",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_projects_project_id": {
+          "name": "users_projects_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_projects_user_id_project_id": {
+          "name": "users_projects_user_id_project_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_projects_userId_users_id_fk": {
+          "name": "users_projects_userId_users_id_fk",
+          "tableFrom": "users_projects",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "users_projects_projectId_projects_id_fk": {
+          "name": "users_projects_projectId_projects_id_fk",
+          "tableFrom": "users_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attacker": {
+      "name": "attacker",
+      "schema": "public",
+      "values": ["ADMINISTRATORS", "APPLICATION_USERS", "SYSTEM_USERS", "UNAUTHORISED_PARTIES"]
+    },
+    "public.confidentiality_level": {
+      "name": "confidentiality_level",
+      "schema": "public",
+      "values": ["PUBLIC", "INTERNAL", "CONFIDENTIAL", "HIGHLY_CONFIDENTIAL"]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": ["EN", "DE"]
+    },
+    "public.point_of_attack": {
+      "name": "point_of_attack",
+      "schema": "public",
+      "values": [
+        "COMMUNICATION_INFRASTRUCTURE",
+        "COMMUNICATION_INTERFACES",
+        "DATA_STORAGE_INFRASTRUCTURE",
+        "PROCESSING_INFRASTRUCTURE",
+        "USER_BEHAVIOUR",
+        "USER_INTERFACE"
+      ]
+    },
+    "public.standard_icon": {
+      "name": "standard_icon",
+      "schema": "public",
+      "values": ["USERS", "CLIENT", "SERVER", "DATABASE"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["OWNER", "EDITOR", "VIEWER"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1780397500794,
       "tag": "0004_add_standard_icon_to_component_types",
       "breakpoints": false
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784216083482,
+      "tag": "0005_change_measures_scheduled_at_to_date",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/backend/src/controllers/importProjects.controller.ts
+++ b/apps/backend/src/controllers/importProjects.controller.ts
@@ -218,6 +218,7 @@ export async function importProject(request: Request<void>, response: Response, 
                 oldMeasure.projectId = newProjectId;
 
                 const { id: oldMeasureId, ...insertMeasure } = oldMeasure;
+                insertMeasure.scheduledAt = insertMeasure.scheduledAt.slice(0, 10);
                 const newMeasure = await createMeasure(insertMeasure, tx);
 
                 measureIdsDict.set(oldMeasureId, newMeasure!.id);

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import {
     boolean,
     check,
+    date,
     index,
     integer,
     jsonb,
@@ -237,7 +238,7 @@ export const measures = pgTable(
         id: integer().notNull().primaryKey().generatedByDefaultAsIdentity(),
         name: varchar({ length: 255 }).notNull(),
         description: text().notNull(),
-        scheduledAt: timestamp({ mode: "string", withTimezone: true }).notNull(),
+        scheduledAt: date({ mode: "string" }).notNull(),
         catalogMeasureId: integer().references(() => catalogMeasures.id, { onDelete: "set null", onUpdate: "cascade" }),
         createdAt: timestamp({ mode: "string", withTimezone: true })
             .notNull()

--- a/apps/backend/src/types/measure.types.ts
+++ b/apps/backend/src/types/measure.types.ts
@@ -1,5 +1,15 @@
 import { ProjectIdParam } from "#types/project.types.js";
-import { IsDefined, IsInt, IsNotEmpty, IsString, Length, Matches, MaxLength, ValidateIf } from "class-validator";
+import {
+    IsDefined,
+    IsInt,
+    IsISO8601,
+    IsNotEmpty,
+    IsString,
+    Length,
+    Matches,
+    MaxLength,
+    ValidateIf,
+} from "class-validator";
 import {
     FIELD_MUST_BE_INT_MESSAGE,
     FIELD_MUST_BE_ISO_8601_DATE,
@@ -39,6 +49,7 @@ export class UpdateMeasureRequest {
     @IsDefined({ message: FIELD_MUST_EXIST_MESSAGE("scheduledAt") })
     @IsString({ message: FIELD_MUST_BE_STRING_MESSAGE("scheduledAt") })
     @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: FIELD_MUST_BE_ISO_8601_DATE("scheduledAt") })
+    @IsISO8601({ strict: true }, { message: FIELD_MUST_BE_ISO_8601_DATE("scheduledAt") })
     scheduledAt!: string;
 }
 

--- a/apps/backend/src/types/measure.types.ts
+++ b/apps/backend/src/types/measure.types.ts
@@ -1,5 +1,5 @@
 import { ProjectIdParam } from "#types/project.types.js";
-import { IsDefined, IsInt, IsISO8601, IsNotEmpty, IsString, Length, MaxLength, ValidateIf } from "class-validator";
+import { IsDefined, IsInt, IsNotEmpty, IsString, Length, Matches, MaxLength, ValidateIf } from "class-validator";
 import {
     FIELD_MUST_BE_INT_MESSAGE,
     FIELD_MUST_BE_ISO_8601_DATE,
@@ -38,7 +38,7 @@ export class UpdateMeasureRequest {
 
     @IsDefined({ message: FIELD_MUST_EXIST_MESSAGE("scheduledAt") })
     @IsString({ message: FIELD_MUST_BE_STRING_MESSAGE("scheduledAt") })
-    @IsISO8601({ strict: true }, { message: FIELD_MUST_BE_ISO_8601_DATE("scheduledAt") })
+    @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: FIELD_MUST_BE_ISO_8601_DATE("scheduledAt") })
     scheduledAt!: string;
 }
 

--- a/apps/backend/tests/measures.test.ts
+++ b/apps/backend/tests/measures.test.ts
@@ -28,20 +28,20 @@ const VALID_PROJECT: Omit<InstanceType<typeof CreateProjectRequest>, "catalogId"
 const VALID_MEASURE_1: Omit<InstanceType<typeof CreateMeasureRequest>, "catalogMeasureId"> = {
     name: "valid threat from measure",
     description: "valid description test test",
-    scheduledAt: "2022-02-01 00:00:00+00",
+    scheduledAt: "2022-02-01",
 };
 
 const VALID_MEASURE_2: InstanceType<typeof CreateMeasureRequest> = {
     name: "valid threat 2",
     description: "valid description test 2",
-    scheduledAt: "2025-10-10 00:00:00+00",
+    scheduledAt: "2025-10-10",
     catalogMeasureId: null,
 };
 
 const VALID_MEASURE_3: InstanceType<typeof CreateMeasureRequest> = {
     name: "valid threat 3",
     description: "valid description test 3",
-    scheduledAt: "2025-10-10 00:00:00+00",
+    scheduledAt: "2025-10-10",
     catalogMeasureId: null,
 };
 
@@ -56,13 +56,20 @@ const VALID_MEASURE_IMPACT_1: Omit<InstanceType<typeof CreateMeasureImpactReques
 
 const INVALID_MEASURE_NAME_MISSING: Omit<InstanceType<typeof CreateMeasureRequest>, "name"> = {
     description: "valid description test test",
-    scheduledAt: "2022-02-01 00:00:00+00",
+    scheduledAt: "2022-02-01",
     catalogMeasureId: null,
 };
 
 const INVALID_MEASURE_SCHEDULED_AT_MISSING: Omit<InstanceType<typeof CreateMeasureRequest>, "scheduledAt"> = {
     name: "valid threat",
     description: "valid description test test",
+    catalogMeasureId: null,
+};
+
+const INVALID_MEASURE_SCHEDULED_AT_TIMESTAMP: InstanceType<typeof CreateMeasureRequest> = {
+    name: "valid timestamp measure",
+    description: "valid description test test",
+    scheduledAt: "2022-02-01T00:00:00Z",
     catalogMeasureId: null,
 };
 
@@ -244,6 +251,16 @@ describe("get or create measures", () => {
         const res = await request(app)
             .post(`/api/projects/${projectId}/system/measures`)
             .send({ ...INVALID_MEASURE_SCHEDULED_AT_MISSING, threatId })
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it("should not create a measure (scheduled at is a full timestamp, not a date)", async () => {
+        const res = await request(app)
+            .post(`/api/projects/${projectId}/system/measures`)
+            .send({ ...INVALID_MEASURE_SCHEDULED_AT_TIMESTAMP, threatId })
             .set("X-CSRF-TOKEN", csrfToken)
             .set("Cookie", cookies);
         expect(res.statusCode).toEqual(400);

--- a/apps/backend/tests/measures.test.ts
+++ b/apps/backend/tests/measures.test.ts
@@ -73,6 +73,20 @@ const INVALID_MEASURE_SCHEDULED_AT_TIMESTAMP: InstanceType<typeof CreateMeasureR
     catalogMeasureId: null,
 };
 
+const INVALID_MEASURE_SCHEDULED_AT_NONEXISTENT_DAY: InstanceType<typeof CreateMeasureRequest> = {
+    name: "valid nonexistent-day measure",
+    description: "valid description test test",
+    scheduledAt: "2026-02-30",
+    catalogMeasureId: null,
+};
+
+const INVALID_MEASURE_SCHEDULED_AT_BAD_MONTH: InstanceType<typeof CreateMeasureRequest> = {
+    name: "valid bad-month measure",
+    description: "valid description test test",
+    scheduledAt: "2026-13-45",
+    catalogMeasureId: null,
+};
+
 const VALID_THREAT_1: Omit<InstanceType<typeof CreateThreatRequest>, "catalogThreatId"> = {
     pointOfAttackId: nanoid(),
     name: "valid threat",
@@ -261,6 +275,26 @@ describe("get or create measures", () => {
         const res = await request(app)
             .post(`/api/projects/${projectId}/system/measures`)
             .send({ ...INVALID_MEASURE_SCHEDULED_AT_TIMESTAMP, threatId })
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it("should not create a measure (scheduledAt is a nonexistent calendar day)", async () => {
+        const res = await request(app)
+            .post(`/api/projects/${projectId}/system/measures`)
+            .send({ ...INVALID_MEASURE_SCHEDULED_AT_NONEXISTENT_DAY, threatId })
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it("should not create a measure (scheduledAt has an out-of-range month/day)", async () => {
+        const res = await request(app)
+            .post(`/api/projects/${projectId}/system/measures`)
+            .send({ ...INVALID_MEASURE_SCHEDULED_AT_BAD_MONTH, threatId })
             .set("X-CSRF-TOKEN", csrfToken)
             .set("Cookie", cookies);
         expect(res.statusCode).toEqual(400);

--- a/apps/frontend/playwright/tests/measures.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/measures.page.e2e.spec.ts
@@ -7,20 +7,20 @@ import { MeasuresPage } from "../pages/measures.page.ts";
 import { CONFIDENTIALITY_LEVELS } from "#utils/confidentiality.ts";
 import measuresFixture from "../fixtures/measures.json" with { type: "json" };
 
-const measures: { name: string; description: string; scheduledAt: Date; projectId: number }[] = [];
-const invalidMeasures: { name: string; description: string; scheduledAt: Date }[] = [];
+const measures: { name: string; description: string; scheduledAt: string; projectId: number }[] = [];
+const invalidMeasures: { name: string; description: string; scheduledAt: string }[] = [];
 let projectId: number;
 
-function toDisplayFormat(date: Date): string {
-    return date.toISOString().split("T")[0]!;
+function toDateString(isoDateTime: string): string {
+    return new Date(isoDateTime).toISOString().split("T")[0]!;
 }
 
 test.beforeAll(() => {
     measures.push(
-        ...measuresFixture.measures.map((m) => ({ ...m, scheduledAt: new Date(m.scheduledAt), projectId: -1 }))
+        ...measuresFixture.measures.map((m) => ({ ...m, scheduledAt: toDateString(m.scheduledAt), projectId: -1 }))
     );
     invalidMeasures.push(
-        ...measuresFixture.invalidMeasures.map((m) => ({ ...m, scheduledAt: new Date(m.scheduledAt) }))
+        ...measuresFixture.invalidMeasures.map((m) => ({ ...m, scheduledAt: toDateString(m.scheduledAt) }))
     );
 });
 
@@ -74,7 +74,7 @@ test.describe("Measures Page tests", () => {
             await pg.addMeasureButton.click();
             await pg.nameInput.fill(`${measure.name} ${tid}`);
             await pg.descriptionInput.fill(measure.description);
-            await pg.scheduledAtInput.fill(toDisplayFormat(measure.scheduledAt));
+            await pg.scheduledAtInput.fill(measure.scheduledAt);
             await pg.saveButton.click();
         }
         await expect(pg.measureListEntries).toHaveCount(3);
@@ -104,7 +104,7 @@ test.describe("Measures Page tests", () => {
     test("Should sort all measures by scheduled at date", async ({ page, request }) => {
         const pg = new MeasuresPage(page);
         const token = await pg.getCsrfToken();
-        const sorted = [...measures].sort((a, b) => +a.scheduledAt - +b.scheduledAt);
+        const sorted = [...measures].sort((a, b) => a.scheduledAt.localeCompare(b.scheduledAt));
         await createMeasures(request, token, measures);
         await page.reload();
 
@@ -112,14 +112,14 @@ test.describe("Measures Page tests", () => {
         await expect(pg.sortByScheduledAtButton).toHaveAttribute("aria-sort", "ascending");
         const entries = await pg.measureListEntryScheduledAt.allTextContents();
         for (let i = 0; i < sorted.length; i++) {
-            expect(entries[i]).toContain(toDisplayFormat(sorted[i]!.scheduledAt));
+            expect(entries[i]).toContain(sorted[i]!.scheduledAt);
         }
 
         await pg.sortByScheduledAtButton.click();
         await expect(pg.sortByScheduledAtButton).toHaveAttribute("aria-sort", "descending");
         const reversed = await pg.measureListEntryScheduledAt.allTextContents();
         for (let i = 0; i < sorted.length; i++) {
-            expect(reversed[i]).toContain(toDisplayFormat([...sorted].reverse()[i]!.scheduledAt));
+            expect(reversed[i]).toContain([...sorted].reverse()[i]!.scheduledAt);
         }
     });
 
@@ -128,7 +128,7 @@ test.describe("Measures Page tests", () => {
         const token = await pg.getCsrfToken();
         const measure = measures[Math.floor(Math.random() * measures.length)]!;
         const updatedName = "Updated test measure name";
-        const updatedDate = new Date();
+        const updatedDate = "2099-12-31";
 
         await createMeasure(request, token, measure);
         await page.reload();
@@ -137,11 +137,11 @@ test.describe("Measures Page tests", () => {
         await pg.nameInput.fill("");
         await pg.nameInput.fill(updatedName);
         await pg.scheduledAtInput.fill("");
-        await pg.scheduledAtInput.fill(toDisplayFormat(updatedDate));
+        await pg.scheduledAtInput.fill(updatedDate);
         await pg.saveButton.click();
 
         await expect(pg.measureListEntryNames.first()).toContainText(updatedName);
-        await expect(pg.measureListEntryScheduledAt.first()).toContainText(toDisplayFormat(updatedDate));
+        await expect(pg.measureListEntryScheduledAt.first()).toContainText(updatedDate);
     });
 
     test("Should duplicate a measure", async ({ page, request }) => {
@@ -156,7 +156,7 @@ test.describe("Measures Page tests", () => {
         await pg.saveButton.click();
 
         await expect(pg.measureListEntryNames.first()).toContainText(measure.name);
-        await expect(pg.measureListEntryScheduledAt.first()).toContainText(toDisplayFormat(measure.scheduledAt));
+        await expect(pg.measureListEntryScheduledAt.first()).toContainText(measure.scheduledAt);
     });
 
     test("Should delete an existing measure", async ({ page, request }) => {
@@ -193,7 +193,7 @@ test.describe("Measures Page tests", () => {
                 }
 
                 await pg.nameInput.fill(invalidMeasure.name);
-                await pg.scheduledAtInput.fill(toDisplayFormat(invalidMeasure.scheduledAt));
+                await pg.scheduledAtInput.fill(invalidMeasure.scheduledAt);
                 await pg.saveButton.click();
                 await expect(page).toHaveURL(`/projects/${projectId}/measures/edit`);
                 await pg.cancelButton.click();

--- a/apps/frontend/src/api/types/measure.types.ts
+++ b/apps/frontend/src/api/types/measure.types.ts
@@ -1,7 +1,7 @@
 export interface CreateMeasureRequest {
     name: string;
     description: string;
-    scheduledAt: Date;
+    scheduledAt: string;
     projectId: number;
     catalogMeasureId?: number;
 }
@@ -15,7 +15,7 @@ export interface Measure {
     id: number;
     name: string;
     description: string;
-    scheduledAt: Date;
+    scheduledAt: string;
     projectId: number;
     catalogMeasureId: number | null;
     createdAt: Date;

--- a/apps/frontend/src/application/hooks/use-matrix.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-matrix.hook.test.tsx
@@ -33,7 +33,7 @@ const renderUseMatrix = ({ threats = [], measures = [], measureImpacts = [] }: S
 
 // A threat wired to a single measure through a measure impact, so the threat's
 // derived `measures[0].active` flag reflects the timeline-date comparison.
-const linkedSetup = (scheduledAt: Date): SetupArgs => ({
+const linkedSetup = (scheduledAt: string): SetupArgs => ({
     threats: [createThreat({ id: 1 })],
     measures: [createMeasure({ id: 10, scheduledAt })],
     measureImpacts: [createMeasureImpact({ id: 1, measureId: 10, threatId: 1 })],
@@ -45,21 +45,19 @@ describe("useMatrix", () => {
     });
 
     describe("timeline", () => {
-        it("anchors an empty timeline to today's midnight when there are no measures", () => {
+        it("anchors an empty timeline to an empty date string when there are no measures", () => {
             const { result } = renderUseMatrix({ measures: [] });
             const { timeline } = result.current;
 
             expect(timeline.marks).toEqual([]);
             expect(timeline.minValue).toBe(-1);
             expect(timeline.maxValue).toBe(0);
-            expect(timeline.startDate.getTime()).toBe(timeline.endDate.getTime());
-            expect(timeline.startDate.getHours()).toBe(0);
-            expect(timeline.startDate.getMinutes()).toBe(0);
-            expect(timeline.startDate.getSeconds()).toBe(0);
+            expect(timeline.startDate).toBe("");
+            expect(timeline.endDate).toBe("");
         });
 
-        it("prepends a Start mark and adds one ISO-labelled mark per measure", () => {
-            const measure = createMeasure({ id: 10, scheduledAt: new Date("2025-03-10T09:30:00Z") });
+        it("prepends a Start mark and adds one date-labelled mark per measure", () => {
+            const measure = createMeasure({ id: 10, scheduledAt: "2025-03-10" });
 
             const { result } = renderUseMatrix({ measures: [measure] });
             const { marks } = result.current.timeline;
@@ -71,24 +69,22 @@ describe("useMatrix", () => {
             expect(marks[1]?.label).toBe("2025-03-10");
         });
 
-        it("does not mutate the measure's scheduledAt while building marks", () => {
-            const scheduledAt = new Date("2025-03-10T09:30:00Z");
-            const originalTime = scheduledAt.getTime();
+        it("preserves the measure's scheduledAt string when building marks", () => {
+            const scheduledAt = "2025-03-10";
             const measure = createMeasure({ id: 10, scheduledAt });
 
             const { result } = renderUseMatrix({ measures: [measure] });
             const { marks } = result.current.timeline;
 
             expect(marks[1]?.date).toBe(scheduledAt);
-            expect(scheduledAt.getTime()).toBe(originalTime);
-            expect(measure.scheduledAt.getTime()).toBe(originalTime);
+            expect(measure.scheduledAt).toBe(scheduledAt);
         });
 
         it("maps mark values to whole-day offsets from the earliest measure", () => {
             const measures = [
-                createMeasure({ id: 1, scheduledAt: new Date("2025-03-10T08:00:00Z") }),
-                createMeasure({ id: 2, scheduledAt: new Date("2025-03-12T20:00:00Z") }),
-                createMeasure({ id: 3, scheduledAt: new Date("2025-03-15T00:00:00Z") }),
+                createMeasure({ id: 1, scheduledAt: "2025-03-10" }),
+                createMeasure({ id: 2, scheduledAt: "2025-03-12" }),
+                createMeasure({ id: 3, scheduledAt: "2025-03-15" }),
             ];
 
             const { result } = renderUseMatrix({ measures });
@@ -101,8 +97,8 @@ describe("useMatrix", () => {
 
         it("collapses measures on the same calendar day to the same mark value", () => {
             const measures = [
-                createMeasure({ id: 1, scheduledAt: new Date("2025-03-10T01:00:00Z") }),
-                createMeasure({ id: 2, scheduledAt: new Date("2025-03-10T23:00:00Z") }),
+                createMeasure({ id: 1, scheduledAt: "2025-03-10" }),
+                createMeasure({ id: 2, scheduledAt: "2025-03-10" }),
             ];
 
             const { result } = renderUseMatrix({ measures });
@@ -115,36 +111,36 @@ describe("useMatrix", () => {
 
     describe("measure active flag", () => {
         it("is inactive while no timeline date is selected", () => {
-            const { result } = renderUseMatrix(linkedSetup(new Date("2025-03-10T12:00:00Z")));
+            const { result } = renderUseMatrix(linkedSetup("2025-03-10"));
 
             expect(result.current.threats[0]?.measures[0]?.active).toBe(false);
         });
 
-        it("activates when the timeline date is the same day but an earlier clock time", () => {
-            const { result } = renderUseMatrix(linkedSetup(new Date("2025-03-10T18:00:00Z")));
+        it("activates when the timeline date is the same day as the measure", () => {
+            const { result } = renderUseMatrix(linkedSetup("2025-03-10"));
 
             act(() => {
-                result.current.setTimelineDate(new Date("2025-03-10T06:00:00Z"));
+                result.current.setTimelineDate("2025-03-10");
             });
 
             expect(result.current.threats[0]?.measures[0]?.active).toBe(true);
         });
 
         it("stays inactive when the timeline date is on an earlier day", () => {
-            const { result } = renderUseMatrix(linkedSetup(new Date("2025-03-10T12:00:00Z")));
+            const { result } = renderUseMatrix(linkedSetup("2025-03-10"));
 
             act(() => {
-                result.current.setTimelineDate(new Date("2025-03-09T23:00:00Z"));
+                result.current.setTimelineDate("2025-03-09");
             });
 
             expect(result.current.threats[0]?.measures[0]?.active).toBe(false);
         });
 
         it("activates when the timeline date is on a later day", () => {
-            const { result } = renderUseMatrix(linkedSetup(new Date("2025-03-10T12:00:00Z")));
+            const { result } = renderUseMatrix(linkedSetup("2025-03-10"));
 
             act(() => {
-                result.current.setTimelineDate(new Date("2025-03-11T01:00:00Z"));
+                result.current.setTimelineDate("2025-03-11");
             });
 
             expect(result.current.threats[0]?.measures[0]?.active).toBe(true);

--- a/apps/frontend/src/application/hooks/use-matrix.hook.ts
+++ b/apps/frontend/src/application/hooks/use-matrix.hook.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { ExtendedThreat } from "#api/types/threat.types.ts";
 import type { MeasureImpact } from "#api/types/measure-impact.types.ts";
 import { calcNetRisk } from "#utils/calcRisk.ts";
-import { createRiskMatrixDesign, addThreatsToRiskMatrix, toDayNumber } from "#utils/riskMatrix.ts";
+import { createRiskMatrixDesign, addThreatsToRiskMatrix, dayNumberFromDateString } from "#utils/riskMatrix.ts";
 import { useCatalogMeasures } from "./use-catalog-measures.hook.ts";
 import { useMeasureImpacts } from "./use-measureImpacts.hook.ts";
 import { useMeasures } from "./use-measures.hook.ts";
@@ -19,7 +19,7 @@ export interface ThreatMeasure {
     catalogMeasureId: number | null;
     name: string;
     description: string;
-    scheduledAt: Date;
+    scheduledAt: string;
     measureImpact: MeasureImpact | undefined;
 }
 
@@ -45,14 +45,14 @@ export type MatrixGrid = MatrixCell[][];
 interface TimelineMark {
     value: number;
     tooltipText: string;
-    date: Date | null;
+    date: string | null;
     label: string;
 }
 
 export interface TimelineData {
     marks: TimelineMark[];
-    startDate: Date;
-    endDate: Date;
+    startDate: string;
+    endDate: string;
     minValue: number;
     maxValue: number;
 }
@@ -86,7 +86,7 @@ export const useMatrix = ({ projectId, catalogId }: UseMatrixArgs) => {
     const [currentGreenValue, setCurrentGreenValue] = useState<number>(defaultGreen);
     const [currentRedValue, setCurrentRedValue] = useState<number>(defaultRed);
     const [selectedCell, setSelectedCell] = useState<SelectedMatrixCell | null>(null);
-    const [timelineDate, setTimelineDate] = useState<Date | null>(null);
+    const [timelineDate, setTimelineDate] = useState<string | null>(null);
     const [threatSearchValue, setThreatSearchValue] = useState<string>("");
     const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
     const [sortBy, setSortBy] = useState<"name" | "newProbability" | "newRisk" | "componentName">("name");
@@ -114,7 +114,9 @@ export const useMatrix = ({ projectId, catalogId }: UseMatrixArgs) => {
                             })
                             .map((measure) => {
                                 const active =
-                                    !!timelineDate && toDayNumber(timelineDate) >= toDayNumber(measure.scheduledAt);
+                                    !!timelineDate &&
+                                    dayNumberFromDateString(timelineDate) >=
+                                        dayNumberFromDateString(measure.scheduledAt);
                                 return {
                                     measureId: measure.id,
                                     active: active,
@@ -204,26 +206,24 @@ export const useMatrix = ({ projectId, catalogId }: UseMatrixArgs) => {
 
     const timeline: TimelineData = useMemo(() => {
         if (measures.length === 0) {
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
             return {
                 marks: [],
-                startDate: today,
-                endDate: today,
+                startDate: "",
+                endDate: "",
                 minValue: -1,
                 maxValue: 0,
             };
         }
 
-        const startDate = measures[0]?.scheduledAt ?? new Date();
-        const endDate = measures[measures.length - 1]?.scheduledAt ?? new Date();
-        const maxDate = toDayNumber(endDate);
-        const minDate = toDayNumber(startDate);
+        const startDate = measures[0]?.scheduledAt ?? "";
+        const endDate = measures[measures.length - 1]?.scheduledAt ?? "";
+        const maxDate = dayNumberFromDateString(endDate);
+        const minDate = dayNumberFromDateString(startDate);
         const minValue = -1;
         const maxValue = maxDate - minDate;
         const marks: TimelineMark[] = measures.map((measure) => {
-            const value = toDayNumber(measure.scheduledAt) - minDate;
-            const tooltipText = measure.scheduledAt.toISOString().split("T")[0] ?? "";
+            const value = dayNumberFromDateString(measure.scheduledAt) - minDate;
+            const tooltipText = measure.scheduledAt;
             return {
                 value: value,
                 tooltipText: tooltipText,

--- a/apps/frontend/src/application/hooks/use-measures.hook.ts
+++ b/apps/frontend/src/application/hooks/use-measures.hook.ts
@@ -19,7 +19,7 @@ export const useMeasures = ({ projectId }: { projectId: number }) => {
     };
 
     const measures: Measure[] = useMemo(
-        () => [...items].sort((a, b) => (a.scheduledAt > b.scheduledAt ? 1 : -1)),
+        () => [...items].sort((a, b) => (a.scheduledAt === b.scheduledAt ? 0 : a.scheduledAt > b.scheduledAt ? 1 : -1)),
         [items]
     );
 

--- a/apps/frontend/src/application/hooks/use-measures.hook.ts
+++ b/apps/frontend/src/application/hooks/use-measures.hook.ts
@@ -19,13 +19,7 @@ export const useMeasures = ({ projectId }: { projectId: number }) => {
     };
 
     const measures: Measure[] = useMemo(
-        () =>
-            items
-                .map((item) => ({
-                    ...item,
-                    scheduledAt: new Date(item.scheduledAt),
-                }))
-                .sort((a, b) => (a.scheduledAt > b.scheduledAt ? 1 : -1)),
+        () => [...items].sort((a, b) => (a.scheduledAt > b.scheduledAt ? 1 : -1)),
         [items]
     );
 

--- a/apps/frontend/src/application/hooks/use-report.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-report.hook.test.tsx
@@ -83,12 +83,12 @@ describe("useReport", () => {
             netRisk: 6,
             measures: [
                 createReportThreatMeasure({
-                    scheduledAt: "2025-01-15T00:00:00.000Z",
+                    scheduledAt: "2025-01-15",
                     impactsProbability: true,
                     probability: 2,
                 }),
                 createReportThreatMeasure({
-                    scheduledAt: "2025-06-15T00:00:00.000Z",
+                    scheduledAt: "2025-06-15",
                     impactsDamage: true,
                     damage: 3,
                 }),
@@ -110,7 +110,7 @@ describe("useReport", () => {
     it("groups milestones by measure date and toggles active via riskMatrixMeasures", async () => {
         const report = createProjectReport({
             threats: [createReportThreat({ id: 1 })],
-            measures: [createReportMeasure({ scheduledAt: "2025-01-01T00:00:00.000Z" })],
+            measures: [createReportMeasure({ scheduledAt: "2025-01-01" })],
         });
         const { result } = renderUseReport(report);
 

--- a/apps/frontend/src/application/hooks/use-report.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-report.hook.test.tsx
@@ -110,8 +110,7 @@ describe("useReport", () => {
     it("groups milestones by measure date and toggles active via riskMatrixMeasures", async () => {
         const report = createProjectReport({
             threats: [createReportThreat({ id: 1 })],
-            // report measures arrive as ISO strings over the wire, despite the Date type
-            measures: [createReportMeasure({ scheduledAt: "2025-01-01T00:00:00.000Z" as unknown as Date })],
+            measures: [createReportMeasure({ scheduledAt: "2025-01-01T00:00:00.000Z" })],
         });
         const { result } = renderUseReport(report);
 

--- a/apps/frontend/src/application/hooks/use-report.hook.ts
+++ b/apps/frontend/src/application/hooks/use-report.hook.ts
@@ -1,6 +1,6 @@
 import type { ProjectReport } from "#api/types/project.types.ts";
 import type { SortDirection } from "#application/actions/list.actions.ts";
-import { createRiskMatrixDesign, addThreatsToRiskMatrix } from "#utils/riskMatrix.ts";
+import { createRiskMatrixDesign, addThreatsToRiskMatrix, dayNumberFromDateString } from "#utils/riskMatrix.ts";
 import { useAlert } from "#application/hooks/use-alert.hook.ts";
 import { useState, useMemo, useEffect, useEffectEvent, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -166,8 +166,8 @@ export const useReport = ({ projectId }: { projectId: number }) => {
                 if (!item.scheduledAt) {
                     return obj;
                 }
-                const scheduledAt = new Date(item.scheduledAt.toString().substring(0, 10));
-                const scheduledAtTime = scheduledAt.getTime();
+                const scheduledAt = item.scheduledAt.slice(0, 10);
+                const scheduledAtTime = dayNumberFromDateString(scheduledAt);
                 if (Number.isNaN(scheduledAtTime)) {
                     return obj;
                 }
@@ -187,7 +187,7 @@ export const useReport = ({ projectId }: { projectId: number }) => {
             },
             {} as Record<number, Milestone>
         );
-        return Object.values(map).sort((a, b) => (a.scheduledAt.getTime() < b.scheduledAt.getTime() ? -1 : 1));
+        return Object.values(map).sort((a, b) => (a.scheduledAt < b.scheduledAt ? -1 : 1));
     }, [filteredMeasures, filteredThreats, matrixDesign]);
 
     const transformedMilestones: Milestone[] | null = useMemo(() => {
@@ -196,10 +196,9 @@ export const useReport = ({ projectId }: { projectId: number }) => {
         }
         return milestones.map((milestone) => {
             const { scheduledAt } = milestone;
-            const id = scheduledAt.toISOString().substring(0, 10);
             return {
                 ...milestone,
-                active: riskMatrixMeasures.includes(id),
+                active: riskMatrixMeasures.includes(scheduledAt),
             };
         });
     }, [milestones, riskMatrixMeasures]);

--- a/apps/frontend/src/application/hooks/use-threat-measures-list.hook.ts
+++ b/apps/frontend/src/application/hooks/use-threat-measures-list.hook.ts
@@ -17,7 +17,7 @@ export interface ThreatMeasure {
     netDamage: number | null;
     measureId: number;
     measureName: string;
-    measureScheduleAt: Date | null;
+    measureScheduleAt: string | null;
     threatName?: string;
     measure: Measure;
     measureImpact: MeasureImpact;

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -252,7 +252,7 @@ export const createReportThreatMeasure = (overrides: Partial<ReportThreatMeasure
     ...createMeasureImpact(),
     reportId: "M-01",
     name: "Test Measure",
-    scheduledAt: "2025-01-01T00:00:00.000Z",
+    scheduledAt: "2025-01-01",
     ...overrides,
 });
 

--- a/apps/frontend/src/test-utils/builders.ts
+++ b/apps/frontend/src/test-utils/builders.ts
@@ -199,7 +199,7 @@ export const createMeasure = (overrides: Partial<Measure> = {}): Measure => ({
     id: 1,
     name: "Test Measure",
     description: "",
-    scheduledAt: new Date("2025-01-01"),
+    scheduledAt: "2025-01-01",
     projectId: 1,
     catalogMeasureId: null,
     createdAt: new Date("2025-01-01"),
@@ -208,7 +208,7 @@ export const createMeasure = (overrides: Partial<Measure> = {}): Measure => ({
 });
 
 export const createReportMilestone = (overrides: Partial<Milestone> = {}): Milestone & { active: boolean } => ({
-    scheduledAt: new Date("2025-01-01"),
+    scheduledAt: "2025-01-01",
     matrix: null,
     barGraph: null,
     active: false,
@@ -238,7 +238,7 @@ export const createThreatMeasure = (overrides: Partial<ThreatMeasure> = {}): Thr
     netDamage: null,
     measureId: 1,
     measureName: "Test Measure",
-    measureScheduleAt: new Date("2025-01-01"),
+    measureScheduleAt: "2025-01-01",
     threatName: "Test Threat",
     measure: createMeasure(),
     measureImpact: createMeasureImpact(),

--- a/apps/frontend/src/utils/report-risk.test.ts
+++ b/apps/frontend/src/utils/report-risk.test.ts
@@ -14,25 +14,25 @@ describe("filterThreatsByScheduledRange", () => {
     });
 
     it("keeps only the measures scheduled inside the range", () => {
-        const january = createReportThreatMeasure({ scheduledAt: "2025-01-15T00:00:00.000Z" });
-        const june = createReportThreatMeasure({ scheduledAt: "2025-06-15T00:00:00.000Z" });
+        const january = createReportThreatMeasure({ scheduledAt: "2025-01-15" });
+        const june = createReportThreatMeasure({ scheduledAt: "2025-06-15" });
         const threat = createReportThreat({ measures: [january, june] });
 
         const filtered = filterThreatsByScheduledRange([threat], "2025-01-01", "2025-01-31")[0]!;
 
         expect(filtered.measures).toHaveLength(1);
-        expect(filtered.measures[0]!.scheduledAt).toBe("2025-01-15T00:00:00.000Z");
+        expect(filtered.measures[0]!.scheduledAt).toBe("2025-01-15");
     });
 
     it("recomputes the net values from the surviving measures only (issue #877)", () => {
         // Gross 4 x 5 = 20. January measure lowers probability to 2, June measure lowers damage to 3.
         const january = createReportThreatMeasure({
-            scheduledAt: "2025-01-15T00:00:00.000Z",
+            scheduledAt: "2025-01-15",
             impactsProbability: true,
             probability: 2,
         });
         const june = createReportThreatMeasure({
-            scheduledAt: "2025-06-15T00:00:00.000Z",
+            scheduledAt: "2025-06-15",
             impactsDamage: true,
             damage: 3,
         });
@@ -55,7 +55,7 @@ describe("filterThreatsByScheduledRange", () => {
 
     it("restores the gross net values when the range excludes every measure", () => {
         const measure = createReportThreatMeasure({
-            scheduledAt: "2025-06-15T00:00:00.000Z",
+            scheduledAt: "2025-06-15",
             impactsProbability: true,
             probability: 1,
         });
@@ -77,7 +77,7 @@ describe("filterThreatsByScheduledRange", () => {
     });
 
     it("excludes measures without a scheduledAt", () => {
-        const dated = createReportThreatMeasure({ scheduledAt: "2025-01-15T00:00:00.000Z" });
+        const dated = createReportThreatMeasure({ scheduledAt: "2025-01-15" });
         const undatedMeasure = createReportThreatMeasure({ scheduledAt: undefined });
         const threat = createReportThreat({ measures: [dated, undatedMeasure] });
 
@@ -88,8 +88,8 @@ describe("filterThreatsByScheduledRange", () => {
     });
 
     it("treats both range bounds as inclusive", () => {
-        const onFrom = createReportThreatMeasure({ scheduledAt: "2025-01-01T00:00:00.000Z" });
-        const onTill = createReportThreatMeasure({ scheduledAt: "2025-01-31T00:00:00.000Z" });
+        const onFrom = createReportThreatMeasure({ scheduledAt: "2025-01-01" });
+        const onTill = createReportThreatMeasure({ scheduledAt: "2025-01-31" });
         const threat = createReportThreat({ measures: [onFrom, onTill] });
 
         const filtered = filterThreatsByScheduledRange([threat], "2025-01-01", "2025-01-31")[0]!;
@@ -105,8 +105,8 @@ describe("filterMeasuresByScheduledRange", () => {
     });
 
     it("keeps only the measures scheduled inside the range", () => {
-        const january = createReportMeasure({ id: 1, scheduledAt: new Date("2025-01-15") });
-        const june = createReportMeasure({ id: 2, scheduledAt: new Date("2025-06-15") });
+        const january = createReportMeasure({ id: 1, scheduledAt: "2025-01-15" });
+        const june = createReportMeasure({ id: 2, scheduledAt: "2025-06-15" });
 
         const filtered = filterMeasuresByScheduledRange([january, june], "2025-01-01", "2025-01-31");
 
@@ -115,8 +115,8 @@ describe("filterMeasuresByScheduledRange", () => {
     });
 
     it("applies only the lower bound when the upper bound is absent", () => {
-        const january = createReportMeasure({ id: 1, scheduledAt: new Date("2025-01-15") });
-        const june = createReportMeasure({ id: 2, scheduledAt: new Date("2025-06-15") });
+        const january = createReportMeasure({ id: 1, scheduledAt: "2025-01-15" });
+        const june = createReportMeasure({ id: 2, scheduledAt: "2025-06-15" });
 
         const filtered = filterMeasuresByScheduledRange([january, june], "2025-03-01", null);
 
@@ -127,18 +127,18 @@ describe("filterMeasuresByScheduledRange", () => {
 describe("calcActiveMeasureNetRisk", () => {
     it("applies only the measures scheduled on or before the given date", () => {
         const early = createReportThreatMeasure({
-            scheduledAt: "2025-01-15T00:00:00.000Z",
+            scheduledAt: "2025-01-15",
             impactsProbability: true,
             probability: 2,
         });
         const late = createReportThreatMeasure({
-            scheduledAt: "2025-06-15T00:00:00.000Z",
+            scheduledAt: "2025-06-15",
             impactsDamage: true,
             damage: 1,
         });
         const threat = createReportThreat({ probability: 4, damage: 5, measures: [early, late] });
 
-        const { netProbability, netDamage, netRisk } = calcActiveMeasureNetRisk(threat, new Date("2025-03-01"));
+        const { netProbability, netDamage, netRisk } = calcActiveMeasureNetRisk(threat, "2025-03-01");
 
         expect(netProbability).toBe(2);
         expect(netDamage).toBe(5);

--- a/apps/frontend/src/utils/report-risk.ts
+++ b/apps/frontend/src/utils/report-risk.ts
@@ -1,7 +1,7 @@
 import type { ProjectReport } from "#api/types/project.types.ts";
 import type { MatrixColorKey } from "#view/colors/matrix.ts";
 import { calcNetRisk } from "#utils/calcRisk.ts";
-import { toDayNumber, addThreatsToRiskMatrix } from "#utils/riskMatrix.ts";
+import { dayNumberFromDateString, addThreatsToRiskMatrix } from "#utils/riskMatrix.ts";
 
 export type ReportThreat = ProjectReport["threats"][number];
 export type ReportMeasure = ProjectReport["measures"][number];
@@ -19,7 +19,7 @@ export interface RiskBarGraph {
 }
 
 export interface Milestone {
-    scheduledAt: Date;
+    scheduledAt: string;
     matrix: RiskMatrix | null;
     barGraph: RiskBarGraph | null;
     measures?: ReportMeasure[];
@@ -31,11 +31,11 @@ export interface Milestone {
  * A missing or unparseable scheduledAt is treated as out of range. A null bound means "unbounded".
  */
 const isMeasureWithinScheduledRange = (
-    measure: { scheduledAt?: string | Date | null | undefined },
+    measure: { scheduledAt?: string | null | undefined },
     fromDay: number | null,
     tillDay: number | null
 ): boolean => {
-    const scheduledAtDay = measure.scheduledAt ? toDayNumber(new Date(measure.scheduledAt)) : NaN;
+    const scheduledAtDay = measure.scheduledAt ? dayNumberFromDateString(measure.scheduledAt) : NaN;
     if (Number.isNaN(scheduledAtDay)) {
         return false;
     }
@@ -61,8 +61,8 @@ export const filterThreatsByScheduledRange = (
     if (!fromScheduledAt && !tillScheduledAt) {
         return threats;
     }
-    const fromDay = fromScheduledAt ? toDayNumber(new Date(fromScheduledAt)) : null;
-    const tillDay = tillScheduledAt ? toDayNumber(new Date(tillScheduledAt)) : null;
+    const fromDay = fromScheduledAt ? dayNumberFromDateString(fromScheduledAt) : null;
+    const tillDay = tillScheduledAt ? dayNumberFromDateString(tillScheduledAt) : null;
     return threats.map((threat) => {
         const filteredMeasures = threat.measures.filter((measure) =>
             isMeasureWithinScheduledRange(measure, fromDay, tillDay)
@@ -90,21 +90,21 @@ export const filterMeasuresByScheduledRange = (
     if (!fromScheduledAt && !tillScheduledAt) {
         return measures;
     }
-    const fromDay = fromScheduledAt ? toDayNumber(new Date(fromScheduledAt)) : null;
-    const tillDay = tillScheduledAt ? toDayNumber(new Date(tillScheduledAt)) : null;
+    const fromDay = fromScheduledAt ? dayNumberFromDateString(fromScheduledAt) : null;
+    const tillDay = tillScheduledAt ? dayNumberFromDateString(tillScheduledAt) : null;
     return measures.filter((measure) => isMeasureWithinScheduledRange(measure, fromDay, tillDay));
 };
 
 /**
  * Net risk of a threat when only the measures scheduled on or before the given date are applied.
  */
-export const calcActiveMeasureNetRisk = (threat: ReportThreat, scheduledAt: Date) => {
+export const calcActiveMeasureNetRisk = (threat: ReportThreat, scheduledAt: string) => {
     const activeMeasures = threat.measures.filter((measure) => {
         if (!measure.scheduledAt) {
             return false;
         }
-        const measureScheduledAt = toDayNumber(new Date(measure.scheduledAt));
-        return !Number.isNaN(measureScheduledAt) && measureScheduledAt <= toDayNumber(scheduledAt);
+        const measureScheduledAt = dayNumberFromDateString(measure.scheduledAt);
+        return !Number.isNaN(measureScheduledAt) && measureScheduledAt <= dayNumberFromDateString(scheduledAt);
     });
     return calcNetRisk(threat.probability, threat.damage, activeMeasures);
 };
@@ -112,7 +112,7 @@ export const calcActiveMeasureNetRisk = (threat: ReportThreat, scheduledAt: Date
 export const calcNetRiskMatrix = (
     threats: ReportThreat[] | null | undefined,
     matrix: RiskMatrix | null,
-    scheduledAt: Date
+    scheduledAt: string
 ): RiskMatrix | null => {
     if (!threats || !matrix) {
         return null;

--- a/apps/frontend/src/utils/riskMatrix.test.ts
+++ b/apps/frontend/src/utils/riskMatrix.test.ts
@@ -1,4 +1,9 @@
-import { createRiskMatrixDesign, addThreatsToRiskMatrix, type RiskMatrixCellBase } from "#utils/riskMatrix.ts";
+import {
+    createRiskMatrixDesign,
+    addThreatsToRiskMatrix,
+    dayNumberFromDateString,
+    type RiskMatrixCellBase,
+} from "#utils/riskMatrix.ts";
 import { calcRiskColour } from "#utils/calcRisk.ts";
 
 describe("createRiskMatrixDesign", () => {
@@ -267,5 +272,21 @@ describe("addThreatsToRiskMatrix", () => {
             damage: t.damage,
         }));
         result.flat().forEach((cell) => expect(cell.amount).toBeUndefined());
+    });
+});
+
+describe("dayNumberFromDateString", () => {
+    it("maps known dates to their exact UTC day-number", () => {
+        expect(dayNumberFromDateString("1970-01-01")).toBe(0);
+        expect(dayNumberFromDateString("1970-01-11")).toBe(10);
+        expect(dayNumberFromDateString("2026-03-15")).toBe(Math.floor(Date.UTC(2026, 2, 15) / 86_400_000));
+    });
+
+    it("increments by exactly 1 for consecutive days", () => {
+        expect(dayNumberFromDateString("2026-03-16") - dayNumberFromDateString("2026-03-15")).toBe(1);
+    });
+
+    it("orders dates chronologically", () => {
+        expect(dayNumberFromDateString("2025-12-31")).toBeLessThan(dayNumberFromDateString("2026-01-01"));
     });
 });

--- a/apps/frontend/src/utils/riskMatrix.ts
+++ b/apps/frontend/src/utils/riskMatrix.ts
@@ -6,7 +6,8 @@ export interface RiskMatrixCellBase {
     amount?: number;
 }
 
-export const toDayNumber = (date: Date): number => Math.floor(date.getTime() / 1000 / 3600 / 24);
+export const dayNumberFromDateString = (date: string): number =>
+    Math.floor(Date.UTC(+date.slice(0, 4), +date.slice(5, 7) - 1, +date.slice(8, 10)) / 86_400_000);
 
 /**
  * Create empty 5x5 risk-matrix-"design" (only background)

--- a/apps/frontend/src/view/components/measure-timeline.component.tsx
+++ b/apps/frontend/src/view/components/measure-timeline.component.tsx
@@ -69,7 +69,7 @@ const TimeSlider = styled(Slider)(({ theme }) => ({
 
 interface MeasureTimelineProps extends Omit<BoxProps, "onChange"> {
     timeline: TimelineData;
-    onChange: (event: Event, date: Date | null) => void;
+    onChange: (event: Event, date: string | null) => void;
     sx?: SxProps<Theme>;
 }
 

--- a/apps/frontend/src/view/components/report-components/risk-matrix-settings-column.component.test.tsx
+++ b/apps/frontend/src/view/components/report-components/risk-matrix-settings-column.component.test.tsx
@@ -33,8 +33,8 @@ describe("RiskMatrixSettingsColumn", () => {
 
     it("renders one switch per milestone, labelled by its scheduled date", () => {
         const milestones = [
-            createReportMilestone({ scheduledAt: new Date("2025-01-01") }),
-            createReportMilestone({ scheduledAt: new Date("2025-06-15") }),
+            createReportMilestone({ scheduledAt: "2025-01-01" }),
+            createReportMilestone({ scheduledAt: "2025-06-15" }),
         ];
         renderColumn({ milestones });
 
@@ -44,8 +44,8 @@ describe("RiskMatrixSettingsColumn", () => {
 
     it("reflects each milestone's active state", () => {
         const milestones = [
-            createReportMilestone({ scheduledAt: new Date("2025-01-01"), active: true }),
-            createReportMilestone({ scheduledAt: new Date("2025-06-15"), active: false }),
+            createReportMilestone({ scheduledAt: "2025-01-01", active: true }),
+            createReportMilestone({ scheduledAt: "2025-06-15", active: false }),
         ];
         renderColumn({ milestones });
 
@@ -55,7 +55,7 @@ describe("RiskMatrixSettingsColumn", () => {
 
     it("calls onChangeMilestone with the milestone and its new checked value", async () => {
         const onChangeMilestone = vi.fn();
-        const milestone = createReportMilestone({ scheduledAt: new Date("2025-01-01"), active: false });
+        const milestone = createReportMilestone({ scheduledAt: "2025-01-01", active: false });
         renderColumn({ milestones: [milestone], onChangeMilestone });
 
         await userEvent.click(screen.getByLabelText("2025-01-01"));

--- a/apps/frontend/src/view/components/report-components/risk-matrix-settings-column.component.tsx
+++ b/apps/frontend/src/view/components/report-components/risk-matrix-settings-column.component.tsx
@@ -89,7 +89,7 @@ export const RiskMatrixSettingsColumn = ({
                                             onChange={(_, value) => onChangeMilestone(milestone, value)}
                                         />
                                     }
-                                    label={scheduledAt?.toISOString().split("T")[0]}
+                                    label={scheduledAt}
                                     labelPlacement="end"
                                     sx={{
                                         marginRight: 0,

--- a/apps/frontend/src/view/components/threatMeasuresTable.component.tsx
+++ b/apps/frontend/src/view/components/threatMeasuresTable.component.tsx
@@ -218,7 +218,7 @@ const ThreatMeasuresTableRow = ({
                     fontSize: "0.875rem",
                 }}
             >
-                {measureScheduleAt ? measureScheduleAt.toISOString().split("T")[0] : t("notScheduledYet")}
+                {measureScheduleAt ? measureScheduleAt : t("notScheduledYet")}
             </TableCell>
             {setsOutOfScope && (
                 <TableCell

--- a/apps/frontend/src/view/dialogs/add-measure.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-measure.dialog.tsx
@@ -22,7 +22,7 @@ interface FormValues {
     id: number | undefined;
     name: string;
     description: string;
-    scheduledAt: string | Date | null;
+    scheduledAt: string | null;
     catalogMeasureId: number | null;
 }
 

--- a/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/measure-details.dialog.tsx
@@ -74,7 +74,7 @@ const MeasureDetailsDialog = ({ project, measure, initialTab, ...props }: Measur
             id: measure?.id,
             name: measure?.name ?? "",
             description: measure?.description ?? "",
-            scheduledAt: measure?.scheduledAt?.toISOString()?.split("T")[0] ?? null,
+            scheduledAt: measure?.scheduledAt ?? null,
             catalogMeasureId: measure?.catalogMeasureId ?? null,
         },
     });

--- a/apps/frontend/src/view/pages/measures.page.tsx
+++ b/apps/frontend/src/view/pages/measures.page.tsx
@@ -37,7 +37,7 @@ interface MeasuresPageBodyProps {
  */
 type MeasureDialogState = Omit<Partial<Measure>, "id" | "scheduledAt"> & {
     id?: number | undefined;
-    scheduledAt?: Date | undefined;
+    scheduledAt?: string | undefined;
     active?: boolean;
 };
 
@@ -121,13 +121,7 @@ const MeasuresPageBody = ({ project }: MeasuresPageBodyProps) => {
 
     const onClickEditMeasure = (event: React.MouseEvent<HTMLElement>, measure: Measure) => {
         event.preventDefault();
-        const scheduledAt = new Date(
-            measure.scheduledAt.getTime() - measure.scheduledAt.getTimezoneOffset() * 60 * 1000
-        );
-        const measureState: MeasureDialogState = {
-            ...measure,
-            scheduledAt,
-        };
+        const measureState: MeasureDialogState = { ...measure };
         navigate(`/projects/${projectIdParam}/measures/edit`, {
             state: {
                 project,
@@ -378,9 +372,7 @@ const MeasuresPageBody = ({ project }: MeasuresPageBodyProps) => {
                                                                     fontSize: "0.875rem",
                                                                 }}
                                                             >
-                                                                {scheduledAt
-                                                                    ? scheduledAt.toISOString().split("T")[0]
-                                                                    : t("notScheduledYet")}
+                                                                {scheduledAt ? scheduledAt : t("notScheduledYet")}
                                                             </Typography>
                                                         </CustomTableCell>
                                                         <CustomTableCell

--- a/apps/frontend/src/view/pages/measures.page.tsx
+++ b/apps/frontend/src/view/pages/measures.page.tsx
@@ -372,7 +372,7 @@ const MeasuresPageBody = ({ project }: MeasuresPageBodyProps) => {
                                                                     fontSize: "0.875rem",
                                                                 }}
                                                             >
-                                                                {scheduledAt ? scheduledAt : t("notScheduledYet")}
+                                                                {scheduledAt || t("notScheduledYet")}
                                                             </Typography>
                                                         </CustomTableCell>
                                                         <CustomTableCell

--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -208,7 +208,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
     };
 
     const onChangeActiveMilestone = (milestone: ReportMilestone, value: boolean) => {
-        const id = milestone.scheduledAt.toISOString().substring(0, 10);
+        const id = milestone.scheduledAt;
         if (value && !riskMatrixMeasures.includes(id)) {
             setRiskMatrixMeasures([...riskMatrixMeasures, id]);
             setIsChanged(true);

--- a/apps/frontend/src/view/pages/risk.page.tsx
+++ b/apps/frontend/src/view/pages/risk.page.tsx
@@ -121,7 +121,7 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
         setThreatSearchValue(event.target.value);
     };
 
-    const handleChangeTimeline = (_event: unknown, date: Date | null) => {
+    const handleChangeTimeline = (_event: unknown, date: string | null) => {
         setTimelineDate(date);
     };
 
@@ -187,9 +187,7 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
                     ...measure,
                     id: measure.measureId,
                     projectId,
-                    scheduledAt: new Date(
-                        measure.scheduledAt.getTime() - measure.scheduledAt.getTimezoneOffset() * 60 * 1000
-                    ),
+                    scheduledAt: measure.scheduledAt,
                 },
             },
         });
@@ -704,15 +702,6 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
                                                             }
                                                         })
                                                         .map((measure, i) => {
-                                                            measure = {
-                                                                ...measure,
-                                                                scheduledAt: new Date(
-                                                                    measure.scheduledAt.getTime() -
-                                                                        measure.scheduledAt.getTimezoneOffset() *
-                                                                            60 *
-                                                                            1000
-                                                                ),
-                                                            };
                                                             const { name, scheduledAt, active, measureImpact } =
                                                                 measure;
                                                             return (
@@ -803,8 +792,6 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
                                                                         >
                                                                             {scheduledAt
                                                                                 ? scheduledAt
-                                                                                      .toISOString()
-                                                                                      .split("T")[0]
                                                                                 : t("notScheduledYet")}
                                                                         </Typography>
                                                                     </CustomTableCell>

--- a/apps/frontend/src/view/pages/risk.page.tsx
+++ b/apps/frontend/src/view/pages/risk.page.tsx
@@ -790,9 +790,7 @@ const RiskPageBody = ({ project }: RiskPageBodyProps) => {
                                                                                 fontSize: "0.875rem",
                                                                             }}
                                                                         >
-                                                                            {scheduledAt
-                                                                                ? scheduledAt
-                                                                                : t("notScheduledYet")}
+                                                                            {scheduledAt || t("notScheduledYet")}
                                                                         </Typography>
                                                                     </CustomTableCell>
                                                                     <CustomTableCell

--- a/apps/frontend/src/view/report/pages/matrix.report.page.tsx
+++ b/apps/frontend/src/view/report/pages/matrix.report.page.tsx
@@ -100,7 +100,7 @@ export const MatrixPage = ({
                             <Matrix
                                 language={language}
                                 key={i}
-                                title={scheduledAt.toISOString().split("T")[0]}
+                                title={scheduledAt}
                                 data={matrix}
                                 style={{ marginTop: s1 }}
                             />

--- a/apps/frontend/src/view/report/pages/measures.report.page.tsx
+++ b/apps/frontend/src/view/report/pages/measures.report.page.tsx
@@ -10,7 +10,7 @@ import type { IndexCallback, ProjectReport } from "#api/types/project.types.ts";
 import { colors } from "#view/wrappers/color-tokens.ts";
 
 type ReportMeasure = Omit<ProjectReport["measures"][number], "scheduledAt"> & {
-    scheduledAt: string | Date;
+    scheduledAt: string;
     reportId?: string;
 };
 
@@ -86,7 +86,6 @@ export const MeasuresDetailsPage = ({
 };
 
 const MeasureCard = ({ language, reportId, id, name, description, scheduledAt, threats }: MeasureCardProps) => {
-    const scheduledAtDate = typeof scheduledAt === "string" ? new Date(scheduledAt) : new Date(scheduledAt.getTime());
     const fitsOnOnePage = measureCardFitsOnOnePage({ name, description, threats });
     return (
         <View
@@ -135,7 +134,7 @@ const MeasureCard = ({ language, reportId, id, name, description, scheduledAt, t
                         fontStyle: "italic",
                     }}
                 >
-                    {scheduledAtDate.toISOString().split("T")[0]}
+                    {scheduledAt}
                 </Text>
                 <View
                     style={{

--- a/apps/frontend/src/view/report/report-md.test.ts
+++ b/apps/frontend/src/view/report/report-md.test.ts
@@ -281,7 +281,7 @@ describe("generateMarkdownReport – matrix rendering", () => {
 
     it("renders a milestone matrix with the milestone date as title", () => {
         const milestone = {
-            scheduledAt: new Date("2025-06-01"),
+            scheduledAt: "2025-06-01",
             matrix: TEST_MATRIX,
             barGraph: null,
             active: true,

--- a/apps/frontend/src/view/report/report-md.ts
+++ b/apps/frontend/src/view/report/report-md.ts
@@ -11,7 +11,7 @@ import type { Milestone, RiskMatrix } from "#utils/report-risk.ts";
 
 type ThreatReport = ProjectReport["threats"][number];
 type ReportMeasure = Omit<ProjectReport["measures"][number], "scheduledAt"> & {
-    scheduledAt: string | Date;
+    scheduledAt: string;
     reportId?: string;
 };
 type AssetWithReportId = ProjectReport["assets"][number];
@@ -458,8 +458,7 @@ function matrixSection(
     if (activeMilestones && activeMilestones.length > 0) {
         activeMilestones.forEach((milestone) => {
             if (milestone.matrix) {
-                const title = milestone.scheduledAt.toISOString().split("T")[0];
-                lines.push(renderMatrix(T, milestone.matrix, title ?? ""));
+                lines.push(renderMatrix(T, milestone.matrix, milestone.scheduledAt));
                 lines.push("");
             }
         });
@@ -550,11 +549,7 @@ function measuresSection(T: Translations, measures: ReportMeasure[]): string {
         lines.push(`*ID: ${escapeInline(String(measure.id))}*`);
         lines.push("");
 
-        const scheduledAtDate =
-            typeof measure.scheduledAt === "string"
-                ? new Date(measure.scheduledAt)
-                : new Date(measure.scheduledAt.getTime());
-        lines.push(`*${scheduledAtDate.toISOString().split("T")[0]}*`);
+        lines.push(`*${measure.scheduledAt}*`);
         lines.push("");
 
         if (measure.description && measure.description.length > 0) {

--- a/apps/frontend/src/view/report/testData/project-report.fixture.json
+++ b/apps/frontend/src/view/report/testData/project-report.fixture.json
@@ -125,7 +125,7 @@
                     "projectId": 1,
                     "reportId": "M-01",
                     "name": "Input Validation",
-                    "scheduledAt": "2024-06-01T00:00:00.000Z",
+                    "scheduledAt": "2024-06-01",
                     "createdAt": "2024-01-01T00:00:00.000Z",
                     "updatedAt": "2024-01-01T00:00:00.000Z"
                 }
@@ -177,7 +177,7 @@
             "id": 1,
             "name": "Input Validation",
             "description": "Use parameterised queries and input sanitisation to prevent injection attacks.",
-            "scheduledAt": "2024-06-01T00:00:00.000Z",
+            "scheduledAt": "2024-06-01",
             "projectId": 1,
             "catalogMeasureId": null,
             "reportId": "M-01",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Scheduled measure dates are now stored and processed as date-only values (`YYYY-MM-DD`) across the app, including timelines, risk calculations, reports, and sorting.
  * Scheduled date inputs, table displays, and milestone/matrix views now render and compare the date string directly to reduce timezone-related shifts during edit and navigation.
* **Bug Fixes**
  * Strengthened scheduled date validation: timestamps and invalid/out-of-range calendar dates are rejected with `400` responses and validation errors.
* **Tests**
  * Updated unit and E2E test fixtures and assertions to use `YYYY-MM-DD` strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->