### PR TITLE
feat(users): add inactive user detection and optional purge

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -19,3 +19,8 @@ OIDC_ISSUER_URL=<your-oidc-provider-issuer-url>
 OIDC_CLIENT_ID=<your-oidc-provider-client-id>
 OIDC_CLIENT_SECRET=<your-oidc-provider-client-secret>
 OIDC_ALLOW_HTTP=<default=false|true> # Allow insecure HTTP connections to the OIDC provider. Only enable for local development if necessary.
+
+USER_PURGE_ENABLED=<default=true|false> # automatic hard-deletion of long-inactive users
+USER_HIDE_THRESHOLD_DAYS=90 # days of inactivity before a user is hidden from member lists
+USER_PURGE_THRESHOLD_DAYS=365 # days of inactivity before a user is hard-deleted (must be greater than USER_HIDE_THRESHOLD_DAYS)
+USER_PURGE_INTERVAL_HOURS=24 # how often the purge job runs

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -20,7 +20,7 @@ OIDC_CLIENT_ID=<your-oidc-provider-client-id>
 OIDC_CLIENT_SECRET=<your-oidc-provider-client-secret>
 OIDC_ALLOW_HTTP=<default=false|true> # Allow insecure HTTP connections to the OIDC provider. Only enable for local development if necessary.
 
-USER_PURGE_ENABLED=<default=true|false> # automatic hard-deletion of long-inactive users
+USER_PURGE_ENABLED=false # set to "true" to opt in to automatic hard-deletion of long-inactive users (disabled unless exactly "true")
 USER_HIDE_THRESHOLD_DAYS=90 # days of inactivity before a user is hidden from member lists
 USER_PURGE_THRESHOLD_DAYS=365 # days of inactivity before a user is hard-deleted (must be greater than USER_HIDE_THRESHOLD_DAYS)
 USER_PURGE_INTERVAL_HOURS=24 # how often the purge job runs

--- a/apps/backend/drizzle/0006_add-last-login-to-user.sql
+++ b/apps/backend/drizzle/0006_add-last-login-to-user.sql
@@ -1,2 +1,1 @@
 ALTER TABLE "users" ADD COLUMN "last_login_at" timestamp with time zone DEFAULT now() NOT NULL;
-UPDATE "users" SET "last_login_at" = "updatedAt";

--- a/apps/backend/drizzle/0006_add-last-login-to-user.sql
+++ b/apps/backend/drizzle/0006_add-last-login-to-user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "last_login_at" timestamp with time zone DEFAULT now() NOT NULL;
+UPDATE "users" SET "last_login_at" = "updatedAt";

--- a/apps/backend/drizzle/meta/0006_snapshot.json
+++ b/apps/backend/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1783 @@
+{
+  "id": "7454f98f-dd6f-4e77-8829-1b7af394b76e",
+  "prevId": "439fc15d-8efa-484c-ad34-59c9f32a6070",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "assets_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentialityJustification": {
+          "name": "confidentialityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrityJustification": {
+          "name": "integrityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availabilityJustification": {
+          "name": "availabilityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_project_id": {
+          "name": "assets_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_name": {
+          "name": "assets_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_projectId_projects_id_fk": {
+          "name": "assets_projectId_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assets_name_not_empty": {
+          "name": "assets_name_not_empty",
+          "value": "\"assets\".\"name\" <> ''"
+        },
+        "assets_confidentiality_min_max": {
+          "name": "assets_confidentiality_min_max",
+          "value": "\"assets\".\"confidentiality\" between 1 and 5"
+        },
+        "assets_integrity_min_max": {
+          "name": "assets_integrity_min_max",
+          "value": "\"assets\".\"integrity\" between 1 and 5"
+        },
+        "assets_availability_min_max": {
+          "name": "assets_availability_min_max",
+          "value": "\"assets\".\"availability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_measures": {
+      "name": "catalog_measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalog_measures_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_measures_catalog_id": {
+          "name": "catalog_measures_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_name": {
+          "name": "catalog_measures_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_point_of_attack": {
+          "name": "catalog_measures_point_of_attack",
+          "columns": [
+            {
+              "expression": "pointOfAttack",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_attacker": {
+          "name": "catalog_measures_attacker",
+          "columns": [
+            {
+              "expression": "attacker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_measures_catalogId_catalogs_id_fk": {
+          "name": "catalog_measures_catalogId_catalogs_id_fk",
+          "tableFrom": "catalog_measures",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_measures_probability_min_max": {
+          "name": "catalog_measures_probability_min_max",
+          "value": "\"catalog_measures\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_threats": {
+      "name": "catalog_threats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalog_threats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_threats_catalog_id": {
+          "name": "catalog_threats_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_name": {
+          "name": "catalog_threats_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_point_of_attack": {
+          "name": "catalog_threats_point_of_attack",
+          "columns": [
+            {
+              "expression": "pointOfAttack",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_attacker": {
+          "name": "catalog_threats_attacker",
+          "columns": [
+            {
+              "expression": "attacker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_threats_catalogId_catalogs_id_fk": {
+          "name": "catalog_threats_catalogId_catalogs_id_fk",
+          "tableFrom": "catalog_threats",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_threats_probability_min_max": {
+          "name": "catalog_threats_probability_min_max",
+          "value": "\"catalog_threats\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalogs": {
+      "name": "catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalogs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catalogs_name": {
+          "name": "catalogs_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalogs_name_not_empty": {
+          "name": "catalogs_name_not_empty",
+          "value": "\"catalogs\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.component_types": {
+      "name": "component_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "component_types_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointsOfAttack": {
+          "name": "pointsOfAttack",
+          "type": "point_of_attack[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standardIcon": {
+          "name": "standardIcon",
+          "type": "standard_icon",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "component_types_project_id": {
+          "name": "component_types_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "component_types_projectId_projects_id_fk": {
+          "name": "component_types_projectId_projects_id_fk",
+          "tableFrom": "component_types",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "component_types_icon_not_both_set": {
+          "name": "component_types_icon_not_both_set",
+          "value": "not (\"component_types\".\"symbol\" is not null and \"component_types\".\"standardIcon\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.measure_impacts": {
+      "name": "measure_impacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "measure_impacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setsOutOfScope": {
+          "name": "setsOutOfScope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impactsProbability": {
+          "name": "impactsProbability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impactsDamage": {
+          "name": "impactsDamage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage": {
+          "name": "damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "threatId": {
+          "name": "threatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measureId": {
+          "name": "measureId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "measure_impacts_measure_id_threat_id": {
+          "name": "measure_impacts_measure_id_threat_id",
+          "columns": [
+            {
+              "expression": "measureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "measure_impacts_threatId_threats_id_fk": {
+          "name": "measure_impacts_threatId_threats_id_fk",
+          "tableFrom": "measure_impacts",
+          "tableTo": "threats",
+          "columnsFrom": ["threatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "measure_impacts_measureId_measures_id_fk": {
+          "name": "measure_impacts_measureId_measures_id_fk",
+          "tableFrom": "measure_impacts",
+          "tableTo": "measures",
+          "columnsFrom": ["measureId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "measure_impacts_measure_id_threat_id_unique": {
+          "name": "measure_impacts_measure_id_threat_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["measureId", "threatId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "measure_impacts_probability_min_max": {
+          "name": "measure_impacts_probability_min_max",
+          "value": "\"measure_impacts\".\"probability\" between 1 and 5"
+        },
+        "measure_impacts_probability": {
+          "name": "measure_impacts_probability",
+          "value": "\"measure_impacts\".\"impactsProbability\" = false OR \"measure_impacts\".\"probability\" IS NOT NULL"
+        },
+        "measure_impacts_damage_min_max": {
+          "name": "measure_impacts_damage_min_max",
+          "value": "\"measure_impacts\".\"damage\" between 1 and 5"
+        },
+        "measure_impacts_damage": {
+          "name": "measure_impacts_damage",
+          "value": "\"measure_impacts\".\"impactsDamage\" = false OR \"measure_impacts\".\"damage\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.measures": {
+      "name": "measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "measures_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledAt": {
+          "name": "scheduledAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalogMeasureId": {
+          "name": "catalogMeasureId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "measures_catalog_measure_id": {
+          "name": "measures_catalog_measure_id",
+          "columns": [
+            {
+              "expression": "catalogMeasureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "measures_project_id": {
+          "name": "measures_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "measures_catalogMeasureId_catalog_measures_id_fk": {
+          "name": "measures_catalogMeasureId_catalog_measures_id_fk",
+          "tableFrom": "measures",
+          "tableTo": "catalog_measures",
+          "columnsFrom": ["catalogMeasureId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "measures_projectId_projects_id_fk": {
+          "name": "measures_projectId_projects_id_fk",
+          "tableFrom": "measures",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "measures_name_not_empty": {
+          "name": "measures_name_not_empty",
+          "value": "\"measures\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "projects_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentialityLevel": {
+          "name": "confidentialityLevel",
+          "type": "confidentiality_level",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INTERNAL'"
+        },
+        "lineOfToleranceGreen": {
+          "name": "lineOfToleranceGreen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "lineOfToleranceRed": {
+          "name": "lineOfToleranceRed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_catalog_id": {
+          "name": "projects_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name": {
+          "name": "projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_catalogId_catalogs_id_fk": {
+          "name": "projects_catalogId_catalogs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_name_not_empty": {
+          "name": "projects_name_not_empty",
+          "value": "\"projects\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.systems": {
+      "name": "systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "systems_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "systems_projectId_projects_id_fk": {
+          "name": "systems_projectId_projects_id_fk",
+          "tableFrom": "systems",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_id": {
+          "name": "project_id",
+          "nullsNotDistinct": false,
+          "columns": ["projectId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threats": {
+      "name": "threats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "threats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "pointOfAttackId": {
+          "name": "pointOfAttackId",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doneEditing": {
+          "name": "doneEditing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogThreatId": {
+          "name": "catalogThreatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "threats_catalog_threat_id": {
+          "name": "threats_catalog_threat_id",
+          "columns": [
+            {
+              "expression": "catalogThreatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threats_project_id": {
+          "name": "threats_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "threats_catalogThreatId_catalog_threats_id_fk": {
+          "name": "threats_catalogThreatId_catalog_threats_id_fk",
+          "tableFrom": "threats",
+          "tableTo": "catalog_threats",
+          "columnsFrom": ["catalogThreatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "threats_projectId_projects_id_fk": {
+          "name": "threats_projectId_projects_id_fk",
+          "tableFrom": "threats",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "threats_name_not_empty": {
+          "name": "threats_name_not_empty",
+          "value": "\"threats\".\"name\" <> ''"
+        },
+        "threats_probability_min_max": {
+          "name": "threats_probability_min_max",
+          "value": "\"threats\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tokens_token": {
+          "name": "tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastname": {
+          "name": "lastname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email": {
+          "name": "users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_oidc_sub": {
+          "name": "users_oidc_sub",
+          "columns": [
+            {
+              "expression": "oidc_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_catalogs": {
+      "name": "users_catalogs",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_catalogs_catalog_id": {
+          "name": "users_catalogs_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_catalogs_user_id_catalog_id": {
+          "name": "users_catalogs_user_id_catalog_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_catalogs_userId_users_id_fk": {
+          "name": "users_catalogs_userId_users_id_fk",
+          "tableFrom": "users_catalogs",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "users_catalogs_catalogId_catalogs_id_fk": {
+          "name": "users_catalogs_catalogId_catalogs_id_fk",
+          "tableFrom": "users_catalogs",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_projects": {
+      "name": "users_projects",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_projects_project_id": {
+          "name": "users_projects_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_projects_user_id_project_id": {
+          "name": "users_projects_user_id_project_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_projects_userId_users_id_fk": {
+          "name": "users_projects_userId_users_id_fk",
+          "tableFrom": "users_projects",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "users_projects_projectId_projects_id_fk": {
+          "name": "users_projects_projectId_projects_id_fk",
+          "tableFrom": "users_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attacker": {
+      "name": "attacker",
+      "schema": "public",
+      "values": ["ADMINISTRATORS", "APPLICATION_USERS", "SYSTEM_USERS", "UNAUTHORISED_PARTIES"]
+    },
+    "public.confidentiality_level": {
+      "name": "confidentiality_level",
+      "schema": "public",
+      "values": ["PUBLIC", "INTERNAL", "CONFIDENTIAL", "HIGHLY_CONFIDENTIAL"]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": ["EN", "DE"]
+    },
+    "public.point_of_attack": {
+      "name": "point_of_attack",
+      "schema": "public",
+      "values": [
+        "COMMUNICATION_INFRASTRUCTURE",
+        "COMMUNICATION_INTERFACES",
+        "DATA_STORAGE_INFRASTRUCTURE",
+        "PROCESSING_INFRASTRUCTURE",
+        "USER_BEHAVIOUR",
+        "USER_INTERFACE"
+      ]
+    },
+    "public.standard_icon": {
+      "name": "standard_icon",
+      "schema": "public",
+      "values": ["USERS", "CLIENT", "SERVER", "DATABASE"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["OWNER", "EDITOR", "VIEWER"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784216083482,
       "tag": "0005_change_measures_scheduled_at_to_date",
       "breakpoints": false
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1784373856712,
+      "tag": "0006_add-last-login-to-user",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -13,6 +13,18 @@ function getEnvironmentVariable(key: string): string {
     return value;
 }
 
+function getOptionalPositiveNumber(key: string, defaultValue: number): number {
+    const rawValue = process.env[key];
+    if (rawValue === undefined || rawValue === "") {
+        return defaultValue;
+    }
+    const parsedValue = Number(rawValue);
+    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+        throw new Error(`Environment variable ${key} must be a positive number`);
+    }
+    return parsedValue;
+}
+
 export const JWT_SECRET = new TextEncoder().encode(getEnvironmentVariable("JWT_SECRET"));
 export const JWT_ISSUER = "threatsea";
 export const JWT_AUDIENCE = "threatsea-api";
@@ -99,9 +111,21 @@ export const sessionConfig: SessionOptions = {
     rolling: true,
 };
 
+const MAXIMUM_PURGE_INTERVAL_HOURS = 596; // setInterval delays above 2^31 - 1 ms overflow and fire every millisecond
+
 export const userLifecycleConfig = {
-    purgeEnabled: process.env["USER_PURGE_ENABLED"] !== "false",
-    hideThresholdDays: Number(process.env["USER_HIDE_THRESHOLD_DAYS"] ?? "90"),
-    purgeThresholdDays: Number(process.env["USER_PURGE_THRESHOLD_DAYS"] ?? "365"),
-    purgeIntervalHours: Number(process.env["USER_PURGE_INTERVAL_HOURS"] ?? "24"),
+    // Destructive job: opt-in only. It runs solely when explicitly enabled, so any other
+    // value (unset, "0", "off", a typo) fails safe by leaving the purge disabled.
+    purgeEnabled: process.env["USER_PURGE_ENABLED"] === "true",
+    hideThresholdDays: getOptionalPositiveNumber("USER_HIDE_THRESHOLD_DAYS", 90),
+    purgeThresholdDays: getOptionalPositiveNumber("USER_PURGE_THRESHOLD_DAYS", 365),
+    purgeIntervalHours: getOptionalPositiveNumber("USER_PURGE_INTERVAL_HOURS", 24),
 };
+
+if (userLifecycleConfig.purgeIntervalHours > MAXIMUM_PURGE_INTERVAL_HOURS) {
+    throw new Error(`Environment variable USER_PURGE_INTERVAL_HOURS must be at most ${MAXIMUM_PURGE_INTERVAL_HOURS}`);
+}
+
+if (userLifecycleConfig.hideThresholdDays >= userLifecycleConfig.purgeThresholdDays) {
+    throw new Error("Environment variable USER_HIDE_THRESHOLD_DAYS must be smaller than USER_PURGE_THRESHOLD_DAYS");
+}

--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -98,3 +98,10 @@ export const sessionConfig: SessionOptions = {
     saveUninitialized: false,
     rolling: true,
 };
+
+export const userLifecycleConfig = {
+    purgeEnabled: process.env["USER_PURGE_ENABLED"] !== "false",
+    hideThresholdDays: Number(process.env["USER_HIDE_THRESHOLD_DAYS"] ?? "90"),
+    purgeThresholdDays: Number(process.env["USER_PURGE_THRESHOLD_DAYS"] ?? "365"),
+    purgeIntervalHours: Number(process.env["USER_PURGE_INTERVAL_HOURS"] ?? "24"),
+};

--- a/apps/backend/src/controllers/members.controller.ts
+++ b/apps/backend/src/controllers/members.controller.ts
@@ -3,11 +3,11 @@
  *     for the routing of the members.
  */
 import { NextFunction, Request, Response } from "express";
-import { User } from "#db/schema.js";
 import * as MembersService from "#services/members.service.js";
 import {
     isCatalogMember,
     isProjectMember,
+    PublicUser,
     removeCatalogMember,
     removeProjectMember,
     UserWithRole,
@@ -64,12 +64,12 @@ export async function getProjectAddedMembers(
  * @param {Response} response - The http response.
  */
 export async function getCatalogAddableMembers(
-    request: Request<CatalogIdParam, User[], void>,
-    response: Response<User[]>
+    request: Request<CatalogIdParam, PublicUser[], void>,
+    response: Response<PublicUser[]>
 ): Promise<void> {
     const catalogId = request.params.catalogId;
 
-    const addableMembers: User[] = await MembersService.getCatalogAddableMembers(catalogId);
+    const addableMembers: PublicUser[] = await MembersService.getCatalogAddableMembers(catalogId);
 
     response.json(addableMembers);
 }
@@ -81,12 +81,12 @@ export async function getCatalogAddableMembers(
  * @param {Response} response - The http response.
  */
 export async function getProjectAddableMembers(
-    request: Request<ProjectIdParam, User[], void>,
-    response: Response<User[]>
+    request: Request<ProjectIdParam, PublicUser[], void>,
+    response: Response<PublicUser[]>
 ): Promise<void> {
     const projectId = request.params.projectId;
 
-    const addableMembers: User[] = await MembersService.getProjectAddableMembers(projectId);
+    const addableMembers: PublicUser[] = await MembersService.getProjectAddableMembers(projectId);
 
     response.json(addableMembers);
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -372,6 +372,9 @@ export const users = pgTable(
         firstname: varchar({ length: 255 }).notNull(),
         lastname: varchar({ length: 255 }).notNull(),
         email: varchar({ length: 255 }).notNull(),
+        lastLoginAt: timestamp("last_login_at", { mode: "string", withTimezone: true })
+            .notNull()
+            .default(sql`now()`),
         oidcSub: varchar("oidc_sub", { length: 255 }),
         createdAt: timestamp({ mode: "string", withTimezone: true })
             .notNull()

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { app } from "#server.js";
 import { Logger } from "#logging/index.js";
 import { runMigrations } from "#db/index.js";
+import { startInactiveUserPurgeScheduler, stopInactiveUserPurgeScheduler } from "#jobs/purge-inactive-users.job.js";
 
 /**
  * Port of the backend server.
@@ -14,9 +15,11 @@ await runMigrations();
 
 const server = app.listen(PORT, () => {
     Logger.info(`server is running (port=${PORT})...`);
+    void startInactiveUserPurgeScheduler();
 });
 
 process.on("SIGTERM", () => {
+    stopInactiveUserPurgeScheduler();
     server.close(() => {
         process.exit(0);
     });

--- a/apps/backend/src/jobs/purge-inactive-users.job.ts
+++ b/apps/backend/src/jobs/purge-inactive-users.job.ts
@@ -3,7 +3,7 @@
  *     older than the purge threshold, unless they are the sole owner of a
  *     project or catalog.
  */
-import { and, eq, inArray, lte, ne, notExists, sql } from "drizzle-orm";
+import { and, eq, inArray, lte, ne, notExists, notInArray, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { userLifecycleConfig } from "#config/config.js";
 import { db } from "#db/index.js";
@@ -45,7 +45,8 @@ export async function purgeInactiveUsers(
                             and(
                                 eq(otherProjectOwner.projectId, usersProjects.projectId),
                                 eq(otherProjectOwner.role, USER_ROLES.OWNER),
-                                ne(otherProjectOwner.userId, usersProjects.userId)
+                                ne(otherProjectOwner.userId, usersProjects.userId),
+                                notInArray(otherProjectOwner.userId, candidateIds)
                             )
                         )
                 )
@@ -68,7 +69,8 @@ export async function purgeInactiveUsers(
                             and(
                                 eq(otherCatalogOwner.catalogId, usersCatalogs.catalogId),
                                 eq(otherCatalogOwner.role, USER_ROLES.OWNER),
-                                ne(otherCatalogOwner.userId, usersCatalogs.userId)
+                                ne(otherCatalogOwner.userId, usersCatalogs.userId),
+                                notInArray(otherCatalogOwner.userId, candidateIds)
                             )
                         )
                 )

--- a/apps/backend/src/jobs/purge-inactive-users.job.ts
+++ b/apps/backend/src/jobs/purge-inactive-users.job.ts
@@ -3,108 +3,171 @@
  *     older than the purge threshold, unless they are the sole owner of a
  *     project or catalog.
  */
-import { and, eq, inArray, lte, ne, notExists, notInArray, sql } from "drizzle-orm";
-import { alias } from "drizzle-orm/pg-core";
+import { and, eq, gt, lte, ne, notExists, SQL, sql } from "drizzle-orm";
+import { alias, PgColumn } from "drizzle-orm/pg-core";
 import { userLifecycleConfig } from "#config/config.js";
 import { db } from "#db/index.js";
 import { users, usersCatalogs, usersProjects } from "#db/schema.js";
 import { Logger } from "#logging/index.js";
 import { USER_ROLES } from "#types/user-roles.types.js";
 
+type OwnershipAlias =
+    | ReturnType<typeof alias<typeof usersProjects, string>>
+    | ReturnType<typeof alias<typeof usersCatalogs, string>>;
+type UsersAlias = ReturnType<typeof alias<typeof users, string>>;
+
+/**
+ * Builds a `notExists` predicate that holds when the given ownership row has no OTHER
+ * owner of the same entity who survives this purge (i.e. logged in more recently than
+ * the cutoff). One helper collapses the project/catalog × select/delete variants so
+ * the "would this leave the entity ownerless" rule stays provably identical everywhere.
+ */
+function noOtherSurvivingOwner(
+    survivingOwnership: OwnershipAlias,
+    survivingOwner: UsersAlias,
+    entityMatches: SQL,
+    ownerUserId: PgColumn,
+    purgeCutoff: SQL
+): SQL {
+    return notExists(
+        db
+            .select({ survivingOwnerExists: sql`1` })
+            .from(survivingOwnership)
+            .innerJoin(survivingOwner, eq(survivingOwner.id, survivingOwnership.userId))
+            .where(
+                and(
+                    entityMatches,
+                    eq(survivingOwnership.role, USER_ROLES.OWNER),
+                    ne(survivingOwnership.userId, ownerUserId),
+                    gt(survivingOwner.lastLoginAt, purgeCutoff)
+                )
+            )
+    );
+}
+
 export async function purgeInactiveUsers(
     purgeThresholdDays: number = userLifecycleConfig.purgeThresholdDays
 ): Promise<void> {
-    const purgeCutoff = () => sql`now() - (${purgeThresholdDays} * interval '1 day')`;
+    const purgeCutoff = (): SQL => sql`now() - (${purgeThresholdDays} * interval '1 day')`;
 
-    const purgeCandidates = await db
-        .select({ id: users.id, email: users.email })
-        .from(users)
-        .where(lte(users.lastLoginAt, purgeCutoff()));
-
-    if (purgeCandidates.length === 0) {
-        Logger.info("purgeInactiveUsers: deleted 0 users, skipped 0 sole owners");
-        return;
-    }
-
-    const candidateIds = purgeCandidates.map((candidate) => candidate.id);
-    const candidateEmailById = new Map(purgeCandidates.map((candidate) => [candidate.id, candidate.email]));
-
-    const otherProjectOwner = alias(usersProjects, "other_project_owner");
+    // Sole owners that will be kept back are only queried for observability; the DELETE
+    // below re-derives the same protection independently from committed state.
+    const soleProjectOwner = alias(usersProjects, "sole_project_owner");
+    const soleProjectOwnerUser = alias(users, "sole_project_owner_user");
     const soleOwnedProjects = await db
         .select({ userId: usersProjects.userId, projectId: usersProjects.projectId })
         .from(usersProjects)
+        .innerJoin(users, eq(users.id, usersProjects.userId))
         .where(
             and(
-                inArray(usersProjects.userId, candidateIds),
                 eq(usersProjects.role, USER_ROLES.OWNER),
-                notExists(
-                    db
-                        .select({ ownerExists: sql`1` })
-                        .from(otherProjectOwner)
-                        .where(
-                            and(
-                                eq(otherProjectOwner.projectId, usersProjects.projectId),
-                                eq(otherProjectOwner.role, USER_ROLES.OWNER),
-                                ne(otherProjectOwner.userId, usersProjects.userId),
-                                notInArray(otherProjectOwner.userId, candidateIds)
-                            )
-                        )
+                lte(users.lastLoginAt, purgeCutoff()),
+                noOtherSurvivingOwner(
+                    soleProjectOwner,
+                    soleProjectOwnerUser,
+                    eq(soleProjectOwner.projectId, usersProjects.projectId),
+                    usersProjects.userId,
+                    purgeCutoff()
                 )
             )
         );
 
-    const otherCatalogOwner = alias(usersCatalogs, "other_catalog_owner");
+    const soleCatalogOwner = alias(usersCatalogs, "sole_catalog_owner");
+    const soleCatalogOwnerUser = alias(users, "sole_catalog_owner_user");
     const soleOwnedCatalogs = await db
         .select({ userId: usersCatalogs.userId, catalogId: usersCatalogs.catalogId })
         .from(usersCatalogs)
+        .innerJoin(users, eq(users.id, usersCatalogs.userId))
         .where(
             and(
-                inArray(usersCatalogs.userId, candidateIds),
                 eq(usersCatalogs.role, USER_ROLES.OWNER),
-                notExists(
-                    db
-                        .select({ ownerExists: sql`1` })
-                        .from(otherCatalogOwner)
-                        .where(
-                            and(
-                                eq(otherCatalogOwner.catalogId, usersCatalogs.catalogId),
-                                eq(otherCatalogOwner.role, USER_ROLES.OWNER),
-                                ne(otherCatalogOwner.userId, usersCatalogs.userId),
-                                notInArray(otherCatalogOwner.userId, candidateIds)
-                            )
-                        )
+                lte(users.lastLoginAt, purgeCutoff()),
+                noOtherSurvivingOwner(
+                    soleCatalogOwner,
+                    soleCatalogOwnerUser,
+                    eq(soleCatalogOwner.catalogId, usersCatalogs.catalogId),
+                    usersCatalogs.userId,
+                    purgeCutoff()
                 )
             )
         );
 
     for (const soleOwnership of soleOwnedProjects) {
         Logger.warning(
-            `purgeInactiveUsers: skipping user ${candidateEmailById.get(soleOwnership.userId)} (id=${soleOwnership.userId}), sole owner of project ${soleOwnership.projectId}`
+            `purgeInactiveUsers: skipping user id=${soleOwnership.userId}, sole owner of project ${soleOwnership.projectId}`
         );
     }
     for (const soleOwnership of soleOwnedCatalogs) {
         Logger.warning(
-            `purgeInactiveUsers: skipping user ${candidateEmailById.get(soleOwnership.userId)} (id=${soleOwnership.userId}), sole owner of catalog ${soleOwnership.catalogId}`
+            `purgeInactiveUsers: skipping user id=${soleOwnership.userId}, sole owner of catalog ${soleOwnership.catalogId}`
         );
     }
 
-    const blockedUserIds = new Set([
+    const skippedSoleOwnerIds = new Set([
         ...soleOwnedProjects.map((soleOwnership) => soleOwnership.userId),
         ...soleOwnedCatalogs.map((soleOwnership) => soleOwnership.userId),
     ]);
-    const deletableUserIds = candidateIds.filter((candidateId) => !blockedUserIds.has(candidateId));
 
-    let deletedCount = 0;
-    if (deletableUserIds.length > 0) {
-        // Re-check the cutoff so a login between candidate selection and deletion is respected.
-        const deletedUsers = await db
-            .delete(users)
-            .where(and(inArray(users.id, deletableUserIds), lte(users.lastLoginAt, purgeCutoff())))
-            .returning({ id: users.id });
-        deletedCount = deletedUsers.length;
-    }
+    // Delete every user past the cutoff who is not the last surviving owner of any project
+    // or catalog. Last-login and ownership are re-evaluated here, so a login or ownership
+    // change since the queries above is still respected. Users are matched by predicate
+    // rather than a bound ID array, so the statement stays within Postgres's parameter
+    // limit no matter how many users are inactive.
+    const projectOwnership = alias(usersProjects, "project_ownership");
+    const deleteProjectSurvivor = alias(usersProjects, "delete_project_survivor");
+    const deleteProjectSurvivorUser = alias(users, "delete_project_survivor_user");
+    const catalogOwnership = alias(usersCatalogs, "catalog_ownership");
+    const deleteCatalogSurvivor = alias(usersCatalogs, "delete_catalog_survivor");
+    const deleteCatalogSurvivorUser = alias(users, "delete_catalog_survivor_user");
 
-    Logger.info(`purgeInactiveUsers: deleted ${deletedCount} users, skipped ${blockedUserIds.size} sole owners`);
+    const deletedUsers = await db
+        .delete(users)
+        .where(
+            and(
+                lte(users.lastLoginAt, purgeCutoff()),
+                notExists(
+                    db
+                        .select({ ownershipExists: sql`1` })
+                        .from(projectOwnership)
+                        .where(
+                            and(
+                                eq(projectOwnership.userId, users.id),
+                                eq(projectOwnership.role, USER_ROLES.OWNER),
+                                noOtherSurvivingOwner(
+                                    deleteProjectSurvivor,
+                                    deleteProjectSurvivorUser,
+                                    eq(deleteProjectSurvivor.projectId, projectOwnership.projectId),
+                                    projectOwnership.userId,
+                                    purgeCutoff()
+                                )
+                            )
+                        )
+                ),
+                notExists(
+                    db
+                        .select({ ownershipExists: sql`1` })
+                        .from(catalogOwnership)
+                        .where(
+                            and(
+                                eq(catalogOwnership.userId, users.id),
+                                eq(catalogOwnership.role, USER_ROLES.OWNER),
+                                noOtherSurvivingOwner(
+                                    deleteCatalogSurvivor,
+                                    deleteCatalogSurvivorUser,
+                                    eq(deleteCatalogSurvivor.catalogId, catalogOwnership.catalogId),
+                                    catalogOwnership.userId,
+                                    purgeCutoff()
+                                )
+                            )
+                        )
+                )
+            )
+        )
+        .returning({ id: users.id });
+
+    Logger.info(
+        `purgeInactiveUsers: deleted ${deletedUsers.length} users, skipped ${skippedSoleOwnerIds.size} sole owners`
+    );
 }
 
 let purgeIntervalHandle: NodeJS.Timeout | undefined;

--- a/apps/backend/src/jobs/purge-inactive-users.job.ts
+++ b/apps/backend/src/jobs/purge-inactive-users.job.ts
@@ -106,3 +106,47 @@ export async function purgeInactiveUsers(
 
     Logger.info(`purgeInactiveUsers: deleted ${deletedCount} users, skipped ${blockedUserIds.size} sole owners`);
 }
+
+let purgeIntervalHandle: NodeJS.Timeout | undefined;
+
+export function startInactiveUserPurgeScheduler(
+    lifecycleConfig: typeof userLifecycleConfig = userLifecycleConfig
+): Promise<void> {
+    if (purgeIntervalHandle !== undefined) {
+        Logger.warning("purgeInactiveUsers: scheduler already running; ignoring duplicate start");
+        return Promise.resolve();
+    }
+    if (!lifecycleConfig.purgeEnabled) {
+        Logger.info("purgeInactiveUsers: scheduler disabled via USER_PURGE_ENABLED");
+        return Promise.resolve();
+    }
+    if (lifecycleConfig.hideThresholdDays >= lifecycleConfig.purgeThresholdDays) {
+        Logger.error(
+            `purgeInactiveUsers: invalid configuration, USER_HIDE_THRESHOLD_DAYS (${lifecycleConfig.hideThresholdDays}) must be smaller than USER_PURGE_THRESHOLD_DAYS (${lifecycleConfig.purgeThresholdDays}); purge scheduler not started`
+        );
+        return Promise.resolve();
+    }
+
+    purgeIntervalHandle = setInterval(
+        () => void runPurgeSafely(lifecycleConfig.purgeThresholdDays),
+        lifecycleConfig.purgeIntervalHours * 60 * 60 * 1000
+    );
+    // Don't let the recurring purge keep the process alive on its own.
+    purgeIntervalHandle.unref();
+    return runPurgeSafely(lifecycleConfig.purgeThresholdDays);
+}
+
+export function stopInactiveUserPurgeScheduler(): void {
+    if (purgeIntervalHandle !== undefined) {
+        clearInterval(purgeIntervalHandle);
+        purgeIntervalHandle = undefined;
+    }
+}
+
+async function runPurgeSafely(purgeThresholdDays: number): Promise<void> {
+    try {
+        await purgeInactiveUsers(purgeThresholdDays);
+    } catch (error) {
+        Logger.error(`purgeInactiveUsers: run failed: ${String(error)}`);
+    }
+}

--- a/apps/backend/src/jobs/purge-inactive-users.job.ts
+++ b/apps/backend/src/jobs/purge-inactive-users.job.ts
@@ -1,0 +1,106 @@
+/**
+ * @module purge-inactive-users.job - Hard-deletes users whose last login is
+ *     older than the purge threshold, unless they are the sole owner of a
+ *     project or catalog.
+ */
+import { and, eq, inArray, lte, ne, notExists, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import { userLifecycleConfig } from "#config/config.js";
+import { db } from "#db/index.js";
+import { users, usersCatalogs, usersProjects } from "#db/schema.js";
+import { Logger } from "#logging/index.js";
+import { USER_ROLES } from "#types/user-roles.types.js";
+
+export async function purgeInactiveUsers(
+    purgeThresholdDays: number = userLifecycleConfig.purgeThresholdDays
+): Promise<void> {
+    const purgeCutoff = () => sql`now() - (${purgeThresholdDays} * interval '1 day')`;
+
+    const purgeCandidates = await db
+        .select({ id: users.id, email: users.email })
+        .from(users)
+        .where(lte(users.lastLoginAt, purgeCutoff()));
+
+    if (purgeCandidates.length === 0) {
+        Logger.info("purgeInactiveUsers: deleted 0 users, skipped 0 sole owners");
+        return;
+    }
+
+    const candidateIds = purgeCandidates.map((candidate) => candidate.id);
+    const candidateEmailById = new Map(purgeCandidates.map((candidate) => [candidate.id, candidate.email]));
+
+    const otherProjectOwner = alias(usersProjects, "other_project_owner");
+    const soleOwnedProjects = await db
+        .select({ userId: usersProjects.userId, projectId: usersProjects.projectId })
+        .from(usersProjects)
+        .where(
+            and(
+                inArray(usersProjects.userId, candidateIds),
+                eq(usersProjects.role, USER_ROLES.OWNER),
+                notExists(
+                    db
+                        .select({ ownerExists: sql`1` })
+                        .from(otherProjectOwner)
+                        .where(
+                            and(
+                                eq(otherProjectOwner.projectId, usersProjects.projectId),
+                                eq(otherProjectOwner.role, USER_ROLES.OWNER),
+                                ne(otherProjectOwner.userId, usersProjects.userId)
+                            )
+                        )
+                )
+            )
+        );
+
+    const otherCatalogOwner = alias(usersCatalogs, "other_catalog_owner");
+    const soleOwnedCatalogs = await db
+        .select({ userId: usersCatalogs.userId, catalogId: usersCatalogs.catalogId })
+        .from(usersCatalogs)
+        .where(
+            and(
+                inArray(usersCatalogs.userId, candidateIds),
+                eq(usersCatalogs.role, USER_ROLES.OWNER),
+                notExists(
+                    db
+                        .select({ ownerExists: sql`1` })
+                        .from(otherCatalogOwner)
+                        .where(
+                            and(
+                                eq(otherCatalogOwner.catalogId, usersCatalogs.catalogId),
+                                eq(otherCatalogOwner.role, USER_ROLES.OWNER),
+                                ne(otherCatalogOwner.userId, usersCatalogs.userId)
+                            )
+                        )
+                )
+            )
+        );
+
+    for (const soleOwnership of soleOwnedProjects) {
+        Logger.warning(
+            `purgeInactiveUsers: skipping user ${candidateEmailById.get(soleOwnership.userId)} (id=${soleOwnership.userId}), sole owner of project ${soleOwnership.projectId}`
+        );
+    }
+    for (const soleOwnership of soleOwnedCatalogs) {
+        Logger.warning(
+            `purgeInactiveUsers: skipping user ${candidateEmailById.get(soleOwnership.userId)} (id=${soleOwnership.userId}), sole owner of catalog ${soleOwnership.catalogId}`
+        );
+    }
+
+    const blockedUserIds = new Set([
+        ...soleOwnedProjects.map((soleOwnership) => soleOwnership.userId),
+        ...soleOwnedCatalogs.map((soleOwnership) => soleOwnership.userId),
+    ]);
+    const deletableUserIds = candidateIds.filter((candidateId) => !blockedUserIds.has(candidateId));
+
+    let deletedCount = 0;
+    if (deletableUserIds.length > 0) {
+        // Re-check the cutoff so a login between candidate selection and deletion is respected.
+        const deletedUsers = await db
+            .delete(users)
+            .where(and(inArray(users.id, deletableUserIds), lte(users.lastLoginAt, purgeCutoff())))
+            .returning({ id: users.id });
+        deletedCount = deletedUsers.length;
+    }
+
+    Logger.info(`purgeInactiveUsers: deleted ${deletedCount} users, skipped ${blockedUserIds.size} sole owners`);
+}

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -51,12 +51,25 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
         }
 
         if (user) {
-            // Update profile if name has changed
-            if (user.firstname !== firstName || user.lastname !== lastName || user.email !== email) {
-                await tx
-                    .update(users)
-                    .set({ firstname: firstName, lastname: lastName, email: email, updatedAt: sql`now()` })
-                    .where(eq(users.id, user.id));
+            const profileChanged = user.firstname !== firstName || user.lastname !== lastName || user.email !== email;
+
+            // Fold the last-login refresh into the profile write so a login is at most one
+            // UPDATE. lastLoginAt on its own must not bump updatedAt.
+            const touchedRows = await tx
+                .update(users)
+                .set({
+                    lastLoginAt: sql`now()`,
+                    ...(profileChanged
+                        ? { firstname: firstName, lastname: lastName, email: email, updatedAt: sql`now()` }
+                        : {}),
+                })
+                .where(eq(users.id, user.id))
+                .returning({ id: users.id });
+
+            // A concurrent purge may have deleted this user between the lookup above and this
+            // UPDATE; if the row is gone we must not mint a token for an account that no longer exists.
+            if (touchedRows.length === 0) {
+                throw new UnauthorizedError("User no longer exists");
             }
             return user;
         }

--- a/apps/backend/src/services/members.service.ts
+++ b/apps/backend/src/services/members.service.ts
@@ -2,13 +2,34 @@
  * @module members.service - Defines services for the controlling
  *     functions of the members
  */
-import { and, eq, getTableColumns, isNull, not } from "drizzle-orm";
+import { and, eq, gt, isNull, not, sql } from "drizzle-orm";
 import { db, TransactionType } from "#db/index.js";
-import { projects, User, users, usersCatalogs, usersProjects } from "#db/schema.js";
+import { projects, users, usersCatalogs, usersProjects } from "#db/schema.js";
 import { checkRole } from "#guards/authorisation.guard.js";
 import { USER_ROLES } from "#types/user-roles.types.js";
+import { userLifecycleConfig } from "#config/config.js";
 
-export type UserWithRole = User & { role: USER_ROLES };
+// Only non-sensitive identity fields are exposed via member endpoints; lastLoginAt,
+// oidcSub, createdAt and updatedAt must never leak to other users.
+const publicUserColumns = {
+    id: users.id,
+    firstname: users.firstname,
+    lastname: users.lastname,
+    email: users.email,
+} as const;
+
+export interface PublicUser {
+    id: number;
+    firstname: string;
+    lastname: string;
+    email: string;
+}
+
+export type UserWithRole = PublicUser & { role: USER_ROLES };
+
+// live = logged in within the hide window; long-inactive users are only filtered out of the
+// addable-member picker, never from the added-member lists (they stay visible and manageable).
+const liveUsers = gt(users.lastLoginAt, sql`now() - (${userLifecycleConfig.hideThresholdDays} * interval '1 day')`);
 
 /**
  * Gets all members of a given project.
@@ -18,7 +39,7 @@ export type UserWithRole = User & { role: USER_ROLES };
  */
 export async function getProjectAddedMembers(projectId: number): Promise<UserWithRole[]> {
     return await db
-        .select({ ...getTableColumns(users), role: usersProjects.role })
+        .select({ ...publicUserColumns, role: usersProjects.role })
         .from(users)
         .innerJoin(usersProjects, eq(users.id, usersProjects.userId))
         .where(eq(usersProjects.projectId, projectId));
@@ -32,7 +53,7 @@ export async function getProjectAddedMembers(projectId: number): Promise<UserWit
  */
 export async function getCatalogAddedMembers(catalogId: number): Promise<UserWithRole[]> {
     return await db
-        .select({ ...getTableColumns(users), role: usersCatalogs.role })
+        .select({ ...publicUserColumns, role: usersCatalogs.role })
         .from(users)
         .innerJoin(usersCatalogs, eq(users.id, usersCatalogs.userId))
         .where(eq(usersCatalogs.catalogId, catalogId));
@@ -44,12 +65,12 @@ export async function getCatalogAddedMembers(catalogId: number): Promise<UserWit
  * @param {number} projectId - The id of the project.
  * @return {Promise<User[]>} A promise that resolves to an array of users that can be added to the project.
  */
-export async function getProjectAddableMembers(projectId: number): Promise<User[]> {
+export async function getProjectAddableMembers(projectId: number): Promise<PublicUser[]> {
     return await db
-        .select({ ...getTableColumns(users) })
+        .select(publicUserColumns)
         .from(users)
         .leftJoin(usersProjects, and(eq(users.id, usersProjects.userId), eq(usersProjects.projectId, projectId)))
-        .where(isNull(usersProjects.userId));
+        .where(and(isNull(usersProjects.userId), liveUsers));
 }
 
 /**
@@ -58,12 +79,12 @@ export async function getProjectAddableMembers(projectId: number): Promise<User[
  * @param {number} catalogId - The id of the catalog.
  * @return {Promise<User[]>} A promise that resolves to an array of users that can be added to the catalog.
  */
-export async function getCatalogAddableMembers(catalogId: number): Promise<User[]> {
+export async function getCatalogAddableMembers(catalogId: number): Promise<PublicUser[]> {
     return await db
-        .select({ ...getTableColumns(users) })
+        .select(publicUserColumns)
         .from(users)
         .leftJoin(usersCatalogs, and(eq(users.id, usersCatalogs.userId), eq(usersCatalogs.catalogId, catalogId)))
-        .where(isNull(usersCatalogs.userId));
+        .where(and(isNull(usersCatalogs.userId), liveUsers));
 }
 
 /**

--- a/apps/backend/src/types/member.types.ts
+++ b/apps/backend/src/types/member.types.ts
@@ -39,6 +39,7 @@ export interface UserResponse {
     firstname: string;
     lastname: string;
     email: string;
+    lastLoginAt: string;
     oidcSub: string | null;
     createdAt: string;
     updatedAt: string;

--- a/apps/backend/src/types/member.types.ts
+++ b/apps/backend/src/types/member.types.ts
@@ -39,10 +39,6 @@ export interface UserResponse {
     firstname: string;
     lastname: string;
     email: string;
-    lastLoginAt: string;
-    oidcSub: string | null;
-    createdAt: string;
-    updatedAt: string;
 }
 
 export interface MemberResponse extends UserResponse {

--- a/apps/backend/tests/inactive-member-filtering.test.ts
+++ b/apps/backend/tests/inactive-member-filtering.test.ts
@@ -1,0 +1,102 @@
+/// <reference types="vitest/globals" />
+/**
+ * Module that defines tests for hiding inactive users from member reads.
+ */
+import { sql } from "drizzle-orm";
+import { db } from "#db/index.js";
+import { catalogs, projects, users, usersCatalogs, usersProjects } from "#db/schema.js";
+import {
+    getCatalogAddableMembers,
+    getCatalogAddedMembers,
+    getProjectAddableMembers,
+    getProjectAddedMembers,
+} from "#services/members.service.js";
+import { LANGUAGES } from "#types/languages.type.js";
+import { USER_ROLES } from "#types/user-roles.types.js";
+
+async function insertTestUser(email: string, daysSinceLastLogin?: number): Promise<number> {
+    const insertedUser = (
+        await db
+            .insert(users)
+            .values({
+                firstname: "Filter",
+                lastname: "Test",
+                email: email,
+                ...(daysSinceLastLogin === undefined
+                    ? {}
+                    : { lastLoginAt: sql`now() - (${daysSinceLastLogin} * interval '1 day')` }),
+            })
+            .returning({ id: users.id })
+    ).at(0)!;
+    return insertedUser.id;
+}
+
+let catalogId: number;
+let projectId: number;
+let activeMemberId: number;
+let inactiveMemberId: number;
+let activePoolUserId: number;
+let inactivePoolUserId: number;
+let boundaryPoolUserId: number;
+
+beforeAll(async () => {
+    catalogId = (
+        await db.insert(catalogs).values({ name: "filter-test-catalog", language: LANGUAGES.EN }).returning()
+    ).at(0)!.id;
+    projectId = (
+        await db
+            .insert(projects)
+            .values({ name: "filter-test-project", description: "filter test", catalogId: catalogId })
+            .returning()
+    ).at(0)!.id;
+
+    activeMemberId = await insertTestUser("filter-active-member@threatsea.test");
+    inactiveMemberId = await insertTestUser("filter-inactive-member@threatsea.test", 100);
+    activePoolUserId = await insertTestUser("filter-active-pool@threatsea.test");
+    inactivePoolUserId = await insertTestUser("filter-inactive-pool@threatsea.test", 100);
+    boundaryPoolUserId = await insertTestUser("filter-boundary-pool@threatsea.test", 90);
+
+    await db.insert(usersProjects).values([
+        { projectId: projectId, userId: activeMemberId, role: USER_ROLES.OWNER },
+        { projectId: projectId, userId: inactiveMemberId, role: USER_ROLES.EDITOR },
+    ]);
+    await db.insert(usersCatalogs).values([
+        { catalogId: catalogId, userId: activeMemberId, role: USER_ROLES.OWNER },
+        { catalogId: catalogId, userId: inactiveMemberId, role: USER_ROLES.EDITOR },
+    ]);
+});
+
+describe("member list (added members)", () => {
+    it("keeps inactive project members visible alongside active ones", async () => {
+        const memberIds = (await getProjectAddedMembers(projectId)).map((member) => member.id);
+        expect(memberIds).toContain(activeMemberId);
+        expect(memberIds).toContain(inactiveMemberId);
+    });
+
+    it("keeps inactive catalog members visible alongside active ones", async () => {
+        const memberIds = (await getCatalogAddedMembers(catalogId)).map((member) => member.id);
+        expect(memberIds).toContain(activeMemberId);
+        expect(memberIds).toContain(inactiveMemberId);
+    });
+});
+
+describe("member picker filtering (addable members)", () => {
+    it("offers active non-members and hides inactive ones for projects", async () => {
+        const addableIds = (await getProjectAddableMembers(projectId)).map((addableUser) => addableUser.id);
+        expect(addableIds).toContain(activePoolUserId);
+        expect(addableIds).not.toContain(inactivePoolUserId);
+        expect(addableIds).not.toContain(activeMemberId);
+    });
+
+    it("offers active non-members and hides inactive ones for catalogs", async () => {
+        const addableIds = (await getCatalogAddableMembers(catalogId)).map((addableUser) => addableUser.id);
+        expect(addableIds).toContain(activePoolUserId);
+        expect(addableIds).not.toContain(inactivePoolUserId);
+        expect(addableIds).not.toContain(activeMemberId);
+    });
+
+    it("hides a user exactly at the hide threshold (boundary is inclusive)", async () => {
+        const addableIds = (await getProjectAddableMembers(projectId)).map((addableUser) => addableUser.id);
+        expect(addableIds).not.toContain(boundaryPoolUserId);
+    });
+});

--- a/apps/backend/tests/last-login.test.ts
+++ b/apps/backend/tests/last-login.test.ts
@@ -1,0 +1,116 @@
+/// <reference types="vitest/globals" />
+/**
+ * Module that defines tests for last-login tracking on login.
+ */
+import { and, eq, gt, sql } from "drizzle-orm";
+import { db } from "#db/index.js";
+import { users } from "#db/schema.js";
+import { buildThreatSeaAccessToken } from "#services/auth.service.js";
+
+async function findUserWithRecentLogin(userId: number) {
+    return await db.query.users.findFirst({
+        where: and(eq(users.id, userId), gt(users.lastLoginAt, sql`now() - interval '1 minute'`)),
+    });
+}
+
+async function makeUserStale(userId: number): Promise<void> {
+    await db
+        .update(users)
+        .set({ lastLoginAt: sql`now() - interval '100 days'` })
+        .where(eq(users.id, userId));
+}
+
+describe("last login tracking", () => {
+    it("sets lastLoginAt on first login (insert path)", async () => {
+        await buildThreatSeaAccessToken({
+            sub: "last-login-insert-sub",
+            email: "last-login-insert@threatsea.test",
+            firstName: "Insert",
+            lastName: "Path",
+        });
+
+        const createdUser = await db.query.users.findFirst({
+            where: eq(users.oidcSub, "last-login-insert-sub"),
+        });
+        expect(createdUser).toBeDefined();
+        const recentUser = await findUserWithRecentLogin(createdUser!.id);
+        expect(recentUser?.email).toBe("last-login-insert@threatsea.test");
+    });
+
+    it("refreshes lastLoginAt on login when the profile is unchanged", async () => {
+        const profile = {
+            sub: "last-login-unchanged-sub",
+            email: "last-login-unchanged@threatsea.test",
+            firstName: "Unchanged",
+            lastName: "Path",
+        };
+        await buildThreatSeaAccessToken(profile);
+        const existingUser = (await db.query.users.findFirst({ where: eq(users.oidcSub, profile.sub) }))!;
+        await makeUserStale(existingUser.id);
+
+        await buildThreatSeaAccessToken(profile);
+
+        const refreshedUser = await findUserWithRecentLogin(existingUser.id);
+        expect(refreshedUser?.id).toBe(existingUser.id);
+    });
+
+    it("does not bump updatedAt when only the login timestamp is refreshed", async () => {
+        const profile = {
+            sub: "last-login-noupdate-sub",
+            email: "last-login-noupdate@threatsea.test",
+            firstName: "No",
+            lastName: "Update",
+        };
+        await buildThreatSeaAccessToken(profile);
+        const beforeUser = (await db.query.users.findFirst({ where: eq(users.oidcSub, profile.sub) }))!;
+
+        await buildThreatSeaAccessToken(profile);
+
+        const afterUser = (await db.query.users.findFirst({ where: eq(users.oidcSub, profile.sub) }))!;
+        expect(afterUser.updatedAt).toBe(beforeUser.updatedAt);
+        expect(new Date(afterUser.lastLoginAt).getTime()).toBeGreaterThanOrEqual(
+            new Date(beforeUser.lastLoginAt).getTime()
+        );
+    });
+
+    it("refreshes lastLoginAt on login when the profile changed", async () => {
+        const profile = {
+            sub: "last-login-renamed-sub",
+            email: "last-login-renamed@threatsea.test",
+            firstName: "Original",
+            lastName: "Name",
+        };
+        await buildThreatSeaAccessToken(profile);
+        const existingUser = (await db.query.users.findFirst({ where: eq(users.oidcSub, profile.sub) }))!;
+        await makeUserStale(existingUser.id);
+
+        await buildThreatSeaAccessToken({ ...profile, lastName: "Renamed" });
+
+        const refreshedUser = await findUserWithRecentLogin(existingUser.id);
+        expect(refreshedUser?.lastname).toBe("Renamed");
+    });
+
+    it("refreshes lastLoginAt when linking an existing email-only user to an OIDC sub", async () => {
+        const insertedUser = (
+            await db
+                .insert(users)
+                .values({
+                    firstname: "Link",
+                    lastname: "Path",
+                    email: "last-login-link@threatsea.test",
+                    lastLoginAt: sql`now() - interval '100 days'`,
+                })
+                .returning()
+        ).at(0)!;
+
+        await buildThreatSeaAccessToken({
+            sub: "last-login-link-sub",
+            email: "last-login-link@threatsea.test",
+            firstName: "Link",
+            lastName: "Path",
+        });
+
+        const linkedUser = await findUserWithRecentLogin(insertedUser.id);
+        expect(linkedUser?.oidcSub).toBe("last-login-link-sub");
+    });
+});

--- a/apps/backend/tests/members.test.ts
+++ b/apps/backend/tests/members.test.ts
@@ -86,6 +86,9 @@ describe("get or add members", () => {
             .set("Cookie", cookies);
         expect(res.statusCode).toEqual(200);
         expect(Array.isArray(res.body)).toBe(true);
+        for (const member of res.body) {
+            expect(Object.keys(member).sort()).toEqual(["email", "firstname", "id", "lastname", "role"]);
+        }
     });
 
     it("should list all addable members", async () => {
@@ -96,6 +99,10 @@ describe("get or add members", () => {
             .set("Cookie", cookies);
         expect(res.statusCode).toEqual(200);
         expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.length).toBeGreaterThan(0);
+        for (const addableUser of res.body) {
+            expect(Object.keys(addableUser).sort()).toEqual(["email", "firstname", "id", "lastname"]);
+        }
     });
 
     it("should add an addable member", async () => {

--- a/apps/backend/tests/purge-inactive-users.test.ts
+++ b/apps/backend/tests/purge-inactive-users.test.ts
@@ -94,8 +94,7 @@ describe("purgeInactiveUsers", () => {
         const warningMessages = warningSpy.mock.calls.flat();
         expect(
             warningMessages.some(
-                (message) =>
-                    message.includes("purge-sole-project@threatsea.test") && message.includes(`project ${projectId}`)
+                (message) => message.includes(zombieSoleOwnerId.toString()) && message.includes(`project ${projectId}`)
             )
         ).toBe(true);
     });
@@ -114,8 +113,7 @@ describe("purgeInactiveUsers", () => {
         const warningMessages = warningSpy.mock.calls.flat();
         expect(
             warningMessages.some(
-                (message) =>
-                    message.includes("purge-sole-catalog@threatsea.test") && message.includes(`catalog ${catalogId}`)
+                (message) => message.includes(zombieSoleOwnerId.toString()) && message.includes(`catalog ${catalogId}`)
             )
         ).toBe(true);
     });

--- a/apps/backend/tests/purge-inactive-users.test.ts
+++ b/apps/backend/tests/purge-inactive-users.test.ts
@@ -6,7 +6,11 @@
 import { eq, sql } from "drizzle-orm";
 import { db } from "#db/index.js";
 import { catalogs, projects, users, usersCatalogs, usersProjects } from "#db/schema.js";
-import { purgeInactiveUsers } from "#jobs/purge-inactive-users.job.js";
+import {
+    purgeInactiveUsers,
+    startInactiveUserPurgeScheduler,
+    stopInactiveUserPurgeScheduler,
+} from "#jobs/purge-inactive-users.job.js";
 import { Logger } from "#logging/index.js";
 import { LANGUAGES } from "#types/languages.type.js";
 import { USER_ROLES } from "#types/user-roles.types.js";
@@ -175,6 +179,17 @@ describe("purgeInactiveUsers", () => {
         expect(await userExists(secondZombieOwnerId)).toBe(true);
     });
 
+    it("deletes many unrelated inactive users in a single run", async () => {
+        const inactiveUserIds = await Promise.all(
+            Array.from({ length: 40 }, (_unused, index) => insertTestUser(`purge-bulk-${index}@threatsea.test`, 400))
+        );
+
+        await purgeInactiveUsers();
+
+        const survivors = await Promise.all(inactiveUserIds.map((userId) => userExists(userId)));
+        expect(survivors.every((exists) => exists === false)).toBe(true);
+    });
+
     it("respects a custom purge threshold", async () => {
         const oldUserId = await insertTestUser("purge-custom-old@threatsea.test", 250);
         const recentUserId = await insertTestUser("purge-custom-recent@threatsea.test", 150);
@@ -183,5 +198,55 @@ describe("purgeInactiveUsers", () => {
 
         expect(await userExists(oldUserId)).toBe(false);
         expect(await userExists(recentUserId)).toBe(true);
+    });
+});
+
+describe("startInactiveUserPurgeScheduler", () => {
+    const validLifecycleConfig = {
+        purgeEnabled: true,
+        hideThresholdDays: 90,
+        purgeThresholdDays: 365,
+        purgeIntervalHours: 24,
+    };
+
+    afterEach(() => {
+        stopInactiveUserPurgeScheduler();
+    });
+
+    it("runs a purge immediately when enabled", async () => {
+        const zombieUserId = await insertTestUser("scheduler-enabled-zombie@threatsea.test", 400);
+
+        await startInactiveUserPurgeScheduler(validLifecycleConfig);
+
+        expect(await userExists(zombieUserId)).toBe(false);
+    });
+
+    it("does not purge when disabled", async () => {
+        const zombieUserId = await insertTestUser("scheduler-disabled-zombie@threatsea.test", 400);
+
+        await startInactiveUserPurgeScheduler({ ...validLifecycleConfig, purgeEnabled: false });
+
+        expect(await userExists(zombieUserId)).toBe(true);
+    });
+
+    it("ignores a duplicate start so a second interval is not leaked", async () => {
+        const warningSpy = vi.spyOn(Logger, "warning");
+
+        await startInactiveUserPurgeScheduler(validLifecycleConfig);
+        await startInactiveUserPurgeScheduler(validLifecycleConfig);
+
+        const warningMessages = warningSpy.mock.calls.flat();
+        expect(warningMessages.some((message) => message.includes("already running"))).toBe(true);
+    });
+
+    it("logs an error and refuses to start when the hide threshold is not below the purge threshold", async () => {
+        const errorSpy = vi.spyOn(Logger, "error");
+        const zombieUserId = await insertTestUser("scheduler-invalid-zombie@threatsea.test", 400);
+
+        await startInactiveUserPurgeScheduler({ ...validLifecycleConfig, hideThresholdDays: 400 });
+
+        expect(await userExists(zombieUserId)).toBe(true);
+        const errorMessages = errorSpy.mock.calls.flat();
+        expect(errorMessages.some((message) => message.includes("USER_HIDE_THRESHOLD_DAYS"))).toBe(true);
     });
 });

--- a/apps/backend/tests/purge-inactive-users.test.ts
+++ b/apps/backend/tests/purge-inactive-users.test.ts
@@ -1,0 +1,156 @@
+/// <reference types="vitest/globals" />
+
+/**
+ * Module that defines tests for the inactive-user purge job.
+ */
+import { eq, sql } from "drizzle-orm";
+import { db } from "#db/index.js";
+import { catalogs, projects, users, usersCatalogs, usersProjects } from "#db/schema.js";
+import { purgeInactiveUsers } from "#jobs/purge-inactive-users.job.js";
+import { Logger } from "#logging/index.js";
+import { LANGUAGES } from "#types/languages.type.js";
+import { USER_ROLES } from "#types/user-roles.types.js";
+
+async function insertTestUser(email: string, daysSinceLastLogin?: number): Promise<number> {
+    const insertedUser = (
+        await db
+            .insert(users)
+            .values({
+                firstname: "Purge",
+                lastname: "Test",
+                email: email,
+                ...(daysSinceLastLogin === undefined
+                    ? {}
+                    : { lastLoginAt: sql`now() - (${daysSinceLastLogin} * interval '1 day')` }),
+            })
+            .returning({ id: users.id })
+    ).at(0)!;
+    return insertedUser.id;
+}
+
+async function insertTestCatalog(name: string): Promise<number> {
+    return (await db.insert(catalogs).values({ name: name, language: LANGUAGES.EN }).returning()).at(0)!.id;
+}
+
+async function insertTestProject(name: string, catalogId: number): Promise<number> {
+    return (
+        await db.insert(projects).values({ name: name, description: "purge test", catalogId: catalogId }).returning()
+    ).at(0)!.id;
+}
+
+async function userExists(userId: number): Promise<boolean> {
+    return (await db.query.users.findFirst({ where: eq(users.id, userId) })) !== undefined;
+}
+
+describe("purgeInactiveUsers", () => {
+    it("deletes an inactive co-owner and cascades membership rows", async () => {
+        const activeOwnerId = await insertTestUser("purge-happy-active@threatsea.test");
+        const zombieCoOwnerId = await insertTestUser("purge-happy-zombie@threatsea.test", 400);
+        const catalogId = await insertTestCatalog("purge-happy-catalog");
+        const projectId = await insertTestProject("purge-happy-project", catalogId);
+        await db.insert(usersProjects).values([
+            { projectId: projectId, userId: activeOwnerId, role: USER_ROLES.OWNER },
+            { projectId: projectId, userId: zombieCoOwnerId, role: USER_ROLES.OWNER },
+        ]);
+        await db.insert(usersCatalogs).values([
+            { catalogId: catalogId, userId: activeOwnerId, role: USER_ROLES.OWNER },
+            { catalogId: catalogId, userId: zombieCoOwnerId, role: USER_ROLES.VIEWER },
+        ]);
+
+        await purgeInactiveUsers();
+
+        expect(await userExists(zombieCoOwnerId)).toBe(false);
+        expect(await userExists(activeOwnerId)).toBe(true);
+        const zombieProjectMembership = await db.query.usersProjects.findFirst({
+            where: eq(usersProjects.userId, zombieCoOwnerId),
+        });
+        expect(zombieProjectMembership).toBeUndefined();
+        const zombieCatalogMembership = await db.query.usersCatalogs.findFirst({
+            where: eq(usersCatalogs.userId, zombieCoOwnerId),
+        });
+        expect(zombieCatalogMembership).toBeUndefined();
+        const activeOwnerMembership = await db.query.usersProjects.findFirst({
+            where: eq(usersProjects.userId, activeOwnerId),
+        });
+        expect(activeOwnerMembership?.role).toBe(USER_ROLES.OWNER);
+    });
+
+    it("skips an inactive sole project owner and logs a warning", async () => {
+        const warningSpy = vi.spyOn(Logger, "warning");
+        const zombieSoleOwnerId = await insertTestUser("purge-sole-project@threatsea.test", 400);
+        const catalogId = await insertTestCatalog("purge-sole-project-catalog");
+        const projectId = await insertTestProject("purge-sole-project-project", catalogId);
+        await db
+            .insert(usersProjects)
+            .values({ projectId: projectId, userId: zombieSoleOwnerId, role: USER_ROLES.OWNER });
+
+        await purgeInactiveUsers();
+
+        expect(await userExists(zombieSoleOwnerId)).toBe(true);
+        const warningMessages = warningSpy.mock.calls.flat();
+        expect(
+            warningMessages.some(
+                (message) =>
+                    message.includes("purge-sole-project@threatsea.test") && message.includes(`project ${projectId}`)
+            )
+        ).toBe(true);
+    });
+
+    it("skips an inactive sole catalog owner and logs a warning", async () => {
+        const warningSpy = vi.spyOn(Logger, "warning");
+        const zombieSoleOwnerId = await insertTestUser("purge-sole-catalog@threatsea.test", 400);
+        const catalogId = await insertTestCatalog("purge-sole-catalog-catalog");
+        await db
+            .insert(usersCatalogs)
+            .values({ catalogId: catalogId, userId: zombieSoleOwnerId, role: USER_ROLES.OWNER });
+
+        await purgeInactiveUsers();
+
+        expect(await userExists(zombieSoleOwnerId)).toBe(true);
+        const warningMessages = warningSpy.mock.calls.flat();
+        expect(
+            warningMessages.some(
+                (message) =>
+                    message.includes("purge-sole-catalog@threatsea.test") && message.includes(`catalog ${catalogId}`)
+            )
+        ).toBe(true);
+    });
+
+    it("keeps only the sole owner when every member of a project is inactive", async () => {
+        const zombieSoleOwnerId = await insertTestUser("purge-all-zombie-owner@threatsea.test", 400);
+        const zombieEditorId = await insertTestUser("purge-all-zombie-editor@threatsea.test", 400);
+        const catalogId = await insertTestCatalog("purge-all-zombie-catalog");
+        const projectId = await insertTestProject("purge-all-zombie-project", catalogId);
+        await db.insert(usersProjects).values([
+            { projectId: projectId, userId: zombieSoleOwnerId, role: USER_ROLES.OWNER },
+            { projectId: projectId, userId: zombieEditorId, role: USER_ROLES.EDITOR },
+        ]);
+
+        await purgeInactiveUsers();
+
+        expect(await userExists(zombieSoleOwnerId)).toBe(true);
+        expect(await userExists(zombieEditorId)).toBe(false);
+        const remainingOwnerMembership = await db.query.usersProjects.findFirst({
+            where: eq(usersProjects.userId, zombieSoleOwnerId),
+        });
+        expect(remainingOwnerMembership?.role).toBe(USER_ROLES.OWNER);
+    });
+
+    it("treats a user exactly at the purge threshold as a candidate (boundary is inclusive)", async () => {
+        const boundaryUserId = await insertTestUser("purge-boundary@threatsea.test", 365);
+
+        await purgeInactiveUsers();
+
+        expect(await userExists(boundaryUserId)).toBe(false);
+    });
+
+    it("respects a custom purge threshold", async () => {
+        const oldUserId = await insertTestUser("purge-custom-old@threatsea.test", 250);
+        const recentUserId = await insertTestUser("purge-custom-recent@threatsea.test", 150);
+
+        await purgeInactiveUsers(200);
+
+        expect(await userExists(oldUserId)).toBe(false);
+        expect(await userExists(recentUserId)).toBe(true);
+    });
+});

--- a/apps/backend/tests/purge-inactive-users.test.ts
+++ b/apps/backend/tests/purge-inactive-users.test.ts
@@ -144,6 +144,37 @@ describe("purgeInactiveUsers", () => {
         expect(await userExists(boundaryUserId)).toBe(false);
     });
 
+    it("keeps both owners when a project's only two owners are both inactive", async () => {
+        const firstZombieOwnerId = await insertTestUser("purge-costale-project-first@threatsea.test", 400);
+        const secondZombieOwnerId = await insertTestUser("purge-costale-project-second@threatsea.test", 400);
+        const catalogId = await insertTestCatalog("purge-costale-project-catalog");
+        const projectId = await insertTestProject("purge-costale-project-project", catalogId);
+        await db.insert(usersProjects).values([
+            { projectId: projectId, userId: firstZombieOwnerId, role: USER_ROLES.OWNER },
+            { projectId: projectId, userId: secondZombieOwnerId, role: USER_ROLES.OWNER },
+        ]);
+
+        await purgeInactiveUsers();
+
+        expect(await userExists(firstZombieOwnerId)).toBe(true);
+        expect(await userExists(secondZombieOwnerId)).toBe(true);
+    });
+
+    it("keeps both owners when a catalog's only two owners are both inactive", async () => {
+        const firstZombieOwnerId = await insertTestUser("purge-costale-catalog-first@threatsea.test", 400);
+        const secondZombieOwnerId = await insertTestUser("purge-costale-catalog-second@threatsea.test", 400);
+        const catalogId = await insertTestCatalog("purge-costale-catalog-catalog");
+        await db.insert(usersCatalogs).values([
+            { catalogId: catalogId, userId: firstZombieOwnerId, role: USER_ROLES.OWNER },
+            { catalogId: catalogId, userId: secondZombieOwnerId, role: USER_ROLES.OWNER },
+        ]);
+
+        await purgeInactiveUsers();
+
+        expect(await userExists(firstZombieOwnerId)).toBe(true);
+        expect(await userExists(secondZombieOwnerId)).toBe(true);
+    });
+
     it("respects a custom purge threshold", async () => {
         const oldUserId = await insertTestUser("purge-custom-old@threatsea.test", 250);
         const recentUserId = await insertTestUser("purge-custom-recent@threatsea.test", 150);

--- a/apps/backend/tests/user-lifecycle-config.test.ts
+++ b/apps/backend/tests/user-lifecycle-config.test.ts
@@ -1,0 +1,90 @@
+/// <reference types="vitest/globals" />
+
+/**
+ * Module that defines tests for the user lifecycle environment variable validation
+ * in #config/config.js. Because that module is a module-level singleton, each test
+ * stubs env vars, resets the module registry, and re-imports it fresh.
+ */
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+});
+
+async function importUserLifecycleConfig(): Promise<typeof import("#config/config.js").userLifecycleConfig> {
+    vi.resetModules();
+    const configModule = await import("#config/config.js");
+    return configModule.userLifecycleConfig;
+}
+
+describe("userLifecycleConfig", () => {
+    it("uses defaults when the lifecycle env vars are unset", async () => {
+        vi.stubEnv("USER_PURGE_ENABLED", undefined);
+        vi.stubEnv("USER_HIDE_THRESHOLD_DAYS", undefined);
+        vi.stubEnv("USER_PURGE_THRESHOLD_DAYS", undefined);
+        vi.stubEnv("USER_PURGE_INTERVAL_HOURS", undefined);
+
+        const userLifecycleConfig = await importUserLifecycleConfig();
+
+        expect(userLifecycleConfig).toEqual({
+            purgeEnabled: false,
+            hideThresholdDays: 90,
+            purgeThresholdDays: 365,
+            purgeIntervalHours: 24,
+        });
+    });
+
+    it("respects valid custom values", async () => {
+        vi.stubEnv("USER_PURGE_ENABLED", "true");
+        vi.stubEnv("USER_HIDE_THRESHOLD_DAYS", "30");
+        vi.stubEnv("USER_PURGE_THRESHOLD_DAYS", "180");
+        vi.stubEnv("USER_PURGE_INTERVAL_HOURS", "12");
+
+        const userLifecycleConfig = await importUserLifecycleConfig();
+
+        expect(userLifecycleConfig).toEqual({
+            purgeEnabled: true,
+            hideThresholdDays: 30,
+            purgeThresholdDays: 180,
+            purgeIntervalHours: 12,
+        });
+    });
+
+    it("throws with the variable name when USER_HIDE_THRESHOLD_DAYS is non-numeric", async () => {
+        vi.stubEnv("USER_HIDE_THRESHOLD_DAYS", "abc");
+
+        await expect(importUserLifecycleConfig()).rejects.toThrow("USER_HIDE_THRESHOLD_DAYS");
+    });
+
+    it("throws when USER_PURGE_THRESHOLD_DAYS is negative", async () => {
+        vi.stubEnv("USER_PURGE_THRESHOLD_DAYS", "-1");
+
+        await expect(importUserLifecycleConfig()).rejects.toThrow("USER_PURGE_THRESHOLD_DAYS");
+    });
+
+    it("throws when USER_PURGE_INTERVAL_HOURS is zero", async () => {
+        vi.stubEnv("USER_PURGE_INTERVAL_HOURS", "0");
+
+        await expect(importUserLifecycleConfig()).rejects.toThrow("USER_PURGE_INTERVAL_HOURS");
+    });
+
+    it("throws when USER_PURGE_INTERVAL_HOURS exceeds the setInterval overflow limit", async () => {
+        vi.stubEnv("USER_PURGE_INTERVAL_HOURS", "597");
+
+        await expect(importUserLifecycleConfig()).rejects.toThrow("USER_PURGE_INTERVAL_HOURS");
+    });
+
+    it("throws when USER_HIDE_THRESHOLD_DAYS is not below USER_PURGE_THRESHOLD_DAYS", async () => {
+        vi.stubEnv("USER_HIDE_THRESHOLD_DAYS", "400");
+        vi.stubEnv("USER_PURGE_THRESHOLD_DAYS", "365");
+
+        await expect(importUserLifecycleConfig()).rejects.toThrow("USER_HIDE_THRESHOLD_DAYS");
+    });
+
+    it("leaves purgeEnabled false for any value other than 'true'", async () => {
+        vi.stubEnv("USER_PURGE_ENABLED", "1");
+
+        const userLifecycleConfig = await importUserLifecycleConfig();
+
+        expect(userLifecycleConfig.purgeEnabled).toBe(false);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable inactive-user lifecycle management, including hiding inactive users from member pickers and scheduled hard purging of eligible accounts.
  * Added preservation logic to avoid removing the last surviving sole owner for projects and catalogs.
  * Added `lastLoginAt` tracking refreshed on successful sign-ins.
  * Limited member/addable-member responses to non-sensitive identity fields plus role.
  * Added optional OIDC HTTP allowance configuration.
* **Bug Fixes**
  * Prevented token issuance when a user is deleted concurrently during sign-in.
* **Tests**
  * Added coverage for last-login tracking, inactive-member filtering, purge behavior + scheduler, and lifecycle configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->