### PR TITLE
fix(editor): reflect interface add/delete in component side pane

### DIFF
--- a/apps/frontend/src/application/store.ts
+++ b/apps/frontend/src/application/store.ts
@@ -32,7 +32,15 @@ export function createStore(preloadedState?: Partial<RootState>) {
     return configureStore({
         reducer: rootReducer,
 
-        middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(...middleware),
+        // The confirm dialog intentionally stores its onAccept callback (and the captured state
+        // snapshot) in the store, so exempt those from the serializable-state check.
+        middleware: (getDefaultMiddleware) =>
+            getDefaultMiddleware({
+                serializableCheck: {
+                    ignoredActions: ["[confirm] open confirm"],
+                    ignoredPaths: ["confirm.onAccept", "confirm.state"],
+                },
+            }).concat(...middleware),
 
         preloadedState: {
             user: userPreload,

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-component.component.tsx
@@ -20,7 +20,6 @@ import type { Asset } from "#api/types/asset.types.ts";
 import type {
     AugmentedSystemComponent,
     ConnectionEndpointWithComponent,
-    SystemCommunicationInterface,
     SystemPointOfAttack,
 } from "#api/types/system.types.ts";
 
@@ -92,7 +91,6 @@ const EditorSidebarSelectedComponentInner = ({
 }: EditorSidebarSelectedComponentProps) => {
     const { t } = useTranslation("editorPage");
     const theme = useTheme();
-    const [communicationInterfaces, setCommunicationInterfaces] = useState<SystemCommunicationInterface[]>([]);
     const [localName, setLocalName] = useState<string>("");
     const [localDescription, setLocalDescription] = useState<string>("");
     const [interfaceNames, setInterfaceNames] = useState<Record<string, string>>({});
@@ -104,7 +102,6 @@ const EditorSidebarSelectedComponentInner = ({
     const debouncedHandleCommunicationInterfaceName = useDebounce(handleChangeCommunicationInterfaceName);
 
     const setSelectedComponentValuesEvent = useEffectEvent((selectedComponent: AugmentedSystemComponent) => {
-        setCommunicationInterfaces(selectedComponent.communicationInterfaces ?? []);
         setLocalName(selectedComponent.name ?? "");
         setLocalDescription(selectedComponent.description ?? "");
         const names: Record<string, string> = {};
@@ -118,7 +115,9 @@ const EditorSidebarSelectedComponentInner = ({
         if (selectedComponent) {
             setSelectedComponentValuesEvent(selectedComponent);
         }
-        // Depend on id only — selectedComponent reference can change on unrelated re-renders without the underlying component changing.
+        // Depend on id only — this seeds the local edit buffers (name, description, per-interface name) when a
+        // different component is selected. Interface add/delete keeps the same id and is reflected live from the
+        // selectedComponent prop below, so it must not re-seed here (that would clobber an in-progress edit).
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedComponent?.id]);
 
@@ -143,6 +142,9 @@ const EditorSidebarSelectedComponentInner = ({
     if (!selectedComponent) {
         return null;
     }
+
+    // Read the interface list live from the store-backed prop so add/delete is reflected immediately.
+    const communicationInterfaces = selectedComponent.communicationInterfaces ?? [];
 
     return (
         <Box>
@@ -451,7 +453,11 @@ const EditorSidebarSelectedComponentInner = ({
                                     </ListItemAvatar>
                                     {editingInterfaceId === communicationInterface.id ? (
                                         <TextField
-                                            value={interfaceNames[communicationInterface.id] || ""}
+                                            value={
+                                                interfaceNames[communicationInterface.id] ??
+                                                communicationInterface.name ??
+                                                ""
+                                            }
                                             onChange={(event) =>
                                                 handleLocalInterfaceNameChange(
                                                     selectedComponent.id,
@@ -505,7 +511,9 @@ const EditorSidebarSelectedComponentInner = ({
                                                 "&:hover": { textDecoration: "underline" },
                                             }}
                                         >
-                                            {interfaceNames[communicationInterface.id] || ""}
+                                            {interfaceNames[communicationInterface.id] ??
+                                                communicationInterface.name ??
+                                                ""}
                                         </Typography>
                                     )}
                                     <Box sx={{ display: "flex", alignItems: "center" }}>


### PR DESCRIPTION
## Summary
  Resolves #893 

  - Side pane now reflects communication-interface add/delete immediately (read live from store-backed prop instead of local `useState` copy).
  - Silence Redux `serializableCheck` warning fired by the confirm dialog's stored `onAccept` callback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the editor sidebar’s communication interface rendering by using the best available source for interface names, ensuring visibility when custom names aren’t set.
  - Prevented interface add/delete actions from clobbering in-progress edits.
  - Enhanced confirmation dialog behavior by improving Redux serialization handling related to confirm actions during editing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->