### PR TITLE
feat(catalog): add catalog editor nav tab and header title (#822)

### DIFF
--- a/apps/frontend/playwright/pages/catalog.page.ts
+++ b/apps/frontend/playwright/pages/catalog.page.ts
@@ -55,6 +55,7 @@ export class CatalogPage extends BasePage {
     readonly backToCatalogsButton: Locator;
     readonly projectsNavButton: Locator;
     readonly catalogsNavButton: Locator;
+    readonly catalogEditorButton: Locator;
     readonly membersButton: Locator;
     readonly accountButton: Locator;
     readonly accountMenuUsername: Locator;
@@ -130,6 +131,7 @@ export class CatalogPage extends BasePage {
         this.backToCatalogsButton = page.locator('[data-testid="catalog-page_back-to-catalogs-button"]');
         this.projectsNavButton = page.locator('[data-testid="navigation-header_projects-page-button"]');
         this.catalogsNavButton = page.locator('[data-testid="navigation-header_catalogs-page-button"]');
+        this.catalogEditorButton = page.locator('[data-testid="navigation-header_catalog-editor-button"]');
         this.membersButton = page.locator('[data-testid="navigation-header_members-button"]');
         this.accountButton = page.locator('[data-testid="navigation-header_account-button"]');
         this.accountMenuUsername = page.locator('[data-testid="account-menu_username"]');

--- a/apps/frontend/playwright/tests/catalog.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/catalog.page.e2e.spec.ts
@@ -520,7 +520,9 @@ test.describe("Catalog Page Tests", () => {
 
         await pg.membersButton.click();
         await expect(page).toHaveURL(`/catalogs/${catalogId}/members`);
-        await pg.goto(catalogId);
+
+        await pg.catalogEditorButton.click();
+        await expect(page).toHaveURL(`/catalogs/${catalogId}`);
 
         await pg.accountButton.click();
         await expect(pg.accountMenuUsername).toBeVisible();

--- a/apps/frontend/src/application/hooks/use-page-title.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-page-title.hook.test.tsx
@@ -62,13 +62,13 @@ describe("usePageTitle", () => {
         expect(document.title).toBe("ThreatSea - Alpha - Assets");
     });
 
-    it("composes app name, catalogue name and view label on catalogue routes", () => {
-        renderUsePageTitle("Catalogue Editor", {
+    it("composes app name, catalog name and view label on catalog routes", () => {
+        renderUsePageTitle("Catalog Editor", {
             initialEntries: ["/catalogs/7/"],
             preloadedState: { catalogs: catalogsStateWith(createCatalog({ id: 7, name: "Std" })) },
         });
 
-        expect(document.title).toBe("ThreatSea - Std - Catalogue Editor");
+        expect(document.title).toBe("ThreatSea - Std - Catalog Editor");
     });
 
     it("drops the name when the entity is not yet in the store", () => {

--- a/apps/frontend/src/application/hooks/use-project-tabs.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-project-tabs.hook.test.tsx
@@ -1,0 +1,162 @@
+import type { SyntheticEvent, ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route, Routes, type InitialEntry } from "react-router";
+import { I18nextProvider } from "react-i18next";
+import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import catalogsReducer from "#application/reducers/catalogs.reducer.ts";
+import { navigationReducer } from "#application/reducers/navigation.reducer.ts";
+import projectsReducer from "#application/reducers/projects.reducer.ts";
+import { createStore, type RootState } from "#application/store.ts";
+import { createCatalog, createProject } from "#test-utils/builders.ts";
+import { translationUtil } from "#utils/translations.ts";
+import { useProjectTabs } from "./use-project-tabs.hook";
+
+const navigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react-router")>();
+    return { ...actual, useNavigate: () => navigate };
+});
+
+const navigationState = (overrides: Partial<RootState["navigation"]> = {}): RootState["navigation"] => ({
+    ...navigationReducer(undefined, { type: "@@INIT" }),
+    showProjectCatalogueInnerNavigation: true,
+    showUniversalHeaderNavigation: true,
+    ...overrides,
+});
+
+const catalogsStateWithCurrentRole = (role: USER_ROLES): RootState["catalogs"] => ({
+    ...catalogsReducer(undefined, { type: "@@INIT" }),
+    current: createCatalog({ id: 5, role }),
+});
+
+const projectsStateWithCurrentRole = (role: USER_ROLES): RootState["projects"] => ({
+    ...projectsReducer(undefined, { type: "@@INIT" }),
+    current: createProject({ id: 7, role }),
+});
+
+/**
+ * Renders useProjectTabs at a given URL so useParams resolves catalogId / projectId,
+ * with the store pre-loaded. Route patterns mirror App.tsx so the hook's catalogue-vs-
+ * project branching is exercised end to end.
+ */
+const renderUseProjectTabs = ({
+    initialEntries,
+    preloadedState,
+}: {
+    initialEntries: InitialEntry[];
+    preloadedState?: Partial<RootState>;
+}) => {
+    const store = createStore(preloadedState);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <Provider store={store}>
+            <MemoryRouter initialEntries={initialEntries}>
+                <I18nextProvider i18n={translationUtil}>
+                    <Routes>
+                        <Route path="/projects/:projectId/*" element={children} />
+                        <Route path="/catalogs/:catalogId/*" element={children} />
+                        <Route path="/*" element={children} />
+                    </Routes>
+                </I18nextProvider>
+            </MemoryRouter>
+        </Provider>
+    );
+    return renderHook(() => useProjectTabs(), { wrapper });
+};
+
+describe("useProjectTabs", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("catalogue inner navigation", () => {
+        it("exposes a two-way switch between the catalogue editor and members for an editor", () => {
+            const { result } = renderUseProjectTabs({
+                initialEntries: ["/catalogs/5"],
+                preloadedState: {
+                    navigation: navigationState(),
+                    catalogs: catalogsStateWithCurrentRole(USER_ROLES.EDITOR),
+                },
+            });
+
+            const { finalButtons, showProjectTabs } = result.current;
+
+            expect(showProjectTabs).toBe(true);
+            expect(finalButtons).toHaveLength(2);
+            expect(finalButtons[0]).toMatchObject({
+                value: "/catalogs/5",
+                text: "Catalogue Editor",
+                "data-testid": "navigation-header_catalog-editor-button",
+            });
+            expect(finalButtons[1]).toMatchObject({
+                value: "/catalogs/5/members",
+                text: "Members",
+            });
+        });
+
+        it("navigates to the catalogue editor route when its button is chosen", () => {
+            const { result } = renderUseProjectTabs({
+                initialEntries: ["/catalogs/5/members"],
+                preloadedState: {
+                    navigation: navigationState(),
+                    catalogs: catalogsStateWithCurrentRole(USER_ROLES.EDITOR),
+                },
+            });
+
+            result.current.finalOnChangePath({} as SyntheticEvent, "/catalogs/5");
+
+            expect(navigate).toHaveBeenCalledWith("/catalogs/5");
+        });
+
+        it("offers no inner navigation to a viewer who cannot reach the members view", () => {
+            const { result } = renderUseProjectTabs({
+                initialEntries: ["/catalogs/5"],
+                preloadedState: {
+                    navigation: navigationState(),
+                    catalogs: catalogsStateWithCurrentRole(USER_ROLES.VIEWER),
+                },
+            });
+
+            expect(result.current.finalButtons).toEqual([]);
+            expect(result.current.showProjectTabs).toBe(false);
+        });
+    });
+
+    describe("project inner navigation", () => {
+        it("keeps the full set of project view buttons", () => {
+            const { result } = renderUseProjectTabs({
+                initialEntries: ["/projects/7/system"],
+                preloadedState: {
+                    navigation: navigationState(),
+                    projects: projectsStateWithCurrentRole(USER_ROLES.EDITOR),
+                },
+            });
+
+            const { finalButtons, showProjectTabs } = result.current;
+
+            expect(showProjectTabs).toBe(true);
+            expect(finalButtons.map((button) => button.value)).toEqual([
+                "/projects/7/system",
+                "/projects/7/assets",
+                "/projects/7/threats",
+                "/projects/7/measures",
+                "/projects/7/risk",
+                "/projects/7/report",
+                "/projects/7/members",
+            ]);
+        });
+    });
+
+    it("renders no tabs when the universal header navigation is hidden", () => {
+        const { result } = renderUseProjectTabs({
+            initialEntries: ["/catalogs/5"],
+            preloadedState: {
+                navigation: navigationState({ showUniversalHeaderNavigation: false }),
+                catalogs: catalogsStateWithCurrentRole(USER_ROLES.EDITOR),
+            },
+        });
+
+        expect(result.current.finalButtons).toEqual([]);
+        expect(result.current.showProjectTabs).toBe(false);
+    });
+});

--- a/apps/frontend/src/application/hooks/use-project-tabs.hook.test.tsx
+++ b/apps/frontend/src/application/hooks/use-project-tabs.hook.test.tsx
@@ -37,7 +37,7 @@ const projectsStateWithCurrentRole = (role: USER_ROLES): RootState["projects"] =
 
 /**
  * Renders useProjectTabs at a given URL so useParams resolves catalogId / projectId,
- * with the store pre-loaded. Route patterns mirror App.tsx so the hook's catalogue-vs-
+ * with the store pre-loaded. Route patterns mirror App.tsx so the hook's catalog-vs-
  * project branching is exercised end to end.
  */
 const renderUseProjectTabs = ({
@@ -69,8 +69,8 @@ describe("useProjectTabs", () => {
         vi.clearAllMocks();
     });
 
-    describe("catalogue inner navigation", () => {
-        it("exposes a two-way switch between the catalogue editor and members for an editor", () => {
+    describe("catalog inner navigation", () => {
+        it("exposes a two-way switch between the catalog editor and members for an editor", () => {
             const { result } = renderUseProjectTabs({
                 initialEntries: ["/catalogs/5"],
                 preloadedState: {
@@ -85,7 +85,7 @@ describe("useProjectTabs", () => {
             expect(finalButtons).toHaveLength(2);
             expect(finalButtons[0]).toMatchObject({
                 value: "/catalogs/5",
-                text: "Catalogue Editor",
+                text: "Catalog Editor",
                 "data-testid": "navigation-header_catalog-editor-button",
             });
             expect(finalButtons[1]).toMatchObject({
@@ -94,7 +94,7 @@ describe("useProjectTabs", () => {
             });
         });
 
-        it("navigates to the catalogue editor route when its button is chosen", () => {
+        it("navigates to the catalog editor route when its button is chosen", () => {
             const { result } = renderUseProjectTabs({
                 initialEntries: ["/catalogs/5/members"],
                 preloadedState: {

--- a/apps/frontend/src/application/hooks/use-project-tabs.hook.ts
+++ b/apps/frontend/src/application/hooks/use-project-tabs.hook.ts
@@ -101,14 +101,21 @@ export const useProjectTabs = (): ProjectTabs => {
 
     if (showProjectCatalogueInnerNavigation) {
         if (pathname.includes("/catalogs")) {
-            // Catalog inner page exposes only the members button; consumers render it
-            // inline alongside the primary toggle when finalButtons.length === 1.
+            // Catalog inner page exposes the catalogue editor and members buttons;
+            // consumers render them inline alongside the primary toggle.
             if (!checkUserRole(userRole, USER_ROLES.EDITOR)) {
                 finalButtons = [];
             } else {
-                const button = defaultProjectButtons.at(-1);
-                if (button) {
-                    finalButtons = [{ ...button, value: `/catalogs/${catalogId}/members` }];
+                const membersButton = defaultProjectButtons.at(-1);
+                if (membersButton) {
+                    finalButtons = [
+                        {
+                            value: `/catalogs/${catalogId}`,
+                            text: t("catalogueEditor"),
+                            "data-testid": "navigation-header_catalog-editor-button",
+                        },
+                        { ...membersButton, value: `/catalogs/${catalogId}/members` },
+                    ];
                 }
             }
         } else {

--- a/apps/frontend/src/application/hooks/use-project-tabs.hook.ts
+++ b/apps/frontend/src/application/hooks/use-project-tabs.hook.ts
@@ -101,7 +101,7 @@ export const useProjectTabs = (): ProjectTabs => {
 
     if (showProjectCatalogueInnerNavigation) {
         if (pathname.includes("/catalogs")) {
-            // Catalog inner page exposes the catalogue editor and members buttons;
+            // Catalog inner page exposes the catalog editor and members buttons;
             // consumers render them inline alongside the primary toggle.
             if (!checkUserRole(userRole, USER_ROLES.EDITOR)) {
                 finalButtons = [];
@@ -111,7 +111,7 @@ export const useProjectTabs = (): ProjectTabs => {
                     finalButtons = [
                         {
                             value: `/catalogs/${catalogId}`,
-                            text: t("catalogueEditor"),
+                            text: t("catalogEditor"),
                             "data-testid": "navigation-header_catalog-editor-button",
                         },
                         { ...membersButton, value: `/catalogs/${catalogId}/members` },

--- a/apps/frontend/src/translations/de/common.de.json
+++ b/apps/frontend/src/translations/de/common.de.json
@@ -65,7 +65,7 @@
   "system": "System",
   "member": "Mitglieder",
   "projects": "Projekte",
-  "catalogueEditor": "Katalog-Editor",
+  "catalogEditor": "Katalog-Editor",
   "title": "Titel",
 
   "addBtn": "Hinzufügen",

--- a/apps/frontend/src/translations/en/common.en.json
+++ b/apps/frontend/src/translations/en/common.en.json
@@ -63,7 +63,7 @@
   "member": "Members",
   "projects": "Projects",
   "catalogs": "Catalogs",
-  "catalogueEditor": "Catalogue Editor",
+  "catalogEditor": "Catalog Editor",
 
   "addBtn": "Add",
   "cancel": "Cancel",

--- a/apps/frontend/src/view/components/create-page.component.test.tsx
+++ b/apps/frontend/src/view/components/create-page.component.test.tsx
@@ -4,11 +4,12 @@ import type { MouseEvent } from "react";
 import type { ExtendedProject } from "#api/types/project.types.ts";
 import { USER_ROLES } from "#api/types/user-roles.types.ts";
 import { ProjectsActions } from "#application/actions/projects.actions.ts";
+import catalogsReducer from "#application/reducers/catalogs.reducer.ts";
 import projectsReducer from "#application/reducers/projects.reducer.ts";
 import { navigationReducer } from "#application/reducers/navigation.reducer.ts";
 import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { translationUtil } from "#utils/translations.ts";
-import { createProject } from "#test-utils/builders.ts";
+import { createCatalog, createProject } from "#test-utils/builders.ts";
 import { mockUseConfirm } from "#test-utils/mock-hooks.ts";
 
 // Importing the real #main.tsx bootstraps the whole app (createStore + ReactDOM render).
@@ -152,5 +153,43 @@ describe("CreatePage — project header actions", () => {
 
         expect(deleteProject).toHaveBeenCalledWith(project);
         expect(navigate).toHaveBeenCalledWith("/projects");
+    });
+});
+
+describe("CreatePage — catalogue header", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseConfirm({ openConfirm });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const renderOnCatalogue = (current: ReturnType<typeof createCatalog> | undefined, getCatalogInfo: boolean) => {
+        const Page = CreatePage(HeaderRightSlot, PageBody);
+        renderWithProviders(<Page />, {
+            preloadedState: {
+                catalogs: { ...catalogsReducer(undefined, { type: "@@INIT" }), current },
+                navigation: {
+                    ...navigationReducer(undefined, { type: "@@INIT" }),
+                    showProjectInfo: false,
+                    getCatalogInfo,
+                },
+            },
+            initialEntries: ["/catalogs/5"],
+        });
+    };
+
+    it("shows the current catalogue's name so the active catalogue is identifiable", () => {
+        renderOnCatalogue(createCatalog({ id: 5, name: "Threat Library" }), true);
+
+        expect(screen.getByTestId("catalog-header_name")).toHaveTextContent("Threat Library");
+    });
+
+    it("renders no catalogue title when the catalogue info is not requested", () => {
+        renderOnCatalogue(createCatalog({ id: 5, name: "Threat Library" }), false);
+
+        expect(screen.queryByTestId("catalog-header_name")).not.toBeInTheDocument();
     });
 });

--- a/apps/frontend/src/view/components/create-page.component.test.tsx
+++ b/apps/frontend/src/view/components/create-page.component.test.tsx
@@ -156,7 +156,7 @@ describe("CreatePage — project header actions", () => {
     });
 });
 
-describe("CreatePage — catalogue header", () => {
+describe("CreatePage — catalog header", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockUseConfirm({ openConfirm });
@@ -166,7 +166,7 @@ describe("CreatePage — catalogue header", () => {
         vi.restoreAllMocks();
     });
 
-    const renderOnCatalogue = (current: ReturnType<typeof createCatalog> | undefined, getCatalogInfo: boolean) => {
+    const renderOnCatalog = (current: ReturnType<typeof createCatalog> | undefined, getCatalogInfo: boolean) => {
         const Page = CreatePage(HeaderRightSlot, PageBody);
         renderWithProviders(<Page />, {
             preloadedState: {
@@ -181,14 +181,14 @@ describe("CreatePage — catalogue header", () => {
         });
     };
 
-    it("shows the current catalogue's name so the active catalogue is identifiable", () => {
-        renderOnCatalogue(createCatalog({ id: 5, name: "Threat Library" }), true);
+    it("shows the current catalog's name so the active catalog is identifiable", () => {
+        renderOnCatalog(createCatalog({ id: 5, name: "Threat Library" }), true);
 
         expect(screen.getByTestId("catalog-header_name")).toHaveTextContent("Threat Library");
     });
 
-    it("renders no catalogue title when the catalogue info is not requested", () => {
-        renderOnCatalogue(createCatalog({ id: 5, name: "Threat Library" }), false);
+    it("renders no catalog title when the catalog info is not requested", () => {
+        renderOnCatalog(createCatalog({ id: 5, name: "Threat Library" }), false);
 
         expect(screen.queryByTestId("catalog-header_name")).not.toBeInTheDocument();
     });

--- a/apps/frontend/src/view/components/create-page.component.test.tsx
+++ b/apps/frontend/src/view/components/create-page.component.test.tsx
@@ -1,21 +1,30 @@
-import { screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { MouseEvent } from "react";
+import { Provider } from "react-redux";
+import { I18nextProvider } from "react-i18next";
+import { createMemoryRouter, RouterProvider } from "react-router";
 import type { ExtendedProject } from "#api/types/project.types.ts";
 import { USER_ROLES } from "#api/types/user-roles.types.ts";
+import { CatalogsActions } from "#application/actions/catalogs.actions.ts";
 import { ProjectsActions } from "#application/actions/projects.actions.ts";
 import catalogsReducer from "#application/reducers/catalogs.reducer.ts";
 import projectsReducer from "#application/reducers/projects.reducer.ts";
 import { navigationReducer } from "#application/reducers/navigation.reducer.ts";
+import { createStore } from "#application/store.ts";
 import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { translationUtil } from "#utils/translations.ts";
 import { createCatalog, createProject } from "#test-utils/builders.ts";
 import { mockUseConfirm } from "#test-utils/mock-hooks.ts";
+import { Theme } from "#view/wrappers/theme.wrapper.tsx";
 
 // Importing the real #main.tsx bootstraps the whole app (createStore + ReactDOM render).
-// The layout effect only reads this global store, so a minimal stub is enough.
+// The layout effect only reads this global store, so a minimal stub is enough. It needs
+// a catalogs slice so the catalogue-fetch branch can run selectById without throwing.
 vi.mock("#main.tsx", () => ({
-    store: { getState: () => ({ projects: { deletingProjectId: undefined } }) },
+    store: {
+        getState: () => ({ projects: { deletingProjectId: undefined }, catalogs: { ids: [], entities: {} } }),
+    },
 }));
 
 vi.mock("./header-level-one-nav.component", () => ({ HeaderLevelOneNav: () => null }));
@@ -160,6 +169,7 @@ describe("CreatePage — catalog header", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockUseConfirm({ openConfirm });
+        vi.spyOn(CatalogsActions, "getCatalogFromBackend").mockReturnValue((() => Promise.resolve()) as never);
     });
 
     afterEach(() => {
@@ -181,14 +191,53 @@ describe("CreatePage — catalog header", () => {
         });
     };
 
+    // Renders inside a real /catalogs/:catalogId match so useParams resolves catalogId,
+    // which the header compares against the loaded catalogue's id.
+    const renderOnCatalogAtRoute = (current: ReturnType<typeof createCatalog>, catalogId: string) => {
+        const Page = CreatePage(HeaderRightSlot, PageBody);
+        const store = createStore({
+            catalogs: { ...catalogsReducer(undefined, { type: "@@INIT" }), current },
+            navigation: {
+                ...navigationReducer(undefined, { type: "@@INIT" }),
+                showProjectInfo: false,
+                getCatalogInfo: true,
+            },
+        });
+        const router = createMemoryRouter([{ path: "/catalogs/:catalogId", element: <Page /> }], {
+            initialEntries: [`/catalogs/${catalogId}`],
+        });
+        render(
+            <Provider store={store}>
+                <I18nextProvider i18n={translationUtil}>
+                    <Theme>
+                        <RouterProvider router={router} />
+                    </Theme>
+                </I18nextProvider>
+            </Provider>
+        );
+    };
+
     it("shows the current catalog's name so the active catalog is identifiable", () => {
-        renderOnCatalog(createCatalog({ id: 5, name: "Threat Library" }), true);
+        renderOnCatalogAtRoute(createCatalog({ id: 5, name: "Threat Library" }), "5");
 
         expect(screen.getByTestId("catalog-header_name")).toHaveTextContent("Threat Library");
     });
 
+    it("does not show a stale catalog title when the loaded catalog does not match the route", () => {
+        // Route is /catalogs/5 while the store still holds a different catalog.
+        renderOnCatalogAtRoute(createCatalog({ id: 999, name: "Previous Catalog" }), "5");
+
+        expect(screen.queryByTestId("catalog-header_name")).not.toBeInTheDocument();
+    });
+
     it("renders no catalog title when the catalog info is not requested", () => {
         renderOnCatalog(createCatalog({ id: 5, name: "Threat Library" }), false);
+
+        expect(screen.queryByTestId("catalog-header_name")).not.toBeInTheDocument();
+    });
+
+    it("renders no catalog title while the catalog is not yet loaded", () => {
+        renderOnCatalog(undefined, true);
 
         expect(screen.queryByTestId("catalog-header_name")).not.toBeInTheDocument();
     });

--- a/apps/frontend/src/view/components/create-page.component.tsx
+++ b/apps/frontend/src/view/components/create-page.component.tsx
@@ -393,6 +393,40 @@ export const CreatePage = <P extends object>(
                                 </Box>
                             </Box>
                         )}
+                        {getCatalogInfo && catalog && (
+                            <Box
+                                sx={{
+                                    gridArea: "title",
+                                    justifySelf: "center",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    bgcolor: "primary.dark",
+                                    color: "text.primary",
+                                    borderRadius: 5,
+                                    boxShadow: 1,
+                                }}
+                            >
+                                <Box
+                                    sx={{
+                                        display: "flex",
+                                        alignItems: "center",
+                                        p: 1,
+                                        pl: 2,
+                                        pr: 2,
+                                    }}
+                                >
+                                    <Typography
+                                        data-testid="catalog-header_name"
+                                        sx={{
+                                            fontSize: "0.875rem",
+                                            fontWeight: "bold",
+                                        }}
+                                    >
+                                        {catalog.name}
+                                    </Typography>
+                                </Box>
+                            </Box>
+                        )}
                         <Box
                             sx={(theme) => ({
                                 display: "contents",

--- a/apps/frontend/src/view/components/create-page.component.tsx
+++ b/apps/frontend/src/view/components/create-page.component.tsx
@@ -393,7 +393,7 @@ export const CreatePage = <P extends object>(
                                 </Box>
                             </Box>
                         )}
-                        {getCatalogInfo && catalog && (
+                        {getCatalogInfo && catalog?.id === Number(catalogId) && (
                             <Box
                                 sx={{
                                     gridArea: "title",

--- a/apps/frontend/src/view/components/header-level-one-nav.component.tsx
+++ b/apps/frontend/src/view/components/header-level-one-nav.component.tsx
@@ -14,9 +14,9 @@ export const HeaderLevelOneNav = ({ projectTabs }: HeaderLevelOneNavProps) => {
     const { showProjectTabs, finalButtons, finalOnChangePath, pathname } = projectTabs;
 
     const showLevelOne = showUniversalHeaderNavigation;
-    const inlineSingleTab = showProjectTabs && finalButtons.length === 1;
+    const inlineCatalogTabs = showProjectTabs && pathname.includes("/catalogs");
 
-    if (!showLevelOne && !inlineSingleTab) {
+    if (!showLevelOne && !inlineCatalogTabs) {
         return null;
     }
 
@@ -27,6 +27,7 @@ export const HeaderLevelOneNav = ({ projectTabs }: HeaderLevelOneNavProps) => {
                 justifySelf: "center",
                 display: "flex",
                 alignItems: "center",
+                flexWrap: { xs: "wrap", md: "nowrap" },
                 gap: 1,
             }}
         >
@@ -51,7 +52,7 @@ export const HeaderLevelOneNav = ({ projectTabs }: HeaderLevelOneNavProps) => {
                     ]}
                 />
             )}
-            {inlineSingleTab && (
+            {inlineCatalogTabs && (
                 <ButtonNavigation size="medium" value={pathname} onChange={finalOnChangePath} buttons={finalButtons} />
             )}
         </Box>

--- a/apps/frontend/src/view/components/header-project-tabs.component.tsx
+++ b/apps/frontend/src/view/components/header-project-tabs.component.tsx
@@ -9,7 +9,7 @@ interface HeaderProjectTabsProps {
 export const HeaderProjectTabs = ({ projectTabs }: HeaderProjectTabsProps) => {
     const { showProjectTabs, finalButtons, finalOnChangePath, pathname } = projectTabs;
 
-    if (!showProjectTabs || finalButtons.length <= 1) {
+    if (!showProjectTabs || pathname.includes("/catalogs") || finalButtons.length <= 1) {
         return null;
     }
 

--- a/apps/frontend/src/view/pages/catalog.page.tsx
+++ b/apps/frontend/src/view/pages/catalog.page.tsx
@@ -33,7 +33,7 @@ const CatalogPageBody = () => {
     const [pointOfAttack, setPointOfAttack] = useState<POINTS_OF_ATTACK | null>(null);
     const navigate = useNavigate();
     const { t } = useTranslation("catalogPage");
-    usePageTitle(t("catalogueEditor", { ns: "common" }));
+    usePageTitle(t("catalogEditor", { ns: "common" }));
 
     const dispatch = useAppDispatch();
 


### PR DESCRIPTION
## Summary

  Resolves #822

  - Add a Catalogue Editor tab to the catalog top-right nav so users switch editor ↔ members both ways (previously only Members existed → forced browser back-navigation).
  - Show the current catalogue's name in the header on catalogue pages, so the active catalogue is identifiable (was blank — only projects showed a title).

### Screenshots
<img width="1181" height="177" alt="Screenshot 2026-07-28 at 14 10 31" src="https://github.com/user-attachments/assets/3dc06b7a-82be-4235-bb7d-c4c0cb033518" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog header navigation with quick access to the Catalog Editor and Members views.
  * Added catalog names to page headers when catalog information is available.
  * Improved catalog navigation layout and responsive wrapping.

* **Bug Fixes**
  * Prevented project tabs from appearing on catalog routes.
  * Restricted Members navigation for viewers without access.

* **Tests**
  * Expanded coverage for catalog navigation, headers, permissions, and page routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->