### PR TITLE
chore(husky): run pnpm lint on pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm lint


### PR DESCRIPTION
  - Add a husky pre-push hook that runs `pnpm lint` before every push, blocking pushes that fail lint
