### PR TITLE
feat(editor): preselect a default communication-interface icon

### DIFF
--- a/apps/frontend/src/view/dialogs/add-communication-interface.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/add-communication-interface.dialog.test.tsx
@@ -28,10 +28,10 @@ describe("CommunicationInterfaceDialog — default interface icon (#860)", () =>
         vi.clearAllMocks();
     });
 
-    it("preselects a default icon so a new interface shows one without opening the picker", () => {
+    it("preselects a default icon so a new interface shows one without opening the picker", async () => {
         setup();
 
-        expect(screen.getByTestId("DeviceHubIcon")).toBeInTheDocument();
+        expect(await screen.findByTestId("DeviceHubIcon")).toBeInTheDocument();
     });
 
     it("stores the default icon on save when the user never opens the icon picker", async () => {

--- a/apps/frontend/src/view/dialogs/add-communication-interface.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/add-communication-interface.dialog.test.tsx
@@ -1,0 +1,58 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CommunicationInterfaceDialog from "./add-communication-interface.dialog";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { createCommunicationInterface } from "#test-utils/builders.ts";
+import { mockUseDialog } from "#test-utils/mock-hooks.ts";
+import type { SystemCommunicationInterface } from "#api/types/system.types.ts";
+
+mockUseDialog();
+
+const setup = (propsOverride: { communicationInterface?: SystemCommunicationInterface } = {}) => {
+    const handleCreateNew = vi.fn();
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+        <CommunicationInterfaceDialog
+            open={true}
+            onClose={onClose}
+            handleCreateNew={handleCreateNew}
+            {...propsOverride}
+        />
+    );
+    return { handleCreateNew, onClose, user };
+};
+
+describe("CommunicationInterfaceDialog — default interface icon (#860)", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("preselects a default icon so a new interface shows one without opening the picker", () => {
+        setup();
+
+        expect(screen.getByTestId("DeviceHubIcon")).toBeInTheDocument();
+    });
+
+    it("stores the default icon on save when the user never opens the icon picker", async () => {
+        const { handleCreateNew, user } = setup();
+
+        await user.type(screen.getByRole("textbox"), "Ethernet port");
+        await user.click(screen.getByRole("button", { name: /save/i }));
+
+        await waitFor(() => expect(handleCreateNew).toHaveBeenCalledOnce());
+        expect(handleCreateNew).toHaveBeenCalledWith(
+            expect.objectContaining({ name: "Ethernet port", icon: "DeviceHub" })
+        );
+    });
+
+    it("keeps the existing icon instead of the default when editing an interface", async () => {
+        const communicationInterface = createCommunicationInterface({ name: "Existing", icon: "Wifi" });
+        const { handleCreateNew, user } = setup({ communicationInterface });
+
+        await user.click(screen.getByRole("button", { name: /save/i }));
+
+        await waitFor(() => expect(handleCreateNew).toHaveBeenCalledOnce());
+        expect(handleCreateNew).toHaveBeenCalledWith(expect.objectContaining({ icon: "Wifi" }));
+    });
+});

--- a/apps/frontend/src/view/dialogs/add-communication-interface.dialog.tsx
+++ b/apps/frontend/src/view/dialogs/add-communication-interface.dialog.tsx
@@ -16,6 +16,8 @@ interface FormValues {
     icon: string;
 }
 
+const DEFAULT_COMMUNICATION_INTERFACE_ICON = "DeviceHub";
+
 interface CommunicationInterfaceFormValues
     extends FormValues, Omit<SystemCommunicationInterface, keyof FormValues>, DialogValue {}
 
@@ -48,11 +50,13 @@ const CommunicationInterfaceDialog = ({
         defaultValues: {
             ...communicationInterface,
             name: communicationInterface?.name ?? "",
-            icon: communicationInterface?.icon ?? "",
+            icon: communicationInterface?.icon ?? DEFAULT_COMMUNICATION_INTERFACE_ICON,
         },
     });
 
-    const [selectedIcon, setSelectedIcon] = useState(communicationInterface?.icon || "");
+    const [selectedIcon, setSelectedIcon] = useState(
+        communicationInterface?.icon || DEFAULT_COMMUNICATION_INTERFACE_ICON
+    );
 
     const handleCancelDialog = () => {
         cancelDialog();


### PR DESCRIPTION
## Summary
  Resolves #860

  - New communication interfaces now come with a default icon (`DeviceHub`) preselected, so an interface can be created without ever opening the icon picker.
  - The default lives in the form state, so it is actually stored on save — not just shown.
  
  ## Screenshots
<img width="315" height="276" alt="Screenshot 2026-07-21 at 15 11 10" src="https://github.com/user-attachments/assets/bdcb3fa8-c3b3-474d-98d0-6ab9470215fe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New communication interfaces now automatically show a default icon.
  * Saving a new interface preserves the default icon when no custom icon is chosen.
  * Editing an existing interface preserves its current icon.
* **Tests**
  * Added UI coverage to verify default-icon behavior for new and edited communication interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->