### PR TITLE
fix(auth): hardening OIDC and session handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Monorepo composed of a React frontend (the threat-model editor) and an Express b
 ```text
 apps/
   frontend/           React 19 + TypeScript app (Vite, react-konva canvas editor)
-  backend/            Express 5 + TypeScript API (Drizzle ORM, PostgreSQL, socket.io)
+  backend/            Express 5 + TypeScript API (Drizzle ORM, PostgreSQL)
 packages/
   typescript-config/  Shared tsconfig presets
 gh-pages/             Published documentation sources (rendered via mkdocs; see mkdocs.yml)
@@ -51,7 +51,7 @@ utils/           Utility functions
 
 ### Backend structure (`apps/backend/src/`)
 
-Express routers, Drizzle schema/migrations under `apps/backend/drizzle/`, openid-client for auth, socket.io for real-time editor sync.
+Express routers, Drizzle schema/migrations under `apps/backend/drizzle/`, openid-client for auth.
 
 ---
 
@@ -61,7 +61,7 @@ Express routers, Drizzle schema/migrations under `apps/backend/drizzle/`, openid
 | --------------- | -------------------------------------------------------------------------------------------------------- |
 | Package manager | pnpm workspaces + Turborepo                                                                              |
 | Frontend        | React 19, TypeScript, Vite 8, MUI v9, Redux Toolkit, react-konva, react-hook-form, i18next, react-router |
-| Backend         | Express 5, TypeScript, Drizzle ORM, PostgreSQL (`pg`), openid-client, socket.io                          |
+| Backend         | Express 5, TypeScript, Drizzle ORM, PostgreSQL (`pg`), openid-client                                     |
 | Lint / Format   | oxlint, oxfmt                                                                                            |
 | Tests           | Vitest (unit), Playwright (E2E, frontend only)                                                           |
 | Git hooks       | husky + lint-staged                                                                                      |

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -19,6 +19,8 @@ OIDC_ISSUER_URL=<your-oidc-provider-issuer-url>
 OIDC_CLIENT_ID=<your-oidc-provider-client-id>
 OIDC_CLIENT_SECRET=<your-oidc-provider-client-secret>
 OIDC_ALLOW_HTTP=<default=false|true> # Allow insecure HTTP connections to the OIDC provider. Only enable for local development if necessary.
+OIDC_SCOPE=<default=openid profile email> # Space-separated OIDC scopes to request; must include "openid".
+OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING=<default=false|true> # Allow linking an OIDC login to an existing account when the IdP does not assert a verified email. Weakens account-takeover protection; only enable if you trust the IdP.
 
 USER_PURGE_ENABLED=false # set to "true" to opt in to automatic hard-deletion of long-inactive users (disabled unless exactly "true")
 USER_HIDE_THRESHOLD_DAYS=90 # days of inactivity before a user is hidden from member lists

--- a/apps/backend/drizzle/0007_add_session_table.sql
+++ b/apps/backend/drizzle/0007_add_session_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "session" (
+	"sid" varchar PRIMARY KEY NOT NULL,
+	"sess" json NOT NULL,
+	"expire" timestamp (6) NOT NULL
+);
+
+CREATE INDEX "IDX_session_expire" ON "session" USING btree ("expire");

--- a/apps/backend/drizzle/0008_add_profile_synced_at_to_user.sql
+++ b/apps/backend/drizzle/0008_add_profile_synced_at_to_user.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "profile_synced_at" timestamp with time zone;

--- a/apps/backend/drizzle/meta/0007_snapshot.json
+++ b/apps/backend/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1830 @@
+{
+  "id": "054cbfc7-5682-4ad6-81ef-03edaefc8ed7",
+  "prevId": "7454f98f-dd6f-4e77-8829-1b7af394b76e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "assets_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentialityJustification": {
+          "name": "confidentialityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrityJustification": {
+          "name": "integrityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availabilityJustification": {
+          "name": "availabilityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_project_id": {
+          "name": "assets_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_name": {
+          "name": "assets_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_projectId_projects_id_fk": {
+          "name": "assets_projectId_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assets_name_not_empty": {
+          "name": "assets_name_not_empty",
+          "value": "\"assets\".\"name\" <> ''"
+        },
+        "assets_confidentiality_min_max": {
+          "name": "assets_confidentiality_min_max",
+          "value": "\"assets\".\"confidentiality\" between 1 and 5"
+        },
+        "assets_integrity_min_max": {
+          "name": "assets_integrity_min_max",
+          "value": "\"assets\".\"integrity\" between 1 and 5"
+        },
+        "assets_availability_min_max": {
+          "name": "assets_availability_min_max",
+          "value": "\"assets\".\"availability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_measures": {
+      "name": "catalog_measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalog_measures_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_measures_catalog_id": {
+          "name": "catalog_measures_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_name": {
+          "name": "catalog_measures_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_point_of_attack": {
+          "name": "catalog_measures_point_of_attack",
+          "columns": [
+            {
+              "expression": "pointOfAttack",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_attacker": {
+          "name": "catalog_measures_attacker",
+          "columns": [
+            {
+              "expression": "attacker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_measures_catalogId_catalogs_id_fk": {
+          "name": "catalog_measures_catalogId_catalogs_id_fk",
+          "tableFrom": "catalog_measures",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_measures_probability_min_max": {
+          "name": "catalog_measures_probability_min_max",
+          "value": "\"catalog_measures\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_threats": {
+      "name": "catalog_threats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalog_threats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_threats_catalog_id": {
+          "name": "catalog_threats_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_name": {
+          "name": "catalog_threats_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_point_of_attack": {
+          "name": "catalog_threats_point_of_attack",
+          "columns": [
+            {
+              "expression": "pointOfAttack",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_attacker": {
+          "name": "catalog_threats_attacker",
+          "columns": [
+            {
+              "expression": "attacker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_threats_catalogId_catalogs_id_fk": {
+          "name": "catalog_threats_catalogId_catalogs_id_fk",
+          "tableFrom": "catalog_threats",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_threats_probability_min_max": {
+          "name": "catalog_threats_probability_min_max",
+          "value": "\"catalog_threats\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalogs": {
+      "name": "catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalogs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catalogs_name": {
+          "name": "catalogs_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalogs_name_not_empty": {
+          "name": "catalogs_name_not_empty",
+          "value": "\"catalogs\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.component_types": {
+      "name": "component_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "component_types_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointsOfAttack": {
+          "name": "pointsOfAttack",
+          "type": "point_of_attack[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standardIcon": {
+          "name": "standardIcon",
+          "type": "standard_icon",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "component_types_project_id": {
+          "name": "component_types_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "component_types_projectId_projects_id_fk": {
+          "name": "component_types_projectId_projects_id_fk",
+          "tableFrom": "component_types",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "component_types_icon_not_both_set": {
+          "name": "component_types_icon_not_both_set",
+          "value": "not (\"component_types\".\"symbol\" is not null and \"component_types\".\"standardIcon\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.measure_impacts": {
+      "name": "measure_impacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "measure_impacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setsOutOfScope": {
+          "name": "setsOutOfScope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impactsProbability": {
+          "name": "impactsProbability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impactsDamage": {
+          "name": "impactsDamage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage": {
+          "name": "damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "threatId": {
+          "name": "threatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measureId": {
+          "name": "measureId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "measure_impacts_measure_id_threat_id": {
+          "name": "measure_impacts_measure_id_threat_id",
+          "columns": [
+            {
+              "expression": "measureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "measure_impacts_threatId_threats_id_fk": {
+          "name": "measure_impacts_threatId_threats_id_fk",
+          "tableFrom": "measure_impacts",
+          "tableTo": "threats",
+          "columnsFrom": ["threatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "measure_impacts_measureId_measures_id_fk": {
+          "name": "measure_impacts_measureId_measures_id_fk",
+          "tableFrom": "measure_impacts",
+          "tableTo": "measures",
+          "columnsFrom": ["measureId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "measure_impacts_measure_id_threat_id_unique": {
+          "name": "measure_impacts_measure_id_threat_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["measureId", "threatId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "measure_impacts_probability_min_max": {
+          "name": "measure_impacts_probability_min_max",
+          "value": "\"measure_impacts\".\"probability\" between 1 and 5"
+        },
+        "measure_impacts_probability": {
+          "name": "measure_impacts_probability",
+          "value": "\"measure_impacts\".\"impactsProbability\" = false OR \"measure_impacts\".\"probability\" IS NOT NULL"
+        },
+        "measure_impacts_damage_min_max": {
+          "name": "measure_impacts_damage_min_max",
+          "value": "\"measure_impacts\".\"damage\" between 1 and 5"
+        },
+        "measure_impacts_damage": {
+          "name": "measure_impacts_damage",
+          "value": "\"measure_impacts\".\"impactsDamage\" = false OR \"measure_impacts\".\"damage\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.measures": {
+      "name": "measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "measures_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledAt": {
+          "name": "scheduledAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalogMeasureId": {
+          "name": "catalogMeasureId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "measures_catalog_measure_id": {
+          "name": "measures_catalog_measure_id",
+          "columns": [
+            {
+              "expression": "catalogMeasureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "measures_project_id": {
+          "name": "measures_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "measures_catalogMeasureId_catalog_measures_id_fk": {
+          "name": "measures_catalogMeasureId_catalog_measures_id_fk",
+          "tableFrom": "measures",
+          "tableTo": "catalog_measures",
+          "columnsFrom": ["catalogMeasureId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "measures_projectId_projects_id_fk": {
+          "name": "measures_projectId_projects_id_fk",
+          "tableFrom": "measures",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "measures_name_not_empty": {
+          "name": "measures_name_not_empty",
+          "value": "\"measures\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "projects_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentialityLevel": {
+          "name": "confidentialityLevel",
+          "type": "confidentiality_level",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INTERNAL'"
+        },
+        "lineOfToleranceGreen": {
+          "name": "lineOfToleranceGreen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "lineOfToleranceRed": {
+          "name": "lineOfToleranceRed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_catalog_id": {
+          "name": "projects_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name": {
+          "name": "projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_catalogId_catalogs_id_fk": {
+          "name": "projects_catalogId_catalogs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_name_not_empty": {
+          "name": "projects_name_not_empty",
+          "value": "\"projects\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_session_expire": {
+          "name": "IDX_session_expire",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.systems": {
+      "name": "systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "systems_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "systems_projectId_projects_id_fk": {
+          "name": "systems_projectId_projects_id_fk",
+          "tableFrom": "systems",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_id": {
+          "name": "project_id",
+          "nullsNotDistinct": false,
+          "columns": ["projectId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threats": {
+      "name": "threats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "threats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "pointOfAttackId": {
+          "name": "pointOfAttackId",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doneEditing": {
+          "name": "doneEditing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogThreatId": {
+          "name": "catalogThreatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "threats_catalog_threat_id": {
+          "name": "threats_catalog_threat_id",
+          "columns": [
+            {
+              "expression": "catalogThreatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threats_project_id": {
+          "name": "threats_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "threats_catalogThreatId_catalog_threats_id_fk": {
+          "name": "threats_catalogThreatId_catalog_threats_id_fk",
+          "tableFrom": "threats",
+          "tableTo": "catalog_threats",
+          "columnsFrom": ["catalogThreatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "threats_projectId_projects_id_fk": {
+          "name": "threats_projectId_projects_id_fk",
+          "tableFrom": "threats",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "threats_name_not_empty": {
+          "name": "threats_name_not_empty",
+          "value": "\"threats\".\"name\" <> ''"
+        },
+        "threats_probability_min_max": {
+          "name": "threats_probability_min_max",
+          "value": "\"threats\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tokens_token": {
+          "name": "tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastname": {
+          "name": "lastname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email": {
+          "name": "users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_oidc_sub": {
+          "name": "users_oidc_sub",
+          "columns": [
+            {
+              "expression": "oidc_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_catalogs": {
+      "name": "users_catalogs",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_catalogs_catalog_id": {
+          "name": "users_catalogs_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_catalogs_user_id_catalog_id": {
+          "name": "users_catalogs_user_id_catalog_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_catalogs_userId_users_id_fk": {
+          "name": "users_catalogs_userId_users_id_fk",
+          "tableFrom": "users_catalogs",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "users_catalogs_catalogId_catalogs_id_fk": {
+          "name": "users_catalogs_catalogId_catalogs_id_fk",
+          "tableFrom": "users_catalogs",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_projects": {
+      "name": "users_projects",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_projects_project_id": {
+          "name": "users_projects_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_projects_user_id_project_id": {
+          "name": "users_projects_user_id_project_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_projects_userId_users_id_fk": {
+          "name": "users_projects_userId_users_id_fk",
+          "tableFrom": "users_projects",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "users_projects_projectId_projects_id_fk": {
+          "name": "users_projects_projectId_projects_id_fk",
+          "tableFrom": "users_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attacker": {
+      "name": "attacker",
+      "schema": "public",
+      "values": ["ADMINISTRATORS", "APPLICATION_USERS", "SYSTEM_USERS", "UNAUTHORISED_PARTIES"]
+    },
+    "public.confidentiality_level": {
+      "name": "confidentiality_level",
+      "schema": "public",
+      "values": ["PUBLIC", "INTERNAL", "CONFIDENTIAL", "HIGHLY_CONFIDENTIAL"]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": ["EN", "DE"]
+    },
+    "public.point_of_attack": {
+      "name": "point_of_attack",
+      "schema": "public",
+      "values": [
+        "COMMUNICATION_INFRASTRUCTURE",
+        "COMMUNICATION_INTERFACES",
+        "DATA_STORAGE_INFRASTRUCTURE",
+        "PROCESSING_INFRASTRUCTURE",
+        "USER_BEHAVIOUR",
+        "USER_INTERFACE"
+      ]
+    },
+    "public.standard_icon": {
+      "name": "standard_icon",
+      "schema": "public",
+      "values": ["USERS", "CLIENT", "SERVER", "DATABASE"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["OWNER", "EDITOR", "VIEWER"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/0008_snapshot.json
+++ b/apps/backend/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1836 @@
+{
+  "id": "3988f0a9-8b6c-4de9-810d-596323837267",
+  "prevId": "054cbfc7-5682-4ad6-81ef-03edaefc8ed7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "assets_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentialityJustification": {
+          "name": "confidentialityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrityJustification": {
+          "name": "integrityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availabilityJustification": {
+          "name": "availabilityJustification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_project_id": {
+          "name": "assets_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_name": {
+          "name": "assets_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_projectId_projects_id_fk": {
+          "name": "assets_projectId_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assets_name_not_empty": {
+          "name": "assets_name_not_empty",
+          "value": "\"assets\".\"name\" <> ''"
+        },
+        "assets_confidentiality_min_max": {
+          "name": "assets_confidentiality_min_max",
+          "value": "\"assets\".\"confidentiality\" between 1 and 5"
+        },
+        "assets_integrity_min_max": {
+          "name": "assets_integrity_min_max",
+          "value": "\"assets\".\"integrity\" between 1 and 5"
+        },
+        "assets_availability_min_max": {
+          "name": "assets_availability_min_max",
+          "value": "\"assets\".\"availability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_measures": {
+      "name": "catalog_measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalog_measures_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_measures_catalog_id": {
+          "name": "catalog_measures_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_name": {
+          "name": "catalog_measures_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_point_of_attack": {
+          "name": "catalog_measures_point_of_attack",
+          "columns": [
+            {
+              "expression": "pointOfAttack",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_measures_attacker": {
+          "name": "catalog_measures_attacker",
+          "columns": [
+            {
+              "expression": "attacker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_measures_catalogId_catalogs_id_fk": {
+          "name": "catalog_measures_catalogId_catalogs_id_fk",
+          "tableFrom": "catalog_measures",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_measures_probability_min_max": {
+          "name": "catalog_measures_probability_min_max",
+          "value": "\"catalog_measures\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_threats": {
+      "name": "catalog_threats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalog_threats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_threats_catalog_id": {
+          "name": "catalog_threats_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_name": {
+          "name": "catalog_threats_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_point_of_attack": {
+          "name": "catalog_threats_point_of_attack",
+          "columns": [
+            {
+              "expression": "pointOfAttack",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_threats_attacker": {
+          "name": "catalog_threats_attacker",
+          "columns": [
+            {
+              "expression": "attacker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_threats_catalogId_catalogs_id_fk": {
+          "name": "catalog_threats_catalogId_catalogs_id_fk",
+          "tableFrom": "catalog_threats",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_threats_probability_min_max": {
+          "name": "catalog_threats_probability_min_max",
+          "value": "\"catalog_threats\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalogs": {
+      "name": "catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "catalogs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catalogs_name": {
+          "name": "catalogs_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalogs_name_not_empty": {
+          "name": "catalogs_name_not_empty",
+          "value": "\"catalogs\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.component_types": {
+      "name": "component_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "component_types_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointsOfAttack": {
+          "name": "pointsOfAttack",
+          "type": "point_of_attack[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standardIcon": {
+          "name": "standardIcon",
+          "type": "standard_icon",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "component_types_project_id": {
+          "name": "component_types_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "component_types_projectId_projects_id_fk": {
+          "name": "component_types_projectId_projects_id_fk",
+          "tableFrom": "component_types",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "component_types_icon_not_both_set": {
+          "name": "component_types_icon_not_both_set",
+          "value": "not (\"component_types\".\"symbol\" is not null and \"component_types\".\"standardIcon\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.measure_impacts": {
+      "name": "measure_impacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "measure_impacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setsOutOfScope": {
+          "name": "setsOutOfScope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impactsProbability": {
+          "name": "impactsProbability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impactsDamage": {
+          "name": "impactsDamage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage": {
+          "name": "damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "threatId": {
+          "name": "threatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measureId": {
+          "name": "measureId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "measure_impacts_measure_id_threat_id": {
+          "name": "measure_impacts_measure_id_threat_id",
+          "columns": [
+            {
+              "expression": "measureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "measure_impacts_threatId_threats_id_fk": {
+          "name": "measure_impacts_threatId_threats_id_fk",
+          "tableFrom": "measure_impacts",
+          "tableTo": "threats",
+          "columnsFrom": ["threatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "measure_impacts_measureId_measures_id_fk": {
+          "name": "measure_impacts_measureId_measures_id_fk",
+          "tableFrom": "measure_impacts",
+          "tableTo": "measures",
+          "columnsFrom": ["measureId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "measure_impacts_measure_id_threat_id_unique": {
+          "name": "measure_impacts_measure_id_threat_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["measureId", "threatId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "measure_impacts_probability_min_max": {
+          "name": "measure_impacts_probability_min_max",
+          "value": "\"measure_impacts\".\"probability\" between 1 and 5"
+        },
+        "measure_impacts_probability": {
+          "name": "measure_impacts_probability",
+          "value": "\"measure_impacts\".\"impactsProbability\" = false OR \"measure_impacts\".\"probability\" IS NOT NULL"
+        },
+        "measure_impacts_damage_min_max": {
+          "name": "measure_impacts_damage_min_max",
+          "value": "\"measure_impacts\".\"damage\" between 1 and 5"
+        },
+        "measure_impacts_damage": {
+          "name": "measure_impacts_damage",
+          "value": "\"measure_impacts\".\"impactsDamage\" = false OR \"measure_impacts\".\"damage\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.measures": {
+      "name": "measures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "measures_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledAt": {
+          "name": "scheduledAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalogMeasureId": {
+          "name": "catalogMeasureId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "measures_catalog_measure_id": {
+          "name": "measures_catalog_measure_id",
+          "columns": [
+            {
+              "expression": "catalogMeasureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "measures_project_id": {
+          "name": "measures_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "measures_catalogMeasureId_catalog_measures_id_fk": {
+          "name": "measures_catalogMeasureId_catalog_measures_id_fk",
+          "tableFrom": "measures",
+          "tableTo": "catalog_measures",
+          "columnsFrom": ["catalogMeasureId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "measures_projectId_projects_id_fk": {
+          "name": "measures_projectId_projects_id_fk",
+          "tableFrom": "measures",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "measures_name_not_empty": {
+          "name": "measures_name_not_empty",
+          "value": "\"measures\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "projects_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentialityLevel": {
+          "name": "confidentialityLevel",
+          "type": "confidentiality_level",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INTERNAL'"
+        },
+        "lineOfToleranceGreen": {
+          "name": "lineOfToleranceGreen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "lineOfToleranceRed": {
+          "name": "lineOfToleranceRed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_catalog_id": {
+          "name": "projects_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name": {
+          "name": "projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_catalogId_catalogs_id_fk": {
+          "name": "projects_catalogId_catalogs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_name_not_empty": {
+          "name": "projects_name_not_empty",
+          "value": "\"projects\".\"name\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_session_expire": {
+          "name": "IDX_session_expire",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.systems": {
+      "name": "systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "systems_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "systems_projectId_projects_id_fk": {
+          "name": "systems_projectId_projects_id_fk",
+          "tableFrom": "systems",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_id": {
+          "name": "project_id",
+          "nullsNotDistinct": false,
+          "columns": ["projectId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threats": {
+      "name": "threats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "threats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "pointOfAttackId": {
+          "name": "pointOfAttackId",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointOfAttack": {
+          "name": "pointOfAttack",
+          "type": "point_of_attack",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker": {
+          "name": "attacker",
+          "type": "attacker",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidentiality": {
+          "name": "confidentiality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doneEditing": {
+          "name": "doneEditing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "catalogThreatId": {
+          "name": "catalogThreatId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "threats_catalog_threat_id": {
+          "name": "threats_catalog_threat_id",
+          "columns": [
+            {
+              "expression": "catalogThreatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threats_project_id": {
+          "name": "threats_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "threats_catalogThreatId_catalog_threats_id_fk": {
+          "name": "threats_catalogThreatId_catalog_threats_id_fk",
+          "tableFrom": "threats",
+          "tableTo": "catalog_threats",
+          "columnsFrom": ["catalogThreatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "threats_projectId_projects_id_fk": {
+          "name": "threats_projectId_projects_id_fk",
+          "tableFrom": "threats",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "threats_name_not_empty": {
+          "name": "threats_name_not_empty",
+          "value": "\"threats\".\"name\" <> ''"
+        },
+        "threats_probability_min_max": {
+          "name": "threats_probability_min_max",
+          "value": "\"threats\".\"probability\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tokens_token": {
+          "name": "tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastname": {
+          "name": "lastname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "profile_synced_at": {
+          "name": "profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email": {
+          "name": "users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_oidc_sub": {
+          "name": "users_oidc_sub",
+          "columns": [
+            {
+              "expression": "oidc_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_catalogs": {
+      "name": "users_catalogs",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalogId": {
+          "name": "catalogId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_catalogs_catalog_id": {
+          "name": "users_catalogs_catalog_id",
+          "columns": [
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_catalogs_user_id_catalog_id": {
+          "name": "users_catalogs_user_id_catalog_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_catalogs_userId_users_id_fk": {
+          "name": "users_catalogs_userId_users_id_fk",
+          "tableFrom": "users_catalogs",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "users_catalogs_catalogId_catalogs_id_fk": {
+          "name": "users_catalogs_catalogId_catalogs_id_fk",
+          "tableFrom": "users_catalogs",
+          "tableTo": "catalogs",
+          "columnsFrom": ["catalogId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_projects": {
+      "name": "users_projects",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_projects_project_id": {
+          "name": "users_projects_project_id",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_projects_user_id_project_id": {
+          "name": "users_projects_user_id_project_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_projects_userId_users_id_fk": {
+          "name": "users_projects_userId_users_id_fk",
+          "tableFrom": "users_projects",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "users_projects_projectId_projects_id_fk": {
+          "name": "users_projects_projectId_projects_id_fk",
+          "tableFrom": "users_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["projectId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attacker": {
+      "name": "attacker",
+      "schema": "public",
+      "values": ["ADMINISTRATORS", "APPLICATION_USERS", "SYSTEM_USERS", "UNAUTHORISED_PARTIES"]
+    },
+    "public.confidentiality_level": {
+      "name": "confidentiality_level",
+      "schema": "public",
+      "values": ["PUBLIC", "INTERNAL", "CONFIDENTIAL", "HIGHLY_CONFIDENTIAL"]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": ["EN", "DE"]
+    },
+    "public.point_of_attack": {
+      "name": "point_of_attack",
+      "schema": "public",
+      "values": [
+        "COMMUNICATION_INFRASTRUCTURE",
+        "COMMUNICATION_INTERFACES",
+        "DATA_STORAGE_INFRASTRUCTURE",
+        "PROCESSING_INFRASTRUCTURE",
+        "USER_BEHAVIOUR",
+        "USER_INTERFACE"
+      ]
+    },
+    "public.standard_icon": {
+      "name": "standard_icon",
+      "schema": "public",
+      "values": ["USERS", "CLIENT", "SERVER", "DATABASE"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["OWNER", "EDITOR", "VIEWER"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1784373856712,
       "tag": "0006_add-last-login-to-user",
       "breakpoints": false
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1784623830192,
+      "tag": "0007_add_session_table",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1784623830192,
       "tag": "0007_add_session_table",
       "breakpoints": false
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1784715053806,
+      "tag": "0008_add_profile_synced_at_to_user",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.15.1",
     "compression": "1.8.1",
+    "connect-pg-simple": "10.0.0",
     "cookie-parser": "1.4.7",
     "cors": "2.8.6",
     "csrf-sync": "4.2.1",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@types/compression": "1.8.1",
+    "@types/connect-pg-simple": "7.0.3",
     "@types/cookie-parser": "1.4.10",
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",

--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -43,7 +43,7 @@ export const oidcConfig =
               clientSecret: getEnvironmentVariable("OIDC_CLIENT_SECRET"),
               issuerUrl: getEnvironmentVariable("OIDC_ISSUER_URL"),
               callbackURL: `${getEnvironmentVariable("ORIGIN_BACKEND")}/api/auth/redirect`,
-              scope: "openid profile email",
+              scope: process.env["OIDC_SCOPE"] ?? "openid profile email",
               allowHttp: process.env["OIDC_ALLOW_HTTP"] === "true",
           }
         : null;

--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -119,7 +119,9 @@ export const sessionConfig: SessionOptions = {
     secret: getEnvironmentVariable("EXPRESS_SESSION_SECRET"),
     resave: false,
     saveUninitialized: false,
-    rolling: true,
+    // No `rolling`: the Postgres store runs with `disableTouch` (see server.ts), so `touch` cannot
+    // extend a row's `expire` and rolling would only slide the cookie while the store row still
+    // dies at creation + 12h. Keep both lifetimes consistent at a fixed 12h instead.
 };
 
 const MAXIMUM_PURGE_INTERVAL_HOURS = 596; // setInterval delays above 2^31 - 1 ms overflow and fire every millisecond

--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -48,6 +48,8 @@ export const oidcConfig =
           }
         : null;
 
+export const ALLOW_UNVERIFIED_EMAIL_LINKING = process.env["OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING"] === "true";
+
 export const originConfig = {
     app: getEnvironmentVariable("ORIGIN_APP"),
     backend: `${getEnvironmentVariable("ORIGIN_BACKEND")}/api`,

--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -25,6 +25,15 @@ function getOptionalPositiveNumber(key: string, defaultValue: number): number {
     return parsedValue;
 }
 
+// OIDC requires the "openid" scope; without it the IdP returns no ID token and every login fails
+// with a misleading "No 'sub' claim" error, so reject the misconfiguration at startup instead.
+export function validateOidcScope(scope: string): string {
+    if (!scope.split(/\s+/).includes("openid")) {
+        throw new Error('Environment variable OIDC_SCOPE must include the "openid" scope');
+    }
+    return scope;
+}
+
 export const JWT_SECRET = new TextEncoder().encode(getEnvironmentVariable("JWT_SECRET"));
 export const JWT_ISSUER = "threatsea";
 export const JWT_AUDIENCE = "threatsea-api";
@@ -43,7 +52,7 @@ export const oidcConfig =
               clientSecret: getEnvironmentVariable("OIDC_CLIENT_SECRET"),
               issuerUrl: getEnvironmentVariable("OIDC_ISSUER_URL"),
               callbackURL: `${getEnvironmentVariable("ORIGIN_BACKEND")}/api/auth/redirect`,
-              scope: process.env["OIDC_SCOPE"] ?? "openid profile email",
+              scope: validateOidcScope(process.env["OIDC_SCOPE"] ?? "openid profile email"),
               allowHttp: process.env["OIDC_ALLOW_HTTP"] === "true",
           }
         : null;

--- a/apps/backend/src/controllers/authentication.controller.ts
+++ b/apps/backend/src/controllers/authentication.controller.ts
@@ -15,6 +15,12 @@ const ACCESS_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
 let oidcService: typeof import("#services/oidcAuthentication.service.js") | null = null;
 let fixedService: typeof import("#services/fixedAuthentication.service.js") | null = null;
 
+function regenerateSession(request: Request): Promise<void> {
+    return new Promise((resolve, reject) => {
+        request.session.regenerate((error) => (error ? reject(error) : resolve()));
+    });
+}
+
 async function loadStrategy() {
     if (AUTH_METHOD === "oidc") {
         oidcService = await import("#services/oidcAuthentication.service.js");
@@ -134,10 +140,14 @@ export async function finalizeAuthentication(request: Request, response: Respons
         }
 
         const oidcData = request.session.oidc;
-        delete request.session.oidc;
         if (!oidcData) {
             throw new UnauthorizedError("No pending OIDC login found in session");
         }
+        // Durably consume the single-use OIDC transaction before the token exchange: regenerating
+        // destroys the old session (and its pending oidc data) in the store so a concurrent or
+        // replayed callback can't reuse it, and it rotates the session id to prevent post-login
+        // session fixation.
+        await regenerateSession(request);
 
         const callbackUrl = new URL(oidcConfig!.callbackURL);
         callbackUrl.search = new URL(request.originalUrl, "http://localhost").search;

--- a/apps/backend/src/controllers/authentication.controller.ts
+++ b/apps/backend/src/controllers/authentication.controller.ts
@@ -134,6 +134,7 @@ export async function finalizeAuthentication(request: Request, response: Respons
         }
 
         const oidcData = request.session.oidc;
+        delete request.session.oidc;
         if (!oidcData) {
             throw new UnauthorizedError("No pending OIDC login found in session");
         }
@@ -141,8 +142,6 @@ export async function finalizeAuthentication(request: Request, response: Respons
         const callbackUrl = new URL(oidcConfig!.callbackURL);
         callbackUrl.search = new URL(request.originalUrl, "http://localhost").search;
         const threatSeaToken = await oidcService.handleOidcCallback(callbackUrl, oidcData);
-
-        delete request.session.oidc;
 
         response.cookie("accessToken", threatSeaToken, {
             httpOnly: true,

--- a/apps/backend/src/controllers/authentication.controller.ts
+++ b/apps/backend/src/controllers/authentication.controller.ts
@@ -143,15 +143,17 @@ export async function finalizeAuthentication(request: Request, response: Respons
         if (!oidcData) {
             throw new UnauthorizedError("No pending OIDC login found in session");
         }
-        // Durably consume the single-use OIDC transaction before the token exchange: regenerating
-        // destroys the old session (and its pending oidc data) in the store so a concurrent or
-        // replayed callback can't reuse it, and it rotates the session id to prevent post-login
-        // session fixation.
-        await regenerateSession(request);
 
         const callbackUrl = new URL(oidcConfig!.callbackURL);
         callbackUrl.search = new URL(request.originalUrl, "http://localhost").search;
+        // Validate the callback (state check + authorization-code exchange) BEFORE consuming the
+        // pending transaction. A forged, prefetched, or scanner-triggered top-level GET (sameSite:lax
+        // lets it carry the session cookie) fails validation here and leaves session.oidc intact, so
+        // the victim's genuine IdP redirect still completes. Only a successful exchange consumes the
+        // single-use transaction and rotates the session id (post-login fixation defense).
         const threatSeaToken = await oidcService.handleOidcCallback(callbackUrl, oidcData);
+
+        await regenerateSession(request);
 
         response.cookie("accessToken", threatSeaToken, {
             httpOnly: true,

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -5,7 +5,7 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 
-const pool = new Pool(databaseConfig);
+export const pool = new Pool(databaseConfig);
 
 export const db = drizzle({ schema: { ...schema, ...relations }, client: pool });
 export type DatabaseType = typeof db;

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -6,6 +6,7 @@ import {
     date,
     index,
     integer,
+    json,
     jsonb,
     pgEnum,
     pgTable,
@@ -285,6 +286,16 @@ export const projects = pgTable(
         index("projects_catalog_id").on(table.catalogId),
         index("projects_name").on(table.name),
     ]
+);
+
+export const sessions = pgTable(
+    "session",
+    {
+        sid: varchar().notNull().primaryKey(),
+        sess: json().notNull(),
+        expire: timestamp({ mode: "date", precision: 6 }).notNull(),
+    },
+    (table) => [index("IDX_session_expire").on(table.expire)]
 );
 
 export type System = typeof systems.$inferSelect;

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -386,6 +386,7 @@ export const users = pgTable(
         lastLoginAt: timestamp("last_login_at", { mode: "string", withTimezone: true })
             .notNull()
             .default(sql`now()`),
+        profileSyncedAt: timestamp("profile_synced_at", { mode: "string", withTimezone: true }),
         oidcSub: varchar("oidc_sub", { length: 255 }),
         createdAt: timestamp({ mode: "string", withTimezone: true })
             .notNull()

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -49,13 +49,18 @@ const { generateToken, csrfSynchronisedProtection } = csrfSync();
 app.use(cors(corsConfig));
 app.use(cookieParser());
 
+// Health check sits above the session middleware so liveness probes don't touch the shared pool.
+app.get("/api/health", (_req, res) => res.json({ ok: true, ts: Date.now() }));
+
 const PostgresSessionStore = connectPgSimple(session);
 
 // Set up express-session middleware
 app.use(
     session({
         ...sessionConfig,
-        store: new PostgresSessionStore({ pool, createTableIfMissing: false }),
+        // disableTouch avoids a per-request UPDATE from rolling sessions; the 12h cookie makes the
+        // touch low-value against the shared connection pool.
+        store: new PostgresSessionStore({ pool, disableTouch: true }),
     })
 );
 app.use(helmet(helmetConfig));
@@ -82,8 +87,6 @@ app.use("/api/catalogs", apiRateLimiter, CheckTokenHandler, catalogsRouter);
 app.use("/api/projects", apiRateLimiter, CheckTokenHandler, projectsRouter);
 app.use("/api/export", apiRateLimiter, CheckTokenHandler, exportRouter);
 app.use("/api/import", apiRateLimiter, CheckTokenHandler, express.json({ limit: "200mb" }), importRouter);
-
-app.get("/api/health", (_req, res) => res.json({ ok: true, ts: Date.now() }));
 
 app.use((_req, res) => {
     res.sendFile(path.join(PUBLIC_DIR, "index.html"));

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -49,8 +49,10 @@ const { generateToken, csrfSynchronisedProtection } = csrfSync();
 app.use(cors(corsConfig));
 app.use(cookieParser());
 
-// Health check sits above the session middleware so liveness probes don't touch the shared pool.
-app.get("/api/health", (_req, res) => res.json({ ok: true, ts: Date.now() }));
+// Health check sits above the session middleware so liveness probes never touch the shared pool.
+// It sets no-store explicitly because it runs before nocache(): otherwise an intermediary proxy or
+// CDN could keep serving a cached 200 after the backend is down, blinding uptime checks.
+app.get("/api/health", (_req, res) => res.set("Cache-Control", "no-store").json({ ok: true, ts: Date.now() }));
 
 const PostgresSessionStore = connectPgSimple(session);
 

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -9,6 +9,8 @@ import path from "path";
 import helmet from "helmet";
 import { corsConfig, helmetConfig, sessionConfig } from "#config/config.js";
 import nocache from "nocache";
+import connectPgSimple from "connect-pg-simple";
+import { pool } from "#db/index.js";
 
 // Routers
 import { authRouter } from "#routers/auth.router.js";
@@ -47,8 +49,15 @@ const { generateToken, csrfSynchronisedProtection } = csrfSync();
 app.use(cors(corsConfig));
 app.use(cookieParser());
 
+const PostgresSessionStore = connectPgSimple(session);
+
 // Set up express-session middleware
-app.use(session(sessionConfig));
+app.use(
+    session({
+        ...sessionConfig,
+        store: new PostgresSessionStore({ pool, createTableIfMissing: false }),
+    })
+);
 app.use(helmet(helmetConfig));
 app.use(nocache());
 app.set("etag", false);

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -58,8 +58,9 @@ const PostgresSessionStore = connectPgSimple(session);
 app.use(
     session({
         ...sessionConfig,
-        // disableTouch avoids a per-request UPDATE from rolling sessions; the 12h cookie makes the
-        // touch low-value against the shared connection pool.
+        // disableTouch avoids a per-request UPDATE against the shared pool. It also means `touch`
+        // cannot extend a session, so the store row and cookie share one fixed 12h lifetime from
+        // creation (no `rolling` in sessionConfig — it would only slide the cookie, not the row).
         store: new PostgresSessionStore({ pool, disableTouch: true }),
     })
 );

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -19,7 +19,9 @@ export interface OidcProfile {
 }
 
 export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promise<string> {
-    const email = userObject.email;
+    // Normalize to lowercase so an IdP that varies email casing (ID token vs userinfo, UPN vs
+    // canonical mailbox) can't split one account into duplicates.
+    const email = userObject.email?.toLowerCase();
     if (!email) {
         throw new UnauthorizedError("No email found in user profile object.");
     }
@@ -34,7 +36,7 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
 
         if (!user) {
             const emailMatches = await tx.query.users.findMany({
-                where: and(eq(users.email, email), isNull(users.oidcSub)),
+                where: and(sql`lower(${users.email}) = ${email}`, isNull(users.oidcSub)),
             });
 
             if (emailMatches.length > 1) {

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -70,7 +70,7 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
             // No-clobber: for an existing user an absent incoming name coalesces to the stored
             // value rather than the email fallback, so a userinfo-less login can't wipe a name.
             const nextFirstName = userObject.firstName ?? user.firstname;
-            const nextLastName = userObject.lastName ?? userObject.displayName ?? user.lastname;
+            const nextLastName = userObject.lastName ?? user.lastname;
             const profileChanged =
                 user.firstname !== nextFirstName || user.lastname !== nextLastName || user.email !== email;
 

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -3,7 +3,7 @@
  */
 
 import { SignJWT } from "jose";
-import { JWT_AUDIENCE, JWT_ISSUER, JWT_SECRET } from "#config/config.js";
+import { ALLOW_UNVERIFIED_EMAIL_LINKING, JWT_AUDIENCE, JWT_ISSUER, JWT_SECRET } from "#config/config.js";
 import { db } from "#db/index.js";
 import { users } from "#db/schema.js";
 import { and, eq, isNull, sql } from "drizzle-orm";
@@ -12,6 +12,7 @@ import { UnauthorizedError } from "#errors/unauthorized.error.js";
 export interface OidcProfile {
     sub: string;
     email?: string | undefined;
+    emailVerified?: boolean | undefined;
     firstName?: string | undefined;
     lastName?: string | undefined;
     displayName?: string | undefined;
@@ -42,6 +43,11 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
 
             user = emailMatches.at(0);
             if (user) {
+                if (userObject.emailVerified !== true && !ALLOW_UNVERIFIED_EMAIL_LINKING) {
+                    throw new UnauthorizedError(
+                        "Email not verified by IdP; refusing to link existing account — see OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING"
+                    );
+                }
                 // Link existing email-matched user to their OIDC sub
                 await tx
                     .update(users)

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -16,17 +16,18 @@ export interface OidcProfile {
     firstName?: string | undefined;
     lastName?: string | undefined;
     displayName?: string | undefined;
+    profileSynced?: boolean | undefined;
 }
 
-export async function findOidcUserBySub(oidcSub: string): Promise<{ lastLoginAt: string } | undefined> {
-    // Read-only pre-check that only informs the userinfo-fetch decision: how recently THIS OIDC
-    // subject last logged in. It matches solely on oidcSub (uniquely indexed) — a user found only
-    // by email has never been OIDC-synced, so it is treated as unknown (fetch) by the caller, not
-    // as a "fresh" user. The authoritative resolve/link/upsert still happens transactionally in
+export async function findOidcUserBySub(oidcSub: string): Promise<{ profileSyncedAt: string | null } | undefined> {
+    // Read-only pre-check that only informs the userinfo-fetch decision: when THIS OIDC subject's
+    // profile was last synced from userinfo. It matches solely on oidcSub (uniquely indexed) — a
+    // user found only by email has never been OIDC-synced, so it is treated as unknown (fetch) by
+    // the caller. The authoritative resolve/link/upsert still happens transactionally in
     // buildThreatSeaAccessToken, so a stale read here under a concurrent race is benign.
     return await db.query.users.findFirst({
         where: eq(users.oidcSub, oidcSub),
-        columns: { lastLoginAt: true },
+        columns: { profileSyncedAt: true },
     });
 }
 
@@ -89,6 +90,10 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
                 .update(users)
                 .set({
                     lastLoginAt: sql`now()`,
+                    // Track when userinfo was last consulted, independent of lastLoginAt, so the
+                    // staleness gate keeps firing for users who log in more often than the refresh
+                    // window. Bumping this must not bump updatedAt.
+                    ...(userObject.profileSynced ? { profileSyncedAt: sql`now()` } : {}),
                     ...(profileChanged
                         ? {
                               firstname: nextFirstName,
@@ -125,6 +130,7 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
                     lastname: userObject.lastName ?? userObject.displayName ?? email,
                     email: email,
                     oidcSub: userObject.sub,
+                    ...(userObject.profileSynced ? { profileSyncedAt: sql`now()` } : {}),
                 })
                 .returning()
         ).at(0);

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -51,10 +51,6 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
         throw new UnauthorizedError("No email found in user profile object.");
     }
 
-    const firstName = userObject.firstName ?? "";
-    const lastName = userObject.lastName ?? userObject.displayName ?? email;
-    const displayName = userObject.displayName ?? (`${firstName} ${lastName}`.trim() || email);
-
     const user = await db.transaction(async (tx) => {
         // Look up by OIDC sub first, fall back to email for initial account linking
         let user = await tx.query.users.findFirst({ where: eq(users.oidcSub, userObject.sub) });
@@ -84,7 +80,12 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
         }
 
         if (user) {
-            const profileChanged = user.firstname !== firstName || user.lastname !== lastName || user.email !== email;
+            // No-clobber: for an existing user an absent incoming name coalesces to the stored
+            // value rather than the email fallback, so a userinfo-less login can't wipe a name.
+            const nextFirstName = userObject.firstName ?? user.firstname;
+            const nextLastName = userObject.lastName ?? userObject.displayName ?? user.lastname;
+            const profileChanged =
+                user.firstname !== nextFirstName || user.lastname !== nextLastName || user.email !== email;
 
             // Fold the last-login refresh into the profile write so a login is at most one
             // UPDATE. lastLoginAt on its own must not bump updatedAt.
@@ -93,26 +94,26 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
                 .set({
                     lastLoginAt: sql`now()`,
                     ...(profileChanged
-                        ? { firstname: firstName, lastname: lastName, email: email, updatedAt: sql`now()` }
+                        ? { firstname: nextFirstName, lastname: nextLastName, email: email, updatedAt: sql`now()` }
                         : {}),
                 })
                 .where(eq(users.id, user.id))
-                .returning({ id: users.id });
+                .returning();
 
             // A concurrent purge may have deleted this user between the lookup above and this
             // UPDATE; if the row is gone we must not mint a token for an account that no longer exists.
             if (touchedRows.length === 0) {
                 throw new UnauthorizedError("User no longer exists");
             }
-            return user;
+            return touchedRows.at(0);
         }
 
         return (
             await tx
                 .insert(users)
                 .values({
-                    firstname: firstName,
-                    lastname: lastName,
+                    firstname: userObject.firstName ?? "",
+                    lastname: userObject.lastName ?? userObject.displayName ?? email,
                     email: email,
                     oidcSub: userObject.sub,
                 })
@@ -124,12 +125,15 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
         throw new Error("Failed to retrieve user from database");
     }
 
+    // Build the JWT from the persisted row so its names reflect exactly what the DB now holds.
+    const displayName = userObject.displayName ?? (`${user.firstname} ${user.lastname}`.trim() || email);
+
     const threatseaAccessToken = await new SignJWT({
         userId: user.id,
         oidcId: userObject.sub,
         email: email,
-        firstname: firstName,
-        lastname: lastName,
+        firstname: user.firstname,
+        lastname: user.lastname,
         displayName: displayName,
     })
         .setProtectedHeader({ alg: "HS256" })

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -18,27 +18,14 @@ export interface OidcProfile {
     displayName?: string | undefined;
 }
 
-export async function findLinkableUser(
-    oidcSub: string,
-    email: string | undefined
-): Promise<{ lastLoginAt: string } | undefined> {
-    // Read-only pre-check that only informs the userinfo-fetch decision. The authoritative
-    // resolve/link/upsert happens transactionally in buildThreatSeaAccessToken, so a stale read
-    // under a concurrent race here is benign.
-    const linkedUser = await db.query.users.findFirst({
-        where: eq(users.oidcSub, oidcSub),
-        columns: { lastLoginAt: true },
-    });
-    if (linkedUser) {
-        return linkedUser;
-    }
-
-    if (email === undefined) {
-        return undefined;
-    }
-
+export async function findOidcUserBySub(oidcSub: string): Promise<{ lastLoginAt: string } | undefined> {
+    // Read-only pre-check that only informs the userinfo-fetch decision: how recently THIS OIDC
+    // subject last logged in. It matches solely on oidcSub (uniquely indexed) — a user found only
+    // by email has never been OIDC-synced, so it is treated as unknown (fetch) by the caller, not
+    // as a "fresh" user. The authoritative resolve/link/upsert still happens transactionally in
+    // buildThreatSeaAccessToken, so a stale read here under a concurrent race is benign.
     return await db.query.users.findFirst({
-        where: and(sql`lower(${users.email}) = ${email.toLowerCase()}`, isNull(users.oidcSub)),
+        where: eq(users.oidcSub, oidcSub),
         columns: { lastLoginAt: true },
     });
 }

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -38,6 +38,12 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
         throw new UnauthorizedError("No email found in user profile object.");
     }
 
+    // An email is trustworthy only if the IdP asserts it verified, or an operator has opted into
+    // unverified linking via OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING. An untrusted email is never
+    // written through: it can neither overwrite an existing account nor seed a new one, so an
+    // attacker-chosen address can't surface in member pickers as a trusted identity.
+    const emailTrusted = userObject.emailVerified === true || ALLOW_UNVERIFIED_EMAIL_LINKING;
+
     const user = await db.transaction(async (tx) => {
         // Look up by OIDC sub first, fall back to email for initial account linking
         let user = await tx.query.users.findFirst({ where: eq(users.oidcSub, userObject.sub) });
@@ -53,7 +59,7 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
 
             user = emailMatches.at(0);
             if (user) {
-                if (userObject.emailVerified !== true && !ALLOW_UNVERIFIED_EMAIL_LINKING) {
+                if (!emailTrusted) {
                     throw new UnauthorizedError(
                         "Email not verified by IdP; refusing to link existing account — see OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING"
                     );
@@ -71,8 +77,11 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
             // value rather than the email fallback, so a userinfo-less login can't wipe a name.
             const nextFirstName = userObject.firstName ?? user.firstname;
             const nextLastName = userObject.lastName ?? user.lastname;
+            // An untrusted email must not overwrite the stored one; login still proceeds with the
+            // address already on file. A trusted email is allowed to propagate a change.
+            const nextEmail = emailTrusted ? email : user.email;
             const profileChanged =
-                user.firstname !== nextFirstName || user.lastname !== nextLastName || user.email !== email;
+                user.firstname !== nextFirstName || user.lastname !== nextLastName || user.email !== nextEmail;
 
             // Fold the last-login refresh into the profile write so a login is at most one
             // UPDATE. lastLoginAt on its own must not bump updatedAt.
@@ -81,7 +90,12 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
                 .set({
                     lastLoginAt: sql`now()`,
                     ...(profileChanged
-                        ? { firstname: nextFirstName, lastname: nextLastName, email: email, updatedAt: sql`now()` }
+                        ? {
+                              firstname: nextFirstName,
+                              lastname: nextLastName,
+                              email: nextEmail,
+                              updatedAt: sql`now()`,
+                          }
                         : {}),
                 })
                 .where(eq(users.id, user.id))
@@ -93,6 +107,14 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
                 throw new UnauthorizedError("User no longer exists");
             }
             return touchedRows.at(0);
+        }
+
+        // New account: an unverified, attacker-chosen email must not seed a row that member pickers
+        // would later surface as a trusted identity.
+        if (!emailTrusted) {
+            throw new UnauthorizedError(
+                "Email not verified by IdP; refusing to create a new account — see OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING"
+            );
         }
 
         return (
@@ -112,13 +134,14 @@ export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promis
         throw new Error("Failed to retrieve user from database");
     }
 
-    // Build the JWT from the persisted row so its names reflect exactly what the DB now holds.
-    const displayName = userObject.displayName ?? (`${user.firstname} ${user.lastname}`.trim() || email);
+    // Build the JWT from the persisted row so its email and names reflect exactly what the DB now
+    // holds — never a rejected/untrusted incoming email.
+    const displayName = userObject.displayName ?? (`${user.firstname} ${user.lastname}`.trim() || user.email);
 
     const threatseaAccessToken = await new SignJWT({
         userId: user.id,
         oidcId: userObject.sub,
-        email: email,
+        email: user.email,
         firstname: user.firstname,
         lastname: user.lastname,
         displayName: displayName,

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -18,6 +18,31 @@ export interface OidcProfile {
     displayName?: string | undefined;
 }
 
+export async function findLinkableUser(
+    oidcSub: string,
+    email: string | undefined
+): Promise<{ lastLoginAt: string } | undefined> {
+    // Read-only pre-check that only informs the userinfo-fetch decision. The authoritative
+    // resolve/link/upsert happens transactionally in buildThreatSeaAccessToken, so a stale read
+    // under a concurrent race here is benign.
+    const linkedUser = await db.query.users.findFirst({
+        where: eq(users.oidcSub, oidcSub),
+        columns: { lastLoginAt: true },
+    });
+    if (linkedUser) {
+        return linkedUser;
+    }
+
+    if (email === undefined) {
+        return undefined;
+    }
+
+    return await db.query.users.findFirst({
+        where: and(sql`lower(${users.email}) = ${email.toLowerCase()}`, isNull(users.oidcSub)),
+        columns: { lastLoginAt: true },
+    });
+}
+
 export async function buildThreatSeaAccessToken(userObject: OidcProfile): Promise<string> {
     // Normalize to lowercase so an IdP that varies email casing (ID token vs userinfo, UPN vs
     // canonical mailbox) can't split one account into duplicates.

--- a/apps/backend/src/services/fixedAuthentication.service.ts
+++ b/apps/backend/src/services/fixedAuthentication.service.ts
@@ -8,24 +8,28 @@ const profiles: OidcProfile[] = [
         lastName: "testsn",
         email: "test@test.test",
         sub: "testid",
+        emailVerified: true,
     },
     {
         firstName: "E2E",
         lastName: "Testing",
         email: "test2@test.test",
         sub: "testid2",
+        emailVerified: true,
     },
     {
         firstName: "E2E",
         lastName: "Testing",
         email: "test3@test.test",
         sub: "testid3",
+        emailVerified: true,
     },
     {
         firstName: "E2E",
         lastName: "Testing",
         email: "test4@test.test",
         sub: "testid4",
+        emailVerified: true,
     },
 ];
 

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -74,8 +74,11 @@ function hasMissingProfileClaim(profileClaims: ProfileClaims): boolean {
 
 const PROFILE_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000; // equals 24 hours
 
-function isProfileStale(lastLoginAt: string): boolean {
-    return Date.now() - new Date(lastLoginAt).getTime() > PROFILE_REFRESH_INTERVAL_MS;
+function isProfileStale(profileSyncedAt: string | null): boolean {
+    if (profileSyncedAt === null) {
+        return true;
+    }
+    return Date.now() - new Date(profileSyncedAt).getTime() > PROFILE_REFRESH_INTERVAL_MS;
 }
 
 function mergeProfileClaims(idTokenClaims: ProfileClaims, userInfoClaims: ProfileClaims): ProfileClaims {
@@ -202,13 +205,24 @@ export async function handleOidcCallback(callbackUrl: URL, oidcParams: OidcCallb
     }
 
     let profileClaims = readProfileClaims(idTokenClaims);
+    let profileSynced = false;
 
     const userInfoEndpoint = oidcClientConfig.serverMetadata().userinfo_endpoint;
     if (userInfoEndpoint !== undefined && hasMissingProfileClaim(profileClaims)) {
-        const knownUser = await findOidcUserBySub(idTokenClaims.sub);
-        if (knownUser === undefined || isProfileStale(knownUser.lastLoginAt)) {
+        // Email is mandatory to mint a token, so a missing email forces a fetch regardless of
+        // freshness — otherwise a repeat login inside the refresh window would skip userinfo, leave
+        // email undefined, and hard-fail token minting (at most one successful login per refresh
+        // window for IdPs that deliver email only via userinfo). Only the optional enrichment
+        // claims (names, email_verified) defer to the unknown-or-stale gate.
+        let shouldFetch = profileClaims.email === undefined;
+        if (!shouldFetch) {
+            const knownUser = await findOidcUserBySub(idTokenClaims.sub);
+            shouldFetch = knownUser === undefined || isProfileStale(knownUser.profileSyncedAt);
+        }
+        if (shouldFetch) {
             const userInfo = await client.fetchUserInfo(oidcClientConfig, tokenSet.access_token, idTokenClaims.sub);
             profileClaims = mergeProfileClaims(profileClaims, readProfileClaims(userInfo));
+            profileSynced = true;
         }
     }
 
@@ -219,6 +233,7 @@ export async function handleOidcCallback(callbackUrl: URL, oidcParams: OidcCallb
         displayName: profileClaims.name,
         firstName: profileClaims.givenName,
         lastName: profileClaims.familyName,
+        profileSynced,
     };
 
     const threatSeaToken = await buildThreatSeaAccessToken(user);

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -72,9 +72,9 @@ function mergeProfileClaims(idTokenClaims: ProfileClaims, userInfoClaims: Profil
     // (attacker-editable) userinfo email with the ID token's email_verified flag would let an
     // unverified address inherit a verified status and bypass the account-linking gate.
     const emailSource = userInfoClaims.email !== undefined ? userInfoClaims : idTokenClaims;
-    // Exception: when both sources assert the *same* address, the flag describes one email, so an
-    // ID-token "verified" survives a userinfo body that simply omits email_verified. This is the
-    // common shape when the gate fetches userinfo just to fill a missing name for a verified user.
+    // Exception: when both sources assert the *same* address, the signed ID token is the
+    // authoritative assertion for this authentication event and takes precedence over the
+    // userinfo body, falling back to userinfo only when the ID token omits it.
     const emailsMatch =
         userInfoClaims.email !== undefined &&
         idTokenClaims.email !== undefined &&
@@ -82,7 +82,7 @@ function mergeProfileClaims(idTokenClaims: ProfileClaims, userInfoClaims: Profil
     return {
         email: emailSource.email,
         emailVerified: emailsMatch
-            ? (emailSource.emailVerified ?? idTokenClaims.emailVerified)
+            ? (idTokenClaims.emailVerified ?? userInfoClaims.emailVerified)
             : emailSource.emailVerified,
         name: userInfoClaims.name ?? idTokenClaims.name,
         givenName: userInfoClaims.givenName ?? idTokenClaims.givenName,

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -1,6 +1,7 @@
 import { oidcConfig } from "#config/config.js";
 import { UnauthorizedError } from "#errors/unauthorized.error.js";
 import { buildThreatSeaAccessToken, OidcProfile } from "#services/auth.service.js";
+import { Logger } from "#logging/index.js";
 import crypto from "crypto";
 import * as client from "openid-client";
 
@@ -58,12 +59,34 @@ export async function initializeOidc(): Promise<void> {
         options.execute = [client.allowInsecureRequests];
     }
 
-    oidcClientConfig = await client.discovery(
+    const discoveredConfig = await client.discovery(
         issuerUrl,
         oidcConfig.clientId,
         oidcConfig.clientSecret,
         undefined,
         options
+    );
+    const serverMetadata = discoveredConfig.serverMetadata();
+
+    const supportedAuthenticationMethods = serverMetadata.token_endpoint_auth_methods_supported;
+    const useBasicAuthentication =
+        supportedAuthenticationMethods === undefined || supportedAuthenticationMethods.includes("client_secret_basic");
+    const clientAuthentication = useBasicAuthentication
+        ? client.ClientSecretBasic(oidcConfig.clientSecret)
+        : client.ClientSecretPost(oidcConfig.clientSecret);
+
+    oidcClientConfig = new client.Configuration(
+        serverMetadata,
+        oidcConfig.clientId,
+        oidcConfig.clientSecret,
+        clientAuthentication
+    );
+    if (oidcConfig.allowHttp) {
+        client.allowInsecureRequests(oidcClientConfig);
+    }
+
+    Logger.info(
+        `OIDC token endpoint authentication method: ${useBasicAuthentication ? "client_secret_basic" : "client_secret_post"}`
     );
 }
 

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -162,12 +162,3 @@ export async function handleOidcCallback(callbackUrl: URL, oidcParams: OidcCallb
 
     return threatSeaToken;
 }
-
-export function buildLogoutUrl(): string | null {
-    try {
-        const url = client.buildEndSessionUrl(oidcClientConfig, {});
-        return url.href;
-    } catch {
-        return null;
-    }
-}

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -1,6 +1,6 @@
 import { oidcConfig } from "#config/config.js";
 import { UnauthorizedError } from "#errors/unauthorized.error.js";
-import { buildThreatSeaAccessToken, OidcProfile } from "#services/auth.service.js";
+import { buildThreatSeaAccessToken, findLinkableUser, OidcProfile } from "#services/auth.service.js";
 import { Logger } from "#logging/index.js";
 import crypto from "crypto";
 import * as client from "openid-client";
@@ -48,12 +48,23 @@ function readProfileClaims(claimSource: Readonly<Record<string, unknown>>): Prof
     };
 }
 
-// Only email and email_verified drive authorization (the account-linking gate); the name parts are
-// cosmetic. Gate the blocking userinfo round-trip on those two alone so an ID token that already
-// vouches a verified email is trusted as-is — fetching userinfo just for a display name would risk
-// dropping the verified flag (many IdPs assert it only in the ID token) and break legitimate logins.
-function hasMissingRequiredClaim(profileClaims: ProfileClaims): boolean {
-    return profileClaims.email === undefined || profileClaims.emailVerified === undefined;
+// Any wanted field the ID token omits is worth enriching from userinfo. The fetch itself is
+// separately gated on DB state (unknown-or-stale user) so this wide trigger doesn't cause a
+// userinfo round-trip on every login.
+function hasMissingProfileClaim(profileClaims: ProfileClaims): boolean {
+    return (
+        profileClaims.email === undefined ||
+        profileClaims.emailVerified === undefined ||
+        profileClaims.name === undefined ||
+        profileClaims.givenName === undefined ||
+        profileClaims.familyName === undefined
+    );
+}
+
+const PROFILE_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000; // equals 24 hours
+
+function isProfileStale(lastLoginAt: string): boolean {
+    return Date.now() - new Date(lastLoginAt).getTime() > PROFILE_REFRESH_INTERVAL_MS;
 }
 
 function mergeProfileClaims(idTokenClaims: ProfileClaims, userInfoClaims: ProfileClaims): ProfileClaims {
@@ -173,9 +184,12 @@ export async function handleOidcCallback(callbackUrl: URL, oidcParams: OidcCallb
     let profileClaims = readProfileClaims(idTokenClaims);
 
     const userInfoEndpoint = oidcClientConfig.serverMetadata().userinfo_endpoint;
-    if (hasMissingRequiredClaim(profileClaims) && userInfoEndpoint !== undefined) {
-        const userInfo = await client.fetchUserInfo(oidcClientConfig, tokenSet.access_token, idTokenClaims.sub);
-        profileClaims = mergeProfileClaims(profileClaims, readProfileClaims(userInfo));
+    if (userInfoEndpoint !== undefined && hasMissingProfileClaim(profileClaims)) {
+        const knownUser = await findLinkableUser(idTokenClaims.sub, profileClaims.email);
+        if (knownUser === undefined || isProfileStale(knownUser.lastLoginAt)) {
+            const userInfo = await client.fetchUserInfo(oidcClientConfig, tokenSet.access_token, idTokenClaims.sub);
+            profileClaims = mergeProfileClaims(profileClaims, readProfileClaims(userInfo));
+        }
     }
 
     const user: OidcProfile = {

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -26,24 +26,48 @@ interface ProfileClaims {
     familyName?: string | undefined;
 }
 
+// Some IdPs (e.g. AWS Cognito) serialize email_verified as the string "true"/"false"
+// rather than a JSON boolean; honour both while treating anything else as absent.
+function parseEmailVerified(rawValue: unknown): boolean | undefined {
+    if (rawValue === true || rawValue === "true") {
+        return true;
+    }
+    if (rawValue === false || rawValue === "false") {
+        return false;
+    }
+    return undefined;
+}
+
 function readProfileClaims(claimSource: Readonly<Record<string, unknown>>): ProfileClaims {
     return {
         email: typeof claimSource["email"] === "string" ? claimSource["email"] : undefined,
-        emailVerified: typeof claimSource["email_verified"] === "boolean" ? claimSource["email_verified"] : undefined,
+        emailVerified: parseEmailVerified(claimSource["email_verified"]),
         name: typeof claimSource["name"] === "string" ? claimSource["name"] : undefined,
         givenName: typeof claimSource["given_name"] === "string" ? claimSource["given_name"] : undefined,
         familyName: typeof claimSource["family_name"] === "string" ? claimSource["family_name"] : undefined,
     };
 }
 
-function hasMissingProfileClaim(profileClaims: ProfileClaims): boolean {
-    return (
-        profileClaims.email === undefined ||
-        profileClaims.emailVerified === undefined ||
-        profileClaims.name === undefined ||
-        profileClaims.givenName === undefined ||
-        profileClaims.familyName === undefined
-    );
+// Only email and email_verified drive authorization (the account-linking gate); the name parts are
+// cosmetic. Gate the blocking userinfo round-trip on those two alone so an ID token that already
+// vouches a verified email is trusted as-is — fetching userinfo just for a display name would risk
+// dropping the verified flag (many IdPs assert it only in the ID token) and break legitimate logins.
+function hasMissingRequiredClaim(profileClaims: ProfileClaims): boolean {
+    return profileClaims.email === undefined || profileClaims.emailVerified === undefined;
+}
+
+function mergeProfileClaims(idTokenClaims: ProfileClaims, userInfoClaims: ProfileClaims): ProfileClaims {
+    // email and email_verified must be taken as an atomic pair from a single source. Mixing an
+    // (attacker-editable) userinfo email with the ID token's email_verified flag would let an
+    // unverified address inherit a verified status and bypass the account-linking gate.
+    const emailSource = userInfoClaims.email !== undefined ? userInfoClaims : idTokenClaims;
+    return {
+        email: emailSource.email,
+        emailVerified: emailSource.emailVerified,
+        name: userInfoClaims.name ?? idTokenClaims.name,
+        givenName: userInfoClaims.givenName ?? idTokenClaims.givenName,
+        familyName: userInfoClaims.familyName ?? idTokenClaims.familyName,
+    };
 }
 
 let oidcClientConfig: client.Configuration;
@@ -68,12 +92,24 @@ export async function initializeOidc(): Promise<void> {
     );
     const serverMetadata = discoveredConfig.serverMetadata();
 
+    // Prefer client_secret_post — it was the effective default before this detection existed and
+    // avoids the RFC 6749 secret percent-encoding pitfalls of Basic. Metadata that omits the field
+    // is treated as post-capable (the OIDC default). Fall back to Basic only when post is not
+    // advertised, and fail fast when the IdP supports neither secret-based method.
     const supportedAuthenticationMethods = serverMetadata.token_endpoint_auth_methods_supported;
-    const useBasicAuthentication =
-        supportedAuthenticationMethods === undefined || supportedAuthenticationMethods.includes("client_secret_basic");
-    const clientAuthentication = useBasicAuthentication
-        ? client.ClientSecretBasic(oidcConfig.clientSecret)
-        : client.ClientSecretPost(oidcConfig.clientSecret);
+    let clientAuthentication: ReturnType<typeof client.ClientSecretPost>;
+    let selectedAuthenticationMethod: string;
+    if (supportedAuthenticationMethods === undefined || supportedAuthenticationMethods.includes("client_secret_post")) {
+        clientAuthentication = client.ClientSecretPost(oidcConfig.clientSecret);
+        selectedAuthenticationMethod = "client_secret_post";
+    } else if (supportedAuthenticationMethods.includes("client_secret_basic")) {
+        clientAuthentication = client.ClientSecretBasic(oidcConfig.clientSecret);
+        selectedAuthenticationMethod = "client_secret_basic";
+    } else {
+        throw new Error(
+            `OIDC provider does not advertise a client-secret token endpoint authentication method (client_secret_post or client_secret_basic); advertised: ${supportedAuthenticationMethods.join(", ")}`
+        );
+    }
 
     oidcClientConfig = new client.Configuration(
         serverMetadata,
@@ -85,9 +121,7 @@ export async function initializeOidc(): Promise<void> {
         client.allowInsecureRequests(oidcClientConfig);
     }
 
-    Logger.info(
-        `OIDC token endpoint authentication method: ${useBasicAuthentication ? "client_secret_basic" : "client_secret_post"}`
-    );
+    Logger.info(`OIDC token endpoint authentication method: ${selectedAuthenticationMethod}`);
 }
 
 export async function buildLoginRedirectUrl(): Promise<OidcLoginInitiation> {
@@ -137,16 +171,9 @@ export async function handleOidcCallback(callbackUrl: URL, oidcParams: OidcCallb
     let profileClaims = readProfileClaims(idTokenClaims);
 
     const userInfoEndpoint = oidcClientConfig.serverMetadata().userinfo_endpoint;
-    if (hasMissingProfileClaim(profileClaims) && userInfoEndpoint !== undefined) {
+    if (hasMissingRequiredClaim(profileClaims) && userInfoEndpoint !== undefined) {
         const userInfo = await client.fetchUserInfo(oidcClientConfig, tokenSet.access_token, idTokenClaims.sub);
-        const userInfoClaims = readProfileClaims(userInfo);
-        profileClaims = {
-            email: userInfoClaims.email ?? profileClaims.email,
-            emailVerified: userInfoClaims.emailVerified ?? profileClaims.emailVerified,
-            name: userInfoClaims.name ?? profileClaims.name,
-            givenName: userInfoClaims.givenName ?? profileClaims.givenName,
-            familyName: userInfoClaims.familyName ?? profileClaims.familyName,
-        };
+        profileClaims = mergeProfileClaims(profileClaims, readProfileClaims(userInfo));
     }
 
     const user: OidcProfile = {

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -1,6 +1,6 @@
 import { oidcConfig } from "#config/config.js";
 import { UnauthorizedError } from "#errors/unauthorized.error.js";
-import { buildThreatSeaAccessToken, findLinkableUser, OidcProfile } from "#services/auth.service.js";
+import { buildThreatSeaAccessToken, findOidcUserBySub, OidcProfile } from "#services/auth.service.js";
 import { Logger } from "#logging/index.js";
 import crypto from "crypto";
 import * as client from "openid-client";
@@ -194,7 +194,7 @@ export async function handleOidcCallback(callbackUrl: URL, oidcParams: OidcCallb
 
     const userInfoEndpoint = oidcClientConfig.serverMetadata().userinfo_endpoint;
     if (userInfoEndpoint !== undefined && hasMissingProfileClaim(profileClaims)) {
-        const knownUser = await findLinkableUser(idTokenClaims.sub, profileClaims.email);
+        const knownUser = await findOidcUserBySub(idTokenClaims.sub);
         if (knownUser === undefined || isProfileStale(knownUser.lastLoginAt)) {
             const userInfo = await client.fetchUserInfo(oidcClientConfig, tokenSet.access_token, idTokenClaims.sub);
             profileClaims = mergeProfileClaims(profileClaims, readProfileClaims(userInfo));

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -126,21 +126,27 @@ export async function initializeOidc(): Promise<void> {
     );
     const serverMetadata = discoveredConfig.serverMetadata();
 
-    // Prefer client_secret_post — it was the effective default before this detection existed and
-    // avoids the RFC 6749 secret percent-encoding pitfalls of Basic. Metadata that omits the field
-    // is treated as post-capable (the OIDC default). Fall back to Basic only when post is not
-    // advertised, and fail fast when the IdP supports neither secret-based method.
+    // OIDC Discovery 1.0 §3 / RFC 8414 §2 make client_secret_basic the default when the IdP omits
+    // token_endpoint_auth_methods_supported, and Basic is the RFC 6749 §2.3.1 mandatory-to-implement
+    // method — so defaulting an omitted field to Basic is both spec-compliant and secure-by-default.
+    // Prefer client_secret_post ONLY when the IdP explicitly advertises it: post sidesteps the
+    // RFC 6749 Basic secret percent-encoding ambiguity (e.g. Azure AD, which advertises post). Fall
+    // back to Basic when the field is omitted or advertises basic-without-post; fail fast otherwise.
     const supportedAuthenticationMethods = serverMetadata.token_endpoint_auth_methods_supported;
     let selectedAuthenticationMethod: string;
-    if (supportedAuthenticationMethods === undefined || supportedAuthenticationMethods.includes("client_secret_post")) {
+    if (supportedAuthenticationMethods !== undefined && supportedAuthenticationMethods.includes("client_secret_post")) {
         // discovery() already defaults to ClientSecretPost and, when allowHttp is set, applied
         // allowInsecureRequests via options.execute — so the discovered Configuration is ready to
         // reuse as-is. Rebuilding it would duplicate both the auth selection and the insecure-request
         // opt-in and risk the two construction paths drifting apart.
         oidcClientConfig = discoveredConfig;
         selectedAuthenticationMethod = "client_secret_post";
-    } else if (supportedAuthenticationMethods.includes("client_secret_basic")) {
-        // Only the Basic fallback needs a rebuilt Configuration to override discovery()'s post default.
+    } else if (
+        supportedAuthenticationMethods === undefined ||
+        supportedAuthenticationMethods.includes("client_secret_basic")
+    ) {
+        // Omitted field (spec default) or basic-only advertisement: rebuild the Configuration to
+        // override discovery()'s post default with Basic.
         oidcClientConfig = new client.Configuration(
             serverMetadata,
             oidcConfig.clientId,

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -38,13 +38,24 @@ function parseEmailVerified(rawValue: unknown): boolean | undefined {
     return undefined;
 }
 
+// Treat empty or whitespace-only string claims as absent. Some IdPs (e.g. Azure AD guest accounts)
+// send given_name: "" — passing that through would coalesce to "" and overwrite a stored real name,
+// the same clobber class commit a1a01878 fixed for undefined.
+function readStringClaim(rawValue: unknown): string | undefined {
+    if (typeof rawValue !== "string") {
+        return undefined;
+    }
+    const trimmed = rawValue.trim();
+    return trimmed === "" ? undefined : trimmed;
+}
+
 function readProfileClaims(claimSource: Readonly<Record<string, unknown>>): ProfileClaims {
     return {
-        email: typeof claimSource["email"] === "string" ? claimSource["email"] : undefined,
+        email: readStringClaim(claimSource["email"]),
         emailVerified: parseEmailVerified(claimSource["email_verified"]),
-        name: typeof claimSource["name"] === "string" ? claimSource["name"] : undefined,
-        givenName: typeof claimSource["given_name"] === "string" ? claimSource["given_name"] : undefined,
-        familyName: typeof claimSource["family_name"] === "string" ? claimSource["family_name"] : undefined,
+        name: readStringClaim(claimSource["name"]),
+        givenName: readStringClaim(claimSource["given_name"]),
+        familyName: readStringClaim(claimSource["family_name"]),
     };
 }
 

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -97,28 +97,30 @@ export async function initializeOidc(): Promise<void> {
     // is treated as post-capable (the OIDC default). Fall back to Basic only when post is not
     // advertised, and fail fast when the IdP supports neither secret-based method.
     const supportedAuthenticationMethods = serverMetadata.token_endpoint_auth_methods_supported;
-    let clientAuthentication: ReturnType<typeof client.ClientSecretPost>;
     let selectedAuthenticationMethod: string;
     if (supportedAuthenticationMethods === undefined || supportedAuthenticationMethods.includes("client_secret_post")) {
-        clientAuthentication = client.ClientSecretPost(oidcConfig.clientSecret);
+        // discovery() already defaults to ClientSecretPost and, when allowHttp is set, applied
+        // allowInsecureRequests via options.execute — so the discovered Configuration is ready to
+        // reuse as-is. Rebuilding it would duplicate both the auth selection and the insecure-request
+        // opt-in and risk the two construction paths drifting apart.
+        oidcClientConfig = discoveredConfig;
         selectedAuthenticationMethod = "client_secret_post";
     } else if (supportedAuthenticationMethods.includes("client_secret_basic")) {
-        clientAuthentication = client.ClientSecretBasic(oidcConfig.clientSecret);
+        // Only the Basic fallback needs a rebuilt Configuration to override discovery()'s post default.
+        oidcClientConfig = new client.Configuration(
+            serverMetadata,
+            oidcConfig.clientId,
+            oidcConfig.clientSecret,
+            client.ClientSecretBasic(oidcConfig.clientSecret)
+        );
+        if (oidcConfig.allowHttp) {
+            client.allowInsecureRequests(oidcClientConfig);
+        }
         selectedAuthenticationMethod = "client_secret_basic";
     } else {
         throw new Error(
             `OIDC provider does not advertise a client-secret token endpoint authentication method (client_secret_post or client_secret_basic); advertised: ${supportedAuthenticationMethods.join(", ")}`
         );
-    }
-
-    oidcClientConfig = new client.Configuration(
-        serverMetadata,
-        oidcConfig.clientId,
-        oidcConfig.clientSecret,
-        clientAuthentication
-    );
-    if (oidcConfig.allowHttp) {
-        client.allowInsecureRequests(oidcClientConfig);
     }
 
     Logger.info(`OIDC token endpoint authentication method: ${selectedAuthenticationMethod}`);

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -72,9 +72,18 @@ function mergeProfileClaims(idTokenClaims: ProfileClaims, userInfoClaims: Profil
     // (attacker-editable) userinfo email with the ID token's email_verified flag would let an
     // unverified address inherit a verified status and bypass the account-linking gate.
     const emailSource = userInfoClaims.email !== undefined ? userInfoClaims : idTokenClaims;
+    // Exception: when both sources assert the *same* address, the flag describes one email, so an
+    // ID-token "verified" survives a userinfo body that simply omits email_verified. This is the
+    // common shape when the gate fetches userinfo just to fill a missing name for a verified user.
+    const emailsMatch =
+        userInfoClaims.email !== undefined &&
+        idTokenClaims.email !== undefined &&
+        userInfoClaims.email.toLowerCase() === idTokenClaims.email.toLowerCase();
     return {
         email: emailSource.email,
-        emailVerified: emailSource.emailVerified,
+        emailVerified: emailsMatch
+            ? (emailSource.emailVerified ?? idTokenClaims.emailVerified)
+            : emailSource.emailVerified,
         name: userInfoClaims.name ?? idTokenClaims.name,
         givenName: userInfoClaims.givenName ?? idTokenClaims.givenName,
         familyName: userInfoClaims.familyName ?? idTokenClaims.familyName,

--- a/apps/backend/src/services/oidcAuthentication.service.ts
+++ b/apps/backend/src/services/oidcAuthentication.service.ts
@@ -17,6 +17,34 @@ interface OidcCallbackParams {
     codeVerifier: string;
 }
 
+interface ProfileClaims {
+    email?: string | undefined;
+    emailVerified?: boolean | undefined;
+    name?: string | undefined;
+    givenName?: string | undefined;
+    familyName?: string | undefined;
+}
+
+function readProfileClaims(claimSource: Readonly<Record<string, unknown>>): ProfileClaims {
+    return {
+        email: typeof claimSource["email"] === "string" ? claimSource["email"] : undefined,
+        emailVerified: typeof claimSource["email_verified"] === "boolean" ? claimSource["email_verified"] : undefined,
+        name: typeof claimSource["name"] === "string" ? claimSource["name"] : undefined,
+        givenName: typeof claimSource["given_name"] === "string" ? claimSource["given_name"] : undefined,
+        familyName: typeof claimSource["family_name"] === "string" ? claimSource["family_name"] : undefined,
+    };
+}
+
+function hasMissingProfileClaim(profileClaims: ProfileClaims): boolean {
+    return (
+        profileClaims.email === undefined ||
+        profileClaims.emailVerified === undefined ||
+        profileClaims.name === undefined ||
+        profileClaims.givenName === undefined ||
+        profileClaims.familyName === undefined
+    );
+}
+
 let oidcClientConfig: client.Configuration;
 
 export async function initializeOidc(): Promise<void> {
@@ -83,15 +111,28 @@ export async function handleOidcCallback(callbackUrl: URL, oidcParams: OidcCallb
         throw new UnauthorizedError("No 'sub' claim found in ID token");
     }
 
-    const accessToken = tokenSet.access_token;
-    const userInfo = await client.fetchUserInfo(oidcClientConfig, accessToken, idTokenClaims.sub);
+    let profileClaims = readProfileClaims(idTokenClaims);
+
+    const userInfoEndpoint = oidcClientConfig.serverMetadata().userinfo_endpoint;
+    if (hasMissingProfileClaim(profileClaims) && userInfoEndpoint !== undefined) {
+        const userInfo = await client.fetchUserInfo(oidcClientConfig, tokenSet.access_token, idTokenClaims.sub);
+        const userInfoClaims = readProfileClaims(userInfo);
+        profileClaims = {
+            email: userInfoClaims.email ?? profileClaims.email,
+            emailVerified: userInfoClaims.emailVerified ?? profileClaims.emailVerified,
+            name: userInfoClaims.name ?? profileClaims.name,
+            givenName: userInfoClaims.givenName ?? profileClaims.givenName,
+            familyName: userInfoClaims.familyName ?? profileClaims.familyName,
+        };
+    }
 
     const user: OidcProfile = {
         sub: idTokenClaims.sub,
-        email: userInfo.email,
-        displayName: userInfo.name,
-        firstName: userInfo.given_name,
-        lastName: userInfo.family_name,
+        email: profileClaims.email,
+        emailVerified: profileClaims.emailVerified,
+        displayName: profileClaims.name,
+        firstName: profileClaims.givenName,
+        lastName: profileClaims.familyName,
     };
 
     const threatSeaToken = await buildThreatSeaAccessToken(user);

--- a/apps/backend/tests/config-oidc-scope.test.ts
+++ b/apps/backend/tests/config-oidc-scope.test.ts
@@ -1,0 +1,19 @@
+import { validateOidcScope } from "#config/config.js";
+
+describe("validateOidcScope", () => {
+    it("returns the scope unchanged when it contains openid", () => {
+        expect(validateOidcScope("openid profile email")).toBe("openid profile email");
+    });
+
+    it("accepts openid in any position", () => {
+        expect(validateOidcScope("profile openid email")).toBe("profile openid email");
+    });
+
+    it("throws when the openid scope is missing", () => {
+        expect(() => validateOidcScope("profile email")).toThrow(/openid/);
+    });
+
+    it("does not treat a substring as the openid scope", () => {
+        expect(() => validateOidcScope("openidconnect profile")).toThrow(/openid/);
+    });
+});

--- a/apps/backend/tests/fixed-authentication.test.ts
+++ b/apps/backend/tests/fixed-authentication.test.ts
@@ -1,0 +1,23 @@
+import { decodeJwt } from "jose";
+import { eq } from "drizzle-orm";
+import { db } from "#db/index.js";
+import { users } from "#db/schema.js";
+import { getFixedLoginToken } from "#services/fixedAuthentication.service.js";
+
+describe("getFixedLoginToken account linking", () => {
+    it("links a pre-existing unlinked user that matches a fixed profile email", async () => {
+        // Fixed profile index 1 is used by no other test, so its sub/email stay isolated here.
+        const existingUser = (
+            await db
+                .insert(users)
+                .values({ firstname: "Seeded", lastname: "User", email: "test2@test.test" })
+                .returning()
+        ).at(0)!;
+
+        const accessToken = await getFixedLoginToken("/login?testUser=1");
+
+        expect(decodeJwt(accessToken)["userId"]).toBe(existingUser.id);
+        const linkedUser = await db.query.users.findFirst({ where: eq(users.id, existingUser.id) });
+        expect(linkedUser?.oidcSub).toBe("testid2");
+    });
+});

--- a/apps/backend/tests/health.test.ts
+++ b/apps/backend/tests/health.test.ts
@@ -1,0 +1,12 @@
+import request from "supertest";
+import { app } from "#server.js";
+
+describe("GET /api/health", () => {
+    it("returns ok with a no-store cache directive", async () => {
+        const res = await request(app).get("/api/health");
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual(expect.objectContaining({ ok: true }));
+        expect(res.headers["cache-control"]).toBe("no-store");
+    });
+});

--- a/apps/backend/tests/last-login.test.ts
+++ b/apps/backend/tests/last-login.test.ts
@@ -25,6 +25,7 @@ describe("last login tracking", () => {
         await buildThreatSeaAccessToken({
             sub: "last-login-insert-sub",
             email: "last-login-insert@threatsea.test",
+            emailVerified: true,
             firstName: "Insert",
             lastName: "Path",
         });
@@ -41,6 +42,7 @@ describe("last login tracking", () => {
         const profile = {
             sub: "last-login-unchanged-sub",
             email: "last-login-unchanged@threatsea.test",
+            emailVerified: true,
             firstName: "Unchanged",
             lastName: "Path",
         };
@@ -58,6 +60,7 @@ describe("last login tracking", () => {
         const profile = {
             sub: "last-login-noupdate-sub",
             email: "last-login-noupdate@threatsea.test",
+            emailVerified: true,
             firstName: "No",
             lastName: "Update",
         };
@@ -77,6 +80,7 @@ describe("last login tracking", () => {
         const profile = {
             sub: "last-login-renamed-sub",
             email: "last-login-renamed@threatsea.test",
+            emailVerified: true,
             firstName: "Original",
             lastName: "Name",
         };

--- a/apps/backend/tests/last-login.test.ts
+++ b/apps/backend/tests/last-login.test.ts
@@ -106,6 +106,7 @@ describe("last login tracking", () => {
         await buildThreatSeaAccessToken({
             sub: "last-login-link-sub",
             email: "last-login-link@threatsea.test",
+            emailVerified: true,
             firstName: "Link",
             lastName: "Path",
         });

--- a/apps/backend/tests/oidc-account-linking.test.ts
+++ b/apps/backend/tests/oidc-account-linking.test.ts
@@ -153,22 +153,6 @@ describe("buildThreatSeaAccessToken account linking", () => {
         expect(decodeJwt(accessToken)["userId"]).toBe(existingUser.id);
     });
 
-    it("creates a fresh account even when the email is not verified", async () => {
-        const profile: OidcProfile = {
-            sub: "sub-fresh",
-            email: "fresh.account@example.com",
-            emailVerified: false,
-            firstName: "Fresh",
-            lastName: "Account",
-        };
-
-        const accessToken = await buildThreatSeaAccessToken(profile);
-
-        expect(accessToken).toBeTypeOf("string");
-        const createdUser = await db.query.users.findFirst({ where: eq(users.oidcSub, "sub-fresh") });
-        expect(createdUser?.email).toBe("fresh.account@example.com");
-    });
-
     it("rejects when two unlinked users share the email", async () => {
         await createUser({ firstname: "First", lastname: "Duplicate", email: "duplicate@example.com" });
         await createUser({ firstname: "Second", lastname: "Duplicate", email: "duplicate@example.com" });
@@ -257,6 +241,83 @@ describe("buildThreatSeaAccessToken account linking", () => {
         const createdUser = await db.query.users.findFirst({ where: eq(users.oidcSub, "sub-new-noname") });
         expect(createdUser?.firstname).toBe("");
         expect(createdUser?.lastname).toBe("new.noname@example.com");
+    });
+});
+
+describe("buildThreatSeaAccessToken verified-email enforcement", () => {
+    it("keeps a linked user's stored email when the incoming email is unverified", async () => {
+        const existing = await createUser({
+            firstname: "Linked",
+            lastname: "User",
+            email: "real@example.com",
+            oidcSub: "sub-linked-2",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-linked-2",
+            email: "victim@corp.com",
+            emailVerified: false,
+            firstName: "Linked",
+            lastName: "User",
+        };
+
+        const accessToken = await buildThreatSeaAccessToken(profile);
+
+        expect(decodeJwt(accessToken)["userId"]).toBe(existing.id);
+        expect(decodeJwt(accessToken)["email"]).toBe("real@example.com");
+        const stored = await findUserById(existing.id);
+        expect(stored?.email).toBe("real@example.com");
+    });
+
+    it("overwrites a linked user's email when the incoming email is verified", async () => {
+        const existing = await createUser({
+            firstname: "Linked",
+            lastname: "User",
+            email: "old@example.com",
+            oidcSub: "sub-linked-3",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-linked-3",
+            email: "new@example.com",
+            emailVerified: true,
+            firstName: "Linked",
+            lastName: "User",
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const stored = await findUserById(existing.id);
+        expect(stored?.email).toBe("new@example.com");
+    });
+
+    it("refuses to create a new account from an unverified email", async () => {
+        const profile: OidcProfile = {
+            sub: "sub-new-unverified",
+            email: "ceo@company.com",
+            emailVerified: false,
+            firstName: "Cee",
+            lastName: "Oh",
+        };
+
+        await expect(buildThreatSeaAccessToken(profile)).rejects.toThrow(UnauthorizedError);
+        const created = await db.query.users.findFirst({ where: eq(users.oidcSub, "sub-new-unverified") });
+        expect(created).toBeUndefined();
+    });
+
+    it("creates a new account from an unverified email when unverified linking is enabled", async () => {
+        configOverrides.ALLOW_UNVERIFIED_EMAIL_LINKING = true;
+        const profile: OidcProfile = {
+            sub: "sub-new-flag",
+            email: "flagged@example.com",
+            emailVerified: false,
+            firstName: "Flag",
+            lastName: "Ged",
+        };
+
+        const accessToken = await buildThreatSeaAccessToken(profile);
+
+        expect(decodeJwt(accessToken)["email"]).toBe("flagged@example.com");
+        const created = await db.query.users.findFirst({ where: eq(users.oidcSub, "sub-new-flag") });
+        expect(created).toBeDefined();
     });
 });
 

--- a/apps/backend/tests/oidc-account-linking.test.ts
+++ b/apps/backend/tests/oidc-account-linking.test.ts
@@ -1,0 +1,185 @@
+import { decodeJwt } from "jose";
+import { eq } from "drizzle-orm";
+import { db } from "#db/index.js";
+import { users } from "#db/schema.js";
+import { buildThreatSeaAccessToken, OidcProfile } from "#services/auth.service.js";
+import { UnauthorizedError } from "#errors/unauthorized.error.js";
+
+const configOverrides = vi.hoisted(() => ({ ALLOW_UNVERIFIED_EMAIL_LINKING: false }));
+
+vi.mock("#config/config.js", async (importOriginal) => {
+    const actualConfig = await importOriginal<typeof import("#config/config.js")>();
+    return {
+        ...actualConfig,
+        get ALLOW_UNVERIFIED_EMAIL_LINKING() {
+            return configOverrides.ALLOW_UNVERIFIED_EMAIL_LINKING;
+        },
+    };
+});
+
+async function createUser(values: { firstname: string; lastname: string; email: string; oidcSub?: string }) {
+    return (await db.insert(users).values(values).returning()).at(0)!;
+}
+
+async function findUserById(userId: number) {
+    return await db.query.users.findFirst({ where: eq(users.id, userId) });
+}
+
+beforeEach(() => {
+    configOverrides.ALLOW_UNVERIFIED_EMAIL_LINKING = false;
+});
+
+describe("buildThreatSeaAccessToken account linking", () => {
+    it("links an existing unlinked user when the email is verified", async () => {
+        const existingUser = await createUser({
+            firstname: "Linda",
+            lastname: "Linkable",
+            email: "linda.linkable@example.com",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-linkable",
+            email: "linda.linkable@example.com",
+            emailVerified: true,
+            firstName: "Linda",
+            lastName: "Linkable",
+        };
+
+        const accessToken = await buildThreatSeaAccessToken(profile);
+
+        expect(decodeJwt(accessToken)["userId"]).toBe(existingUser.id);
+        const linkedUser = await findUserById(existingUser.id);
+        expect(linkedUser?.oidcSub).toBe("sub-linkable");
+    });
+
+    it("refuses to link an existing user when the email is not verified", async () => {
+        const existingUser = await createUser({
+            firstname: "Victor",
+            lastname: "Victim",
+            email: "victor.victim@example.com",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-attacker",
+            email: "victor.victim@example.com",
+            emailVerified: false,
+            firstName: "Eve",
+            lastName: "Attacker",
+        };
+
+        await expect(buildThreatSeaAccessToken(profile)).rejects.toThrow(UnauthorizedError);
+
+        const unchangedUser = await findUserById(existingUser.id);
+        expect(unchangedUser?.oidcSub).toBeNull();
+        expect(unchangedUser?.firstname).toBe("Victor");
+    });
+
+    it("refuses to link an existing user when the email_verified claim is missing", async () => {
+        const existingUser = await createUser({
+            firstname: "Missy",
+            lastname: "Missingclaim",
+            email: "missy.missingclaim@example.com",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-missing-claim",
+            email: "missy.missingclaim@example.com",
+            firstName: "Missy",
+            lastName: "Missingclaim",
+        };
+
+        await expect(buildThreatSeaAccessToken(profile)).rejects.toThrow(UnauthorizedError);
+
+        const unchangedUser = await findUserById(existingUser.id);
+        expect(unchangedUser?.oidcSub).toBeNull();
+    });
+
+    it("links an unverified email when the escape hatch is enabled", async () => {
+        configOverrides.ALLOW_UNVERIFIED_EMAIL_LINKING = true;
+        const existingUser = await createUser({
+            firstname: "Opt",
+            lastname: "In",
+            email: "opt.in@example.com",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-opt-in",
+            email: "opt.in@example.com",
+            emailVerified: false,
+            firstName: "Opt",
+            lastName: "In",
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const linkedUser = await findUserById(existingUser.id);
+        expect(linkedUser?.oidcSub).toBe("sub-opt-in");
+    });
+
+    it("logs in an already-linked user regardless of email_verified", async () => {
+        const existingUser = await createUser({
+            firstname: "Already",
+            lastname: "Linked",
+            email: "already.linked@example.com",
+            oidcSub: "sub-already-linked",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-already-linked",
+            email: "already.linked@example.com",
+            emailVerified: false,
+            firstName: "Already",
+            lastName: "Linked",
+        };
+
+        const accessToken = await buildThreatSeaAccessToken(profile);
+
+        expect(decodeJwt(accessToken)["userId"]).toBe(existingUser.id);
+    });
+
+    it("creates a fresh account even when the email is not verified", async () => {
+        const profile: OidcProfile = {
+            sub: "sub-fresh",
+            email: "fresh.account@example.com",
+            emailVerified: false,
+            firstName: "Fresh",
+            lastName: "Account",
+        };
+
+        const accessToken = await buildThreatSeaAccessToken(profile);
+
+        expect(accessToken).toBeTypeOf("string");
+        const createdUser = await db.query.users.findFirst({ where: eq(users.oidcSub, "sub-fresh") });
+        expect(createdUser?.email).toBe("fresh.account@example.com");
+    });
+
+    it("rejects when two unlinked users share the email", async () => {
+        await createUser({ firstname: "First", lastname: "Duplicate", email: "duplicate@example.com" });
+        await createUser({ firstname: "Second", lastname: "Duplicate", email: "duplicate@example.com" });
+        const profile: OidcProfile = {
+            sub: "sub-ambiguous",
+            email: "duplicate@example.com",
+            emailVerified: true,
+            firstName: "Which",
+            lastName: "One",
+        };
+
+        await expect(buildThreatSeaAccessToken(profile)).rejects.toThrow("Ambiguous account link for email");
+    });
+
+    it("persists a changed name on login", async () => {
+        const existingUser = await createUser({
+            firstname: "Old",
+            lastname: "Name",
+            email: "rename.me@example.com",
+            oidcSub: "sub-rename",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-rename",
+            email: "rename.me@example.com",
+            emailVerified: true,
+            firstName: "New",
+            lastName: "Name",
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const updatedUser = await findUserById(existingUser.id);
+        expect(updatedUser?.firstname).toBe("New");
+    });
+});

--- a/apps/backend/tests/oidc-account-linking.test.ts
+++ b/apps/backend/tests/oidc-account-linking.test.ts
@@ -51,6 +51,27 @@ describe("buildThreatSeaAccessToken account linking", () => {
         expect(linkedUser?.oidcSub).toBe("sub-linkable");
     });
 
+    it("links a case-mismatched existing user and normalizes the stored email", async () => {
+        const existingUser = await createUser({
+            firstname: "Casey",
+            lastname: "Mixed",
+            email: "Casey.Mixed@Example.com",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-case",
+            email: "casey.mixed@example.com",
+            emailVerified: true,
+            firstName: "Casey",
+            lastName: "Mixed",
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const linkedUser = await findUserById(existingUser.id);
+        expect(linkedUser?.oidcSub).toBe("sub-case");
+        expect(linkedUser?.email).toBe("casey.mixed@example.com");
+    });
+
     it("refuses to link an existing user when the email is not verified", async () => {
         const existingUser = await createUser({
             firstname: "Victor",

--- a/apps/backend/tests/oidc-account-linking.test.ts
+++ b/apps/backend/tests/oidc-account-linking.test.ts
@@ -2,7 +2,7 @@ import { decodeJwt } from "jose";
 import { eq } from "drizzle-orm";
 import { db } from "#db/index.js";
 import { users } from "#db/schema.js";
-import { buildThreatSeaAccessToken, findLinkableUser, OidcProfile } from "#services/auth.service.js";
+import { buildThreatSeaAccessToken, findOidcUserBySub, OidcProfile } from "#services/auth.service.js";
 import { UnauthorizedError } from "#errors/unauthorized.error.js";
 
 const configOverrides = vi.hoisted(() => ({ ALLOW_UNVERIFIED_EMAIL_LINKING: false }));
@@ -239,7 +239,7 @@ describe("buildThreatSeaAccessToken account linking", () => {
     });
 });
 
-describe("findLinkableUser", () => {
+describe("findOidcUserBySub", () => {
     it("returns lastLoginAt for a user matched by oidc sub", async () => {
         await createUser({
             firstname: "Sub",
@@ -248,39 +248,26 @@ describe("findLinkableUser", () => {
             oidcSub: "sub-findable",
         });
 
-        const linkableUser = await findLinkableUser("sub-findable", undefined);
+        const knownUser = await findOidcUserBySub("sub-findable");
 
-        expect(linkableUser?.lastLoginAt).toBeTypeOf("string");
-    });
-
-    it("falls back to an unlinked email match when no sub matches, case-insensitively", async () => {
-        await createUser({
-            firstname: "Email",
-            lastname: "Match",
-            email: "email.match@example.com",
-        });
-
-        const linkableUser = await findLinkableUser("sub-not-present", "Email.Match@example.com");
-
-        expect(linkableUser?.lastLoginAt).toBeTypeOf("string");
-    });
-
-    it("ignores an email that already belongs to a linked account", async () => {
-        await createUser({
-            firstname: "Linked",
-            lastname: "Already",
-            email: "linked.already@example.com",
-            oidcSub: "sub-owns-email",
-        });
-
-        const linkableUser = await findLinkableUser("different-sub", "linked.already@example.com");
-
-        expect(linkableUser).toBeUndefined();
+        expect(knownUser?.lastLoginAt).toBeTypeOf("string");
     });
 
     it("returns undefined for an unknown user", async () => {
-        const linkableUser = await findLinkableUser("sub-unknown", "unknown@example.com");
+        const knownUser = await findOidcUserBySub("sub-unknown");
 
-        expect(linkableUser).toBeUndefined();
+        expect(knownUser).toBeUndefined();
+    });
+
+    it("returns undefined when only an unlinked email matches (never OIDC-synced, must not count as fresh)", async () => {
+        await createUser({
+            firstname: "Email",
+            lastname: "Only",
+            email: "email.only.unsynced@example.com",
+        });
+
+        const knownUser = await findOidcUserBySub("sub-never-synced-this-email");
+
+        expect(knownUser).toBeUndefined();
     });
 });

--- a/apps/backend/tests/oidc-account-linking.test.ts
+++ b/apps/backend/tests/oidc-account-linking.test.ts
@@ -203,6 +203,40 @@ describe("buildThreatSeaAccessToken account linking", () => {
         const updatedUser = await findUserById(existingUser.id);
         expect(updatedUser?.firstname).toBe("New");
     });
+
+    it("keeps stored names when an existing user's incoming profile omits them", async () => {
+        const existingUser = await createUser({
+            firstname: "Keep",
+            lastname: "Mename",
+            email: "keep.mename@example.com",
+            oidcSub: "sub-keep-names",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-keep-names",
+            email: "keep.mename@example.com",
+            emailVerified: true,
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const unchangedUser = await findUserById(existingUser.id);
+        expect(unchangedUser?.firstname).toBe("Keep");
+        expect(unchangedUser?.lastname).toBe("Mename");
+    });
+
+    it("applies the email fallback for a brand-new user with no names", async () => {
+        const profile: OidcProfile = {
+            sub: "sub-new-noname",
+            email: "new.noname@example.com",
+            emailVerified: true,
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const createdUser = await db.query.users.findFirst({ where: eq(users.oidcSub, "sub-new-noname") });
+        expect(createdUser?.firstname).toBe("");
+        expect(createdUser?.lastname).toBe("new.noname@example.com");
+    });
 });
 
 describe("findLinkableUser", () => {

--- a/apps/backend/tests/oidc-account-linking.test.ts
+++ b/apps/backend/tests/oidc-account-linking.test.ts
@@ -224,6 +224,27 @@ describe("buildThreatSeaAccessToken account linking", () => {
         expect(unchangedUser?.lastname).toBe("Mename");
     });
 
+    it("keeps an existing user's stored lastname when the profile sends a display name but no family name", async () => {
+        const existingUser = await createUser({
+            firstname: "Dana",
+            lastname: "Storedlast",
+            email: "dana.storedlast@example.com",
+            oidcSub: "sub-displayname-only",
+        });
+        const profile: OidcProfile = {
+            sub: "sub-displayname-only",
+            email: "dana.storedlast@example.com",
+            emailVerified: true,
+            displayName: "Dana Displayname",
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const unchangedUser = await findUserById(existingUser.id);
+        expect(unchangedUser?.firstname).toBe("Dana");
+        expect(unchangedUser?.lastname).toBe("Storedlast");
+    });
+
     it("applies the email fallback for a brand-new user with no names", async () => {
         const profile: OidcProfile = {
             sub: "sub-new-noname",

--- a/apps/backend/tests/oidc-account-linking.test.ts
+++ b/apps/backend/tests/oidc-account-linking.test.ts
@@ -321,8 +321,42 @@ describe("buildThreatSeaAccessToken verified-email enforcement", () => {
     });
 });
 
+describe("buildThreatSeaAccessToken profile sync tracking", () => {
+    it("stamps profileSyncedAt when the login synced userinfo", async () => {
+        const profile: OidcProfile = {
+            sub: "sub-synced",
+            email: "synced@example.com",
+            emailVerified: true,
+            firstName: "Sy",
+            lastName: "Nced",
+            profileSynced: true,
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const created = await db.query.users.findFirst({ where: eq(users.oidcSub, "sub-synced") });
+        expect(created?.profileSyncedAt).not.toBeNull();
+    });
+
+    it("leaves profileSyncedAt null when the login did not sync userinfo", async () => {
+        const profile: OidcProfile = {
+            sub: "sub-unsynced",
+            email: "unsynced@example.com",
+            emailVerified: true,
+            firstName: "Un",
+            lastName: "Synced",
+            profileSynced: false,
+        };
+
+        await buildThreatSeaAccessToken(profile);
+
+        const created = await db.query.users.findFirst({ where: eq(users.oidcSub, "sub-unsynced") });
+        expect(created?.profileSyncedAt).toBeNull();
+    });
+});
+
 describe("findOidcUserBySub", () => {
-    it("returns lastLoginAt for a user matched by oidc sub", async () => {
+    it("returns profileSyncedAt for a user matched by oidc sub", async () => {
         await createUser({
             firstname: "Sub",
             lastname: "Match",
@@ -332,7 +366,8 @@ describe("findOidcUserBySub", () => {
 
         const knownUser = await findOidcUserBySub("sub-findable");
 
-        expect(knownUser?.lastLoginAt).toBeTypeOf("string");
+        expect(knownUser).toHaveProperty("profileSyncedAt");
+        expect(knownUser?.profileSyncedAt).toBeNull();
     });
 
     it("returns undefined for an unknown user", async () => {

--- a/apps/backend/tests/oidc-account-linking.test.ts
+++ b/apps/backend/tests/oidc-account-linking.test.ts
@@ -2,7 +2,7 @@ import { decodeJwt } from "jose";
 import { eq } from "drizzle-orm";
 import { db } from "#db/index.js";
 import { users } from "#db/schema.js";
-import { buildThreatSeaAccessToken, OidcProfile } from "#services/auth.service.js";
+import { buildThreatSeaAccessToken, findLinkableUser, OidcProfile } from "#services/auth.service.js";
 import { UnauthorizedError } from "#errors/unauthorized.error.js";
 
 const configOverrides = vi.hoisted(() => ({ ALLOW_UNVERIFIED_EMAIL_LINKING: false }));
@@ -202,5 +202,51 @@ describe("buildThreatSeaAccessToken account linking", () => {
 
         const updatedUser = await findUserById(existingUser.id);
         expect(updatedUser?.firstname).toBe("New");
+    });
+});
+
+describe("findLinkableUser", () => {
+    it("returns lastLoginAt for a user matched by oidc sub", async () => {
+        await createUser({
+            firstname: "Sub",
+            lastname: "Match",
+            email: "sub.match@example.com",
+            oidcSub: "sub-findable",
+        });
+
+        const linkableUser = await findLinkableUser("sub-findable", undefined);
+
+        expect(linkableUser?.lastLoginAt).toBeTypeOf("string");
+    });
+
+    it("falls back to an unlinked email match when no sub matches, case-insensitively", async () => {
+        await createUser({
+            firstname: "Email",
+            lastname: "Match",
+            email: "email.match@example.com",
+        });
+
+        const linkableUser = await findLinkableUser("sub-not-present", "Email.Match@example.com");
+
+        expect(linkableUser?.lastLoginAt).toBeTypeOf("string");
+    });
+
+    it("ignores an email that already belongs to a linked account", async () => {
+        await createUser({
+            firstname: "Linked",
+            lastname: "Already",
+            email: "linked.already@example.com",
+            oidcSub: "sub-owns-email",
+        });
+
+        const linkableUser = await findLinkableUser("different-sub", "linked.already@example.com");
+
+        expect(linkableUser).toBeUndefined();
+    });
+
+    it("returns undefined for an unknown user", async () => {
+        const linkableUser = await findLinkableUser("sub-unknown", "unknown@example.com");
+
+        expect(linkableUser).toBeUndefined();
     });
 });

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -251,6 +251,35 @@ describe("handleOidcCallback profile building", () => {
         );
     });
 
+    it("keeps the ID token's verified flag when a stale user's userinfo repeats the same email without email_verified", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        // Stale existing user, so the gate fetches userinfo to enrich the missing name. The ID token
+        // vouched the email as verified; userinfo returns the very same email but omits email_verified.
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: true,
+            given_name: "Alice",
+        });
+        vi.mocked(findLinkableUser).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
+        vi.mocked(client.fetchUserInfo).mockResolvedValue({
+            sub: "subject-1",
+            email: "alice@example.com",
+            family_name: "Smith",
+        } as never);
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(client.fetchUserInfo).toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
+            expect.objectContaining({ email: "alice@example.com", emailVerified: true, lastName: "Smith" })
+        );
+    });
+
     it("treats a string email_verified claim as verified", async () => {
         await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
         mockAuthorizationCodeGrant({

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -415,12 +415,22 @@ describe("initializeOidc client authentication detection", () => {
         expect(client.Configuration).not.toHaveBeenCalled();
     });
 
-    it("reuses the discovered configuration when the metadata field is absent", async () => {
+    it("rebuilds with client_secret_basic when the metadata field is absent (spec default)", async () => {
+        const basicAuthentication = { method: "client_secret_basic" };
+        vi.mocked(client.ClientSecretBasic).mockReturnValue(basicAuthentication as never);
+
         await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
 
+        // Discovery omits the field, so RFC 8414's client_secret_basic default applies — discovery()
+        // defaults the Configuration to post, so the omitted case must rebuild with basic.
         expect(client.ClientSecretPost).not.toHaveBeenCalled();
-        expect(client.ClientSecretBasic).not.toHaveBeenCalled();
-        expect(client.Configuration).not.toHaveBeenCalled();
+        expect(client.ClientSecretBasic).toHaveBeenCalledWith("threatsea-secret");
+        expect(client.Configuration).toHaveBeenCalledWith(
+            expect.objectContaining({ issuer: "https://idp.example.com" }),
+            "threatsea-client",
+            "threatsea-secret",
+            basicAuthentication
+        );
     });
 
     it("reuses the discovered configuration when the IdP only supports post", async () => {

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -147,3 +147,48 @@ describe("handleOidcCallback profile building", () => {
         expect(buildThreatSeaAccessToken).not.toHaveBeenCalled();
     });
 });
+
+describe("initializeOidc client authentication detection", () => {
+    it("uses client_secret_basic when the IdP advertises it", async () => {
+        const basicAuthentication = { method: "client_secret_basic" };
+        vi.mocked(client.ClientSecretBasic).mockReturnValue(basicAuthentication as never);
+
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post"],
+        });
+
+        expect(client.ClientSecretBasic).toHaveBeenCalledWith("threatsea-secret");
+        expect(client.Configuration).toHaveBeenCalledWith(
+            expect.objectContaining({ issuer: "https://idp.example.com" }),
+            "threatsea-client",
+            "threatsea-secret",
+            basicAuthentication
+        );
+    });
+
+    it("uses client_secret_basic when the metadata field is absent", async () => {
+        await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
+
+        expect(client.ClientSecretBasic).toHaveBeenCalledWith("threatsea-secret");
+        expect(client.ClientSecretPost).not.toHaveBeenCalled();
+    });
+
+    it("keeps client_secret_post when the IdP only supports post", async () => {
+        const postAuthentication = { method: "client_secret_post" };
+        vi.mocked(client.ClientSecretPost).mockReturnValue(postAuthentication as never);
+
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            token_endpoint_auth_methods_supported: ["client_secret_post"],
+        });
+
+        expect(client.ClientSecretBasic).not.toHaveBeenCalled();
+        expect(client.Configuration).toHaveBeenCalledWith(
+            expect.anything(),
+            "threatsea-client",
+            "threatsea-secret",
+            postAuthentication
+        );
+    });
+});

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -146,32 +146,104 @@ describe("handleOidcCallback profile building", () => {
         await expect(handleOidcCallback(callbackUrl, callbackParameters)).rejects.toThrow(UnauthorizedError);
         expect(buildThreatSeaAccessToken).not.toHaveBeenCalled();
     });
+
+    it("keeps the ID token's verified email and skips userinfo when only a name claim is missing", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        // ID token already carries a verified email but omits family_name — a common IdP shape where
+        // names live only in userinfo. Fetching userinfo here would drop the verified flag (userinfo
+        // rarely re-asserts email_verified) and break linking for a genuinely-verified user.
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: true,
+            given_name: "Alice",
+        });
+        // If userinfo were (wrongly) consulted, it would swap in a different email with no verification.
+        vi.mocked(client.fetchUserInfo).mockResolvedValue({
+            sub: "subject-1",
+            email: "attacker@example.com",
+            family_name: "Smith",
+        } as never);
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(client.fetchUserInfo).not.toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
+            expect.objectContaining({ email: "alice@example.com", emailVerified: true })
+        );
+    });
+
+    it("takes email and email_verified as an atomic pair from userinfo when the ID token omits verification", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        // ID token has an email but no email_verified, so userinfo must be consulted. Its email and
+        // verification flag are taken together — never a userinfo email with a foreign verified flag.
+        mockAuthorizationCodeGrant({ sub: "subject-1", email: "stale@example.com" });
+        vi.mocked(client.fetchUserInfo).mockResolvedValue({
+            sub: "subject-1",
+            email: "attacker@example.com",
+            given_name: "Attacker",
+        } as never);
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(client.fetchUserInfo).toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
+            expect.objectContaining({ email: "attacker@example.com", emailVerified: undefined })
+        );
+    });
+
+    it("treats a string email_verified claim as verified", async () => {
+        await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "user@example.com",
+            email_verified: "true",
+            name: "User Example",
+            given_name: "User",
+            family_name: "Example",
+        });
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(client.fetchUserInfo).not.toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(expect.objectContaining({ emailVerified: true }));
+    });
 });
 
 describe("initializeOidc client authentication detection", () => {
-    it("uses client_secret_basic when the IdP advertises it", async () => {
-        const basicAuthentication = { method: "client_secret_basic" };
-        vi.mocked(client.ClientSecretBasic).mockReturnValue(basicAuthentication as never);
+    it("prefers client_secret_post when the IdP advertises both methods", async () => {
+        const postAuthentication = { method: "client_secret_post" };
+        vi.mocked(client.ClientSecretPost).mockReturnValue(postAuthentication as never);
 
         await initializeOidcWithServerMetadata({
             issuer: "https://idp.example.com",
             token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post"],
         });
 
-        expect(client.ClientSecretBasic).toHaveBeenCalledWith("threatsea-secret");
+        expect(client.ClientSecretBasic).not.toHaveBeenCalled();
+        expect(client.ClientSecretPost).toHaveBeenCalledWith("threatsea-secret");
         expect(client.Configuration).toHaveBeenCalledWith(
             expect.objectContaining({ issuer: "https://idp.example.com" }),
             "threatsea-client",
             "threatsea-secret",
-            basicAuthentication
+            postAuthentication
         );
     });
 
-    it("uses client_secret_basic when the metadata field is absent", async () => {
+    it("defaults to client_secret_post when the metadata field is absent", async () => {
         await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
 
-        expect(client.ClientSecretBasic).toHaveBeenCalledWith("threatsea-secret");
-        expect(client.ClientSecretPost).not.toHaveBeenCalled();
+        expect(client.ClientSecretPost).toHaveBeenCalledWith("threatsea-secret");
+        expect(client.ClientSecretBasic).not.toHaveBeenCalled();
     });
 
     it("keeps client_secret_post when the IdP only supports post", async () => {
@@ -190,5 +262,35 @@ describe("initializeOidc client authentication detection", () => {
             "threatsea-secret",
             postAuthentication
         );
+    });
+
+    it("falls back to client_secret_basic when the IdP only supports basic", async () => {
+        const basicAuthentication = { method: "client_secret_basic" };
+        vi.mocked(client.ClientSecretBasic).mockReturnValue(basicAuthentication as never);
+
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            token_endpoint_auth_methods_supported: ["client_secret_basic"],
+        });
+
+        expect(client.ClientSecretPost).not.toHaveBeenCalled();
+        expect(client.Configuration).toHaveBeenCalledWith(
+            expect.anything(),
+            "threatsea-client",
+            "threatsea-secret",
+            basicAuthentication
+        );
+    });
+
+    it("throws when the IdP supports no client-secret authentication method", async () => {
+        await expect(
+            initializeOidcWithServerMetadata({
+                issuer: "https://idp.example.com",
+                token_endpoint_auth_methods_supported: ["private_key_jwt"],
+            })
+        ).rejects.toThrow(/client-secret/);
+
+        expect(client.ClientSecretPost).not.toHaveBeenCalled();
+        expect(client.ClientSecretBasic).not.toHaveBeenCalled();
     });
 });

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -220,51 +220,39 @@ describe("handleOidcCallback profile building", () => {
 });
 
 describe("initializeOidc client authentication detection", () => {
-    it("prefers client_secret_post when the IdP advertises both methods", async () => {
-        const postAuthentication = { method: "client_secret_post" };
-        vi.mocked(client.ClientSecretPost).mockReturnValue(postAuthentication as never);
-
+    it("reuses the discovered configuration for client_secret_post without rebuilding", async () => {
         await initializeOidcWithServerMetadata({
             issuer: "https://idp.example.com",
             token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post"],
         });
 
+        // discovery() already returns a Configuration defaulting to ClientSecretPost, so the post path
+        // must reuse it rather than re-selecting the auth method or constructing a second Configuration.
         expect(client.ClientSecretBasic).not.toHaveBeenCalled();
-        expect(client.ClientSecretPost).toHaveBeenCalledWith("threatsea-secret");
-        expect(client.Configuration).toHaveBeenCalledWith(
-            expect.objectContaining({ issuer: "https://idp.example.com" }),
-            "threatsea-client",
-            "threatsea-secret",
-            postAuthentication
-        );
+        expect(client.ClientSecretPost).not.toHaveBeenCalled();
+        expect(client.Configuration).not.toHaveBeenCalled();
     });
 
-    it("defaults to client_secret_post when the metadata field is absent", async () => {
+    it("reuses the discovered configuration when the metadata field is absent", async () => {
         await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
 
-        expect(client.ClientSecretPost).toHaveBeenCalledWith("threatsea-secret");
+        expect(client.ClientSecretPost).not.toHaveBeenCalled();
         expect(client.ClientSecretBasic).not.toHaveBeenCalled();
+        expect(client.Configuration).not.toHaveBeenCalled();
     });
 
-    it("keeps client_secret_post when the IdP only supports post", async () => {
-        const postAuthentication = { method: "client_secret_post" };
-        vi.mocked(client.ClientSecretPost).mockReturnValue(postAuthentication as never);
-
+    it("reuses the discovered configuration when the IdP only supports post", async () => {
         await initializeOidcWithServerMetadata({
             issuer: "https://idp.example.com",
             token_endpoint_auth_methods_supported: ["client_secret_post"],
         });
 
         expect(client.ClientSecretBasic).not.toHaveBeenCalled();
-        expect(client.Configuration).toHaveBeenCalledWith(
-            expect.anything(),
-            "threatsea-client",
-            "threatsea-secret",
-            postAuthentication
-        );
+        expect(client.ClientSecretPost).not.toHaveBeenCalled();
+        expect(client.Configuration).not.toHaveBeenCalled();
     });
 
-    it("falls back to client_secret_basic when the IdP only supports basic", async () => {
+    it("rebuilds the configuration with client_secret_basic when the IdP only supports basic", async () => {
         const basicAuthentication = { method: "client_secret_basic" };
         vi.mocked(client.ClientSecretBasic).mockReturnValue(basicAuthentication as never);
 
@@ -274,8 +262,9 @@ describe("initializeOidc client authentication detection", () => {
         });
 
         expect(client.ClientSecretPost).not.toHaveBeenCalled();
+        expect(client.ClientSecretBasic).toHaveBeenCalledWith("threatsea-secret");
         expect(client.Configuration).toHaveBeenCalledWith(
-            expect.anything(),
+            expect.objectContaining({ issuer: "https://idp.example.com" }),
             "threatsea-client",
             "threatsea-secret",
             basicAuthentication
@@ -292,5 +281,6 @@ describe("initializeOidc client authentication detection", () => {
 
         expect(client.ClientSecretPost).not.toHaveBeenCalled();
         expect(client.ClientSecretBasic).not.toHaveBeenCalled();
+        expect(client.Configuration).not.toHaveBeenCalled();
     });
 });

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -280,6 +280,37 @@ describe("handleOidcCallback profile building", () => {
         );
     });
 
+    it("prefers the ID token's email_verified over a conflicting userinfo value for the same email", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        // Stale existing user, so the gate fetches userinfo to enrich the missing name. Both sources
+        // agree on the email, but userinfo asserts a conflicting email_verified — the signed ID
+        // token is the authoritative assertion for this authentication event and must win.
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: true,
+            given_name: "Alice",
+        });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
+        vi.mocked(client.fetchUserInfo).mockResolvedValue({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: false,
+            family_name: "Smith",
+        } as never);
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(client.fetchUserInfo).toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
+            expect.objectContaining({ email: "alice@example.com", emailVerified: true, lastName: "Smith" })
+        );
+    });
+
     it("treats a string email_verified claim as verified", async () => {
         await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
         mockAuthorizationCodeGrant({

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -93,6 +93,7 @@ describe("handleOidcCallback profile building", () => {
             displayName: "User Example",
             firstName: "User",
             lastName: "Example",
+            profileSynced: false,
         });
     });
 
@@ -122,6 +123,7 @@ describe("handleOidcCallback profile building", () => {
             displayName: "Fresh Name",
             firstName: "Fresh",
             lastName: "Name",
+            profileSynced: true,
         });
     });
 
@@ -141,6 +143,7 @@ describe("handleOidcCallback profile building", () => {
             displayName: undefined,
             firstName: undefined,
             lastName: undefined,
+            profileSynced: false,
         });
     });
 
@@ -191,7 +194,7 @@ describe("handleOidcCallback profile building", () => {
             email_verified: true,
             given_name: "Alice",
         });
-        vi.mocked(findOidcUserBySub).mockResolvedValue({ lastLoginAt: new Date().toISOString() });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ profileSyncedAt: new Date().toISOString() });
         vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
 
         await handleOidcCallback(callbackUrl, callbackParameters);
@@ -200,6 +203,55 @@ describe("handleOidcCallback profile building", () => {
         expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
             expect.objectContaining({ email: "alice@example.com", emailVerified: true, lastName: undefined })
         );
+    });
+
+    it("forces a userinfo fetch when the ID token omits email even for a fresh user", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        // Fresh known user, but the ID token carries no email — the only source is userinfo.
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            given_name: "Alice",
+            family_name: "Smith",
+            name: "Alice Smith",
+        });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ profileSyncedAt: new Date().toISOString() });
+        vi.mocked(client.fetchUserInfo).mockResolvedValue({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: true,
+        } as never);
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(findOidcUserBySub).not.toHaveBeenCalled(); // a missing email short-circuits the freshness check
+        expect(client.fetchUserInfo).toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
+            expect.objectContaining({ email: "alice@example.com", profileSynced: true })
+        );
+    });
+
+    it("marks the profile unsynced when the freshness gate skips userinfo", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: true,
+            given_name: "Alice",
+        });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ profileSyncedAt: new Date().toISOString() });
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(client.fetchUserInfo).not.toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(expect.objectContaining({ profileSynced: false }));
     });
 
     it("fetches userinfo for a known stale user when a name claim is missing", async () => {
@@ -213,7 +265,7 @@ describe("handleOidcCallback profile building", () => {
             email_verified: true,
             given_name: "Alice",
         });
-        vi.mocked(findOidcUserBySub).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ profileSyncedAt: "2000-01-01T00:00:00.000Z" });
         vi.mocked(client.fetchUserInfo).mockResolvedValue({
             sub: "subject-1",
             email: "alice@example.com",
@@ -264,7 +316,7 @@ describe("handleOidcCallback profile building", () => {
             email_verified: true,
             given_name: "Alice",
         });
-        vi.mocked(findOidcUserBySub).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ profileSyncedAt: "2000-01-01T00:00:00.000Z" });
         vi.mocked(client.fetchUserInfo).mockResolvedValue({
             sub: "subject-1",
             email: "alice@example.com",
@@ -294,7 +346,7 @@ describe("handleOidcCallback profile building", () => {
             email_verified: true,
             given_name: "Alice",
         });
-        vi.mocked(findOidcUserBySub).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ profileSyncedAt: "2000-01-01T00:00:00.000Z" });
         vi.mocked(client.fetchUserInfo).mockResolvedValue({
             sub: "subject-1",
             email: "alice@example.com",

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -328,6 +328,25 @@ describe("handleOidcCallback profile building", () => {
         expect(client.fetchUserInfo).not.toHaveBeenCalled();
         expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(expect.objectContaining({ emailVerified: true }));
     });
+
+    it("treats empty and whitespace-only name claims as absent so they can't clobber a stored name", async () => {
+        await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "user@example.com",
+            email_verified: true,
+            given_name: "",
+            family_name: "Example",
+            name: "   ",
+        });
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
+            expect.objectContaining({ firstName: undefined, lastName: "Example", displayName: undefined })
+        );
+    });
 });
 
 describe("initializeOidc client authentication detection", () => {

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -1,0 +1,149 @@
+import * as client from "openid-client";
+import { buildThreatSeaAccessToken } from "#services/auth.service.js";
+import { handleOidcCallback, initializeOidc } from "#services/oidcAuthentication.service.js";
+import { UnauthorizedError } from "#errors/unauthorized.error.js";
+
+vi.mock("openid-client", () => ({
+    discovery: vi.fn(),
+    authorizationCodeGrant: vi.fn(),
+    fetchUserInfo: vi.fn(),
+    buildAuthorizationUrl: vi.fn(),
+    randomPKCECodeVerifier: vi.fn(),
+    calculatePKCECodeChallenge: vi.fn(),
+    allowInsecureRequests: vi.fn(),
+    ClientSecretBasic: vi.fn(),
+    ClientSecretPost: vi.fn(),
+    Configuration: vi.fn(),
+}));
+
+vi.mock("#services/auth.service.js", () => ({
+    buildThreatSeaAccessToken: vi.fn(),
+}));
+
+vi.mock("#config/config.js", async (importOriginal) => {
+    const actualConfig = await importOriginal<typeof import("#config/config.js")>();
+    return {
+        ...actualConfig,
+        oidcConfig: {
+            clientId: "threatsea-client",
+            clientSecret: "threatsea-secret",
+            issuerUrl: "https://idp.example.com",
+            callbackURL: "http://localhost:8000/api/auth/redirect",
+            scope: "openid profile email",
+            allowHttp: false,
+        },
+    };
+});
+
+interface TestServerMetadata {
+    issuer: string;
+    token_endpoint_auth_methods_supported?: string[];
+    userinfo_endpoint?: string;
+}
+
+async function initializeOidcWithServerMetadata(serverMetadata: TestServerMetadata): Promise<void> {
+    vi.mocked(client.discovery).mockResolvedValue({
+        serverMetadata: () => serverMetadata,
+    } as never);
+    vi.mocked(client.Configuration).mockImplementation(function (metadata: unknown) {
+        return { serverMetadata: () => metadata };
+    } as never);
+    await initializeOidc();
+}
+
+function mockAuthorizationCodeGrant(idTokenClaims: Record<string, unknown> | undefined): void {
+    vi.mocked(client.authorizationCodeGrant).mockResolvedValue({
+        access_token: "idp-access-token",
+        claims: () => idTokenClaims,
+    } as never);
+}
+
+const callbackUrl = new URL("http://localhost:8000/api/auth/redirect?code=abc&state=state-1");
+const callbackParameters = { state: "state-1", nonce: "nonce-1", codeVerifier: "verifier-1" };
+
+describe("handleOidcCallback profile building", () => {
+    it("builds the profile from ID token claims without calling userinfo", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "user@example.com",
+            email_verified: true,
+            name: "User Example",
+            given_name: "User",
+            family_name: "Example",
+        });
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        const threatSeaToken = await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(threatSeaToken).toBe("threatsea-token");
+        expect(client.fetchUserInfo).not.toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith({
+            sub: "subject-1",
+            email: "user@example.com",
+            emailVerified: true,
+            displayName: "User Example",
+            firstName: "User",
+            lastName: "Example",
+        });
+    });
+
+    it("falls back to userinfo when a claim is missing and the endpoint exists", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        mockAuthorizationCodeGrant({ sub: "subject-1", email: "stale@example.com" });
+        vi.mocked(client.fetchUserInfo).mockResolvedValue({
+            sub: "subject-1",
+            email: "fresh@example.com",
+            email_verified: true,
+            name: "Fresh Name",
+            given_name: "Fresh",
+            family_name: "Name",
+        } as never);
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(client.fetchUserInfo).toHaveBeenCalledWith(expect.anything(), "idp-access-token", "subject-1");
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith({
+            sub: "subject-1",
+            email: "fresh@example.com",
+            emailVerified: true,
+            displayName: "Fresh Name",
+            firstName: "Fresh",
+            lastName: "Name",
+        });
+    });
+
+    it("skips userinfo when the metadata has no userinfo endpoint", async () => {
+        await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
+        mockAuthorizationCodeGrant({ sub: "subject-1", email: "user@example.com", email_verified: true });
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        const threatSeaToken = await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(threatSeaToken).toBe("threatsea-token");
+        expect(client.fetchUserInfo).not.toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith({
+            sub: "subject-1",
+            email: "user@example.com",
+            emailVerified: true,
+            displayName: undefined,
+            firstName: undefined,
+            lastName: undefined,
+        });
+    });
+
+    it("rejects a token response without a sub claim", async () => {
+        await initializeOidcWithServerMetadata({ issuer: "https://idp.example.com" });
+        mockAuthorizationCodeGrant(undefined);
+
+        await expect(handleOidcCallback(callbackUrl, callbackParameters)).rejects.toThrow(UnauthorizedError);
+        expect(buildThreatSeaAccessToken).not.toHaveBeenCalled();
+    });
+});

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -1,5 +1,5 @@
 import * as client from "openid-client";
-import { buildThreatSeaAccessToken } from "#services/auth.service.js";
+import { buildThreatSeaAccessToken, findLinkableUser } from "#services/auth.service.js";
 import { handleOidcCallback, initializeOidc } from "#services/oidcAuthentication.service.js";
 import { UnauthorizedError } from "#errors/unauthorized.error.js";
 
@@ -18,6 +18,7 @@ vi.mock("openid-client", () => ({
 
 vi.mock("#services/auth.service.js", () => ({
     buildThreatSeaAccessToken: vi.fn(),
+    findLinkableUser: vi.fn(),
 }));
 
 vi.mock("#config/config.js", async (importOriginal) => {
@@ -62,6 +63,10 @@ const callbackUrl = new URL("http://localhost:8000/api/auth/redirect?code=abc&st
 const callbackParameters = { state: "state-1", nonce: "nonce-1", codeVerifier: "verifier-1" };
 
 describe("handleOidcCallback profile building", () => {
+    beforeEach(() => {
+        vi.mocked(findLinkableUser).mockResolvedValue(undefined);
+    });
+
     it("builds the profile from ID token claims without calling userinfo", async () => {
         await initializeOidcWithServerMetadata({
             issuer: "https://idp.example.com",
@@ -147,34 +152,80 @@ describe("handleOidcCallback profile building", () => {
         expect(buildThreatSeaAccessToken).not.toHaveBeenCalled();
     });
 
-    it("keeps the ID token's verified email and skips userinfo when only a name claim is missing", async () => {
+    it("fetches userinfo for an unknown user when the ID token omits a name", async () => {
         await initializeOidcWithServerMetadata({
             issuer: "https://idp.example.com",
             userinfo_endpoint: "https://idp.example.com/userinfo",
         });
-        // ID token already carries a verified email but omits family_name — a common IdP shape where
-        // names live only in userinfo. Fetching userinfo here would drop the verified flag (userinfo
-        // rarely re-asserts email_verified) and break linking for a genuinely-verified user.
         mockAuthorizationCodeGrant({
             sub: "subject-1",
             email: "alice@example.com",
             email_verified: true,
             given_name: "Alice",
         });
-        // If userinfo were (wrongly) consulted, it would swap in a different email with no verification.
+        vi.mocked(findLinkableUser).mockResolvedValue(undefined);
         vi.mocked(client.fetchUserInfo).mockResolvedValue({
             sub: "subject-1",
-            email: "attacker@example.com",
+            email: "alice@example.com",
+            email_verified: true,
             family_name: "Smith",
         } as never);
         vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
 
         await handleOidcCallback(callbackUrl, callbackParameters);
 
+        expect(client.fetchUserInfo).toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
+            expect.objectContaining({ email: "alice@example.com", lastName: "Smith" })
+        );
+    });
+
+    it("skips userinfo for a known fresh user even when a name claim is missing", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: true,
+            given_name: "Alice",
+        });
+        vi.mocked(findLinkableUser).mockResolvedValue({ lastLoginAt: new Date().toISOString() });
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
         expect(client.fetchUserInfo).not.toHaveBeenCalled();
         expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(
-            expect.objectContaining({ email: "alice@example.com", emailVerified: true })
+            expect.objectContaining({ email: "alice@example.com", emailVerified: true, lastName: undefined })
         );
+    });
+
+    it("fetches userinfo for a known stale user when a name claim is missing", async () => {
+        await initializeOidcWithServerMetadata({
+            issuer: "https://idp.example.com",
+            userinfo_endpoint: "https://idp.example.com/userinfo",
+        });
+        mockAuthorizationCodeGrant({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: true,
+            given_name: "Alice",
+        });
+        vi.mocked(findLinkableUser).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
+        vi.mocked(client.fetchUserInfo).mockResolvedValue({
+            sub: "subject-1",
+            email: "alice@example.com",
+            email_verified: true,
+            family_name: "Smith",
+        } as never);
+        vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
+
+        await handleOidcCallback(callbackUrl, callbackParameters);
+
+        expect(client.fetchUserInfo).toHaveBeenCalled();
+        expect(buildThreatSeaAccessToken).toHaveBeenCalledWith(expect.objectContaining({ lastName: "Smith" }));
     });
 
     it("takes email and email_verified as an atomic pair from userinfo when the ID token omits verification", async () => {

--- a/apps/backend/tests/oidc-authentication.test.ts
+++ b/apps/backend/tests/oidc-authentication.test.ts
@@ -1,5 +1,5 @@
 import * as client from "openid-client";
-import { buildThreatSeaAccessToken, findLinkableUser } from "#services/auth.service.js";
+import { buildThreatSeaAccessToken, findOidcUserBySub } from "#services/auth.service.js";
 import { handleOidcCallback, initializeOidc } from "#services/oidcAuthentication.service.js";
 import { UnauthorizedError } from "#errors/unauthorized.error.js";
 
@@ -18,7 +18,7 @@ vi.mock("openid-client", () => ({
 
 vi.mock("#services/auth.service.js", () => ({
     buildThreatSeaAccessToken: vi.fn(),
-    findLinkableUser: vi.fn(),
+    findOidcUserBySub: vi.fn(),
 }));
 
 vi.mock("#config/config.js", async (importOriginal) => {
@@ -64,7 +64,7 @@ const callbackParameters = { state: "state-1", nonce: "nonce-1", codeVerifier: "
 
 describe("handleOidcCallback profile building", () => {
     beforeEach(() => {
-        vi.mocked(findLinkableUser).mockResolvedValue(undefined);
+        vi.mocked(findOidcUserBySub).mockResolvedValue(undefined);
     });
 
     it("builds the profile from ID token claims without calling userinfo", async () => {
@@ -163,7 +163,7 @@ describe("handleOidcCallback profile building", () => {
             email_verified: true,
             given_name: "Alice",
         });
-        vi.mocked(findLinkableUser).mockResolvedValue(undefined);
+        vi.mocked(findOidcUserBySub).mockResolvedValue(undefined);
         vi.mocked(client.fetchUserInfo).mockResolvedValue({
             sub: "subject-1",
             email: "alice@example.com",
@@ -191,7 +191,7 @@ describe("handleOidcCallback profile building", () => {
             email_verified: true,
             given_name: "Alice",
         });
-        vi.mocked(findLinkableUser).mockResolvedValue({ lastLoginAt: new Date().toISOString() });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ lastLoginAt: new Date().toISOString() });
         vi.mocked(buildThreatSeaAccessToken).mockResolvedValue("threatsea-token");
 
         await handleOidcCallback(callbackUrl, callbackParameters);
@@ -213,7 +213,7 @@ describe("handleOidcCallback profile building", () => {
             email_verified: true,
             given_name: "Alice",
         });
-        vi.mocked(findLinkableUser).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
         vi.mocked(client.fetchUserInfo).mockResolvedValue({
             sub: "subject-1",
             email: "alice@example.com",
@@ -264,7 +264,7 @@ describe("handleOidcCallback profile building", () => {
             email_verified: true,
             given_name: "Alice",
         });
-        vi.mocked(findLinkableUser).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
+        vi.mocked(findOidcUserBySub).mockResolvedValue({ lastLoginAt: "2000-01-01T00:00:00.000Z" });
         vi.mocked(client.fetchUserInfo).mockResolvedValue({
             sub: "subject-1",
             email: "alice@example.com",

--- a/apps/backend/tests/oidc-callback-controller.test.ts
+++ b/apps/backend/tests/oidc-callback-controller.test.ts
@@ -26,8 +26,16 @@ vi.mock("#services/oidcAuthentication.service.js", () => ({
 }));
 
 function buildCallbackRequest(): Request {
+    const session: Record<string, unknown> = {
+        oidc: { state: "state-1", nonce: "nonce-1", codeVerifier: "verifier-1" },
+        regenerate(callback: (error: Error | null) => void) {
+            // Mirror express-session: regenerating drops the old session and its pending oidc data.
+            delete session["oidc"];
+            callback(null);
+        },
+    };
     return {
-        session: { oidc: { state: "state-1", nonce: "nonce-1", codeVerifier: "verifier-1" } },
+        session,
         originalUrl: "/api/auth/redirect?code=abc&state=state-1",
         cookies: {},
     } as unknown as Request;
@@ -51,6 +59,27 @@ describe("finalizeAuthentication session cleanup", () => {
         expect(request.session.oidc).toBeUndefined();
         expect(response.redirect).toHaveBeenCalledWith(`${originConfig.app}/login?failure`);
         expect(response.cookie).not.toHaveBeenCalled();
+    });
+
+    it("regenerates the session before exchanging the authorization code", async () => {
+        const callOrder: string[] = [];
+        vi.mocked(handleOidcCallback).mockImplementation(async () => {
+            callOrder.push("exchange");
+            return "threatsea-token";
+        });
+        const request = buildCallbackRequest();
+        (request.session as unknown as { regenerate: (callback: (error: Error | null) => void) => void }).regenerate = (
+            callback
+        ) => {
+            callOrder.push("regenerate");
+            delete (request.session as unknown as Record<string, unknown>)["oidc"];
+            callback(null);
+        };
+        const response = buildCallbackResponse();
+
+        await finalizeAuthentication(request, response);
+
+        expect(callOrder).toEqual(["regenerate", "exchange"]);
     });
 
     it("clears the oidc transaction and issues the cookie on success", async () => {

--- a/apps/backend/tests/oidc-callback-controller.test.ts
+++ b/apps/backend/tests/oidc-callback-controller.test.ts
@@ -49,19 +49,19 @@ function buildCallbackResponse(): Response {
 }
 
 describe("finalizeAuthentication session cleanup", () => {
-    it("clears the oidc transaction when the callback fails", async () => {
+    it("preserves the oidc transaction when the callback fails so the genuine redirect can retry", async () => {
         vi.mocked(handleOidcCallback).mockRejectedValue(new Error("token exchange failed"));
         const request = buildCallbackRequest();
         const response = buildCallbackResponse();
 
         await finalizeAuthentication(request, response);
 
-        expect(request.session.oidc).toBeUndefined();
+        expect(request.session.oidc).toEqual({ state: "state-1", nonce: "nonce-1", codeVerifier: "verifier-1" });
         expect(response.redirect).toHaveBeenCalledWith(`${originConfig.app}/login?failure`);
         expect(response.cookie).not.toHaveBeenCalled();
     });
 
-    it("regenerates the session before exchanging the authorization code", async () => {
+    it("regenerates the session only after a successful exchange", async () => {
         const callOrder: string[] = [];
         vi.mocked(handleOidcCallback).mockImplementation(async () => {
             callOrder.push("exchange");
@@ -79,7 +79,7 @@ describe("finalizeAuthentication session cleanup", () => {
 
         await finalizeAuthentication(request, response);
 
-        expect(callOrder).toEqual(["regenerate", "exchange"]);
+        expect(callOrder).toEqual(["exchange", "regenerate"]);
     });
 
     it("clears the oidc transaction and issues the cookie on success", async () => {

--- a/apps/backend/tests/oidc-callback-controller.test.ts
+++ b/apps/backend/tests/oidc-callback-controller.test.ts
@@ -1,0 +1,76 @@
+import { Request, Response } from "express";
+import { originConfig } from "#config/config.js";
+import { finalizeAuthentication } from "#controllers/authentication.controller.js";
+import { handleOidcCallback } from "#services/oidcAuthentication.service.js";
+
+vi.mock("#config/config.js", async (importOriginal) => {
+    const actualConfig = await importOriginal<typeof import("#config/config.js")>();
+    return {
+        ...actualConfig,
+        AUTH_METHOD: "oidc",
+        oidcConfig: {
+            clientId: "threatsea-client",
+            clientSecret: "threatsea-secret",
+            issuerUrl: "https://idp.example.com",
+            callbackURL: "http://localhost:8000/api/auth/redirect",
+            scope: "openid profile email",
+            allowHttp: false,
+        },
+    };
+});
+
+vi.mock("#services/oidcAuthentication.service.js", () => ({
+    initializeOidc: vi.fn(),
+    buildLoginRedirectUrl: vi.fn(),
+    handleOidcCallback: vi.fn(),
+}));
+
+function buildCallbackRequest(): Request {
+    return {
+        session: { oidc: { state: "state-1", nonce: "nonce-1", codeVerifier: "verifier-1" } },
+        originalUrl: "/api/auth/redirect?code=abc&state=state-1",
+        cookies: {},
+    } as unknown as Request;
+}
+
+function buildCallbackResponse(): Response {
+    return {
+        redirect: vi.fn(),
+        cookie: vi.fn(),
+    } as unknown as Response;
+}
+
+describe("finalizeAuthentication session cleanup", () => {
+    it("clears the oidc transaction when the callback fails", async () => {
+        vi.mocked(handleOidcCallback).mockRejectedValue(new Error("token exchange failed"));
+        const request = buildCallbackRequest();
+        const response = buildCallbackResponse();
+
+        await finalizeAuthentication(request, response);
+
+        expect(request.session.oidc).toBeUndefined();
+        expect(response.redirect).toHaveBeenCalledWith(`${originConfig.app}/login?failure`);
+        expect(response.cookie).not.toHaveBeenCalled();
+    });
+
+    it("clears the oidc transaction and issues the cookie on success", async () => {
+        vi.mocked(handleOidcCallback).mockResolvedValue("threatsea-token");
+        const request = buildCallbackRequest();
+        const response = buildCallbackResponse();
+
+        await finalizeAuthentication(request, response);
+
+        expect(request.session.oidc).toBeUndefined();
+        expect(handleOidcCallback).toHaveBeenCalledWith(expect.any(URL), {
+            state: "state-1",
+            nonce: "nonce-1",
+            codeVerifier: "verifier-1",
+        });
+        expect(response.cookie).toHaveBeenCalledWith(
+            "accessToken",
+            "threatsea-token",
+            expect.objectContaining({ httpOnly: true })
+        );
+        expect(response.redirect).toHaveBeenCalledWith(originConfig.app);
+    });
+});

--- a/apps/backend/tests/session-store.test.ts
+++ b/apps/backend/tests/session-store.test.ts
@@ -1,0 +1,17 @@
+import request from "supertest";
+import { app } from "#server.js";
+import { db } from "#db/index.js";
+import { sessions } from "#db/schema.js";
+
+describe("persistent session store", () => {
+    it("persists the session to postgres", async () => {
+        const csrfTokenResponse = await request(app).get("/api/csrf-token");
+        expect(csrfTokenResponse.status).toBe(200);
+        expect(csrfTokenResponse.body.token).toBeTypeOf("string");
+
+        await vi.waitFor(async () => {
+            const storedSessions = await db.select().from(sessions);
+            expect(storedSessions.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -7,6 +7,7 @@
     },
     "outDir": "./dist",
     "esModuleInterop": true,
+    "types": ["node", "vitest/globals"],
     /* Type Checking */
     "allowImportingTsExtensions": false,
     "useUnknownInCatchVariables": true,

--- a/gh-pages/Technical Documentation/OpenID Connect Setup.md
+++ b/gh-pages/Technical Documentation/OpenID Connect Setup.md
@@ -13,6 +13,7 @@ This guide explains how to setup ThreaSea to use your preferred OpenID Connect P
 - Set OIDC_ISSUER_URL to the URL given by your provider
 - Set OIDC_CLIENT_ID to the id given by your provider
 - Set OIDC_CLIENT_SECRET to the secret given by your provider
+- Optionally set OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING to "true" to allow linking an existing ThreatSea account to an OIDC identity whose email the provider has not verified. Leave it unset unless your provider omits the email_verified claim and you fully trust it — with unverified linking, anyone who can register your users' email addresses at the identity provider can take over their ThreatSea accounts.
 
 ## Example with KeyCloak:
 

--- a/gh-pages/Technical Documentation/OpenID Connect Setup.md
+++ b/gh-pages/Technical Documentation/OpenID Connect Setup.md
@@ -14,6 +14,7 @@ This guide explains how to setup ThreaSea to use your preferred OpenID Connect P
 - Set OIDC_CLIENT_ID to the id given by your provider
 - Set OIDC_CLIENT_SECRET to the secret given by your provider
 - Optionally set OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING to "true" to allow linking an existing ThreatSea account to an OIDC identity whose email the provider has not verified. Leave it unset unless your provider omits the email_verified claim and you fully trust it — with unverified linking, anyone who can register your users' email addresses at the identity provider can take over their ThreatSea accounts.
+- Optionally set OIDC_SCOPE to override the requested scopes (default: "openid profile email")
 
 ## Example with KeyCloak:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       compression:
         specifier: 1.8.1
         version: 1.8.1(supports-color@7.2.0)
+      connect-pg-simple:
+        specifier: 10.0.0
+        version: 10.0.0
       cookie-parser:
         specifier: 1.4.7
         version: 1.4.7
@@ -129,6 +132,9 @@ importers:
       '@types/compression':
         specifier: 1.8.1
         version: 1.8.1
+      '@types/connect-pg-simple':
+        specifier: 7.0.3
+        version: 7.0.3
       '@types/cookie-parser':
         specifier: 1.4.10
         version: 1.4.10(@types/express@5.0.6)
@@ -1838,6 +1844,9 @@ packages:
   '@types/compression@1.8.1':
     resolution: {integrity: sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==}
 
+  '@types/connect-pg-simple@7.0.3':
+    resolution: {integrity: sha512-NGCy9WBlW2bw+J/QlLnFZ9WjoGs6tMo3LAut6mY4kK+XHzue//lpNVpAvYRpIwM969vBRAM2Re0izUvV6kt+NA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -2381,6 +2390,10 @@ packages:
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  connect-pg-simple@10.0.0:
+    resolution: {integrity: sha512-pBGVazlqiMrackzCr0eKhn4LO5trJXsOX0nQoey9wCOayh80MYtThCbq8eoLsjpiWgiok/h+1/uti9/2/Una8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=22.0.0}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -6109,6 +6122,12 @@ snapshots:
       '@types/express': 5.0.6
       '@types/node': 24.13.3
 
+  '@types/connect-pg-simple@7.0.3':
+    dependencies:
+      '@types/express': 5.0.6
+      '@types/express-session': 1.19.0
+      '@types/pg': 8.20.0
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 24.13.3
@@ -6618,6 +6637,12 @@ snapshots:
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
+
+  connect-pg-simple@10.0.0:
+    dependencies:
+      pg: 8.22.0
+    transitivePeerDependencies:
+      - pg-native
 
   content-disposition@1.1.0: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Postgres-backed persistent login sessions for better continuity across restarts.
  * Added support for configurable OIDC scope and optional account linking when emails are unverified.
  * Added OIDC profile sync tracking, and added a cache-disabled `GET /api/health` endpoint for monitoring.
* **Bug Fixes**
  * Improved OIDC callback handling, including safer email/name updates and stricter verified-email rules during account linking.
* **Documentation**
  * Updated OpenID Connect setup docs with `OIDC_SCOPE` and `OIDC_ALLOW_UNVERIFIED_EMAIL_LINKING` details, and removed outdated real-time sync references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->