### PR TITLE
fix(dialogs): preserve label shrink default when caller passes slotProps

### DIFF
--- a/apps/frontend/src/view/components/dialog.textfield.component.tsx
+++ b/apps/frontend/src/view/components/dialog.textfield.component.tsx
@@ -2,7 +2,7 @@ import { TextField } from "@mui/material";
 import type { TextFieldProps } from "@mui/material/TextField";
 import type { JSX } from "react";
 
-export const DialogTextField = ({ sx, ...props }: TextFieldProps): JSX.Element => {
+export const DialogTextField = ({ sx, slotProps, ...props }: TextFieldProps): JSX.Element => {
     let paddingLeft = 3;
     if (props.multiline) {
         paddingLeft = 1;
@@ -11,8 +11,10 @@ export const DialogTextField = ({ sx, ...props }: TextFieldProps): JSX.Element =
     return (
         <TextField
             slotProps={{
+                ...slotProps,
                 inputLabel: {
                     shrink: true,
+                    ...slotProps?.inputLabel,
                 },
             }}
             sx={{


### PR DESCRIPTION
## Summary
  Closes #984

  - Fix German label being clipped in the "Apply Measure" dialog — long labels like `Eintrittswahrscheinlichkeit (brutto 3)` were cut off, hiding the current probability/damage value.
  - Root cause: the shared `DialogTextField` wrapper set `inputLabel.shrink: true` as a default, but any caller passing its own `slotProps` (e.g. an info-tooltip adornment) replaced the whole object and silently dropped the shrink default. Unshrunk labels sit inside the box and clip to input width.
  - Fix restores the default repo-wide, not just for the two dialogs in the bug report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing text field slots, including input label properties.
  * Preserved automatic label shrinking while allowing additional label configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->