### PR TITLE
feat(editor): show point-of-attack type colour in single edit pane

### DIFF
--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.test.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.test.tsx
@@ -6,6 +6,8 @@ import {
 } from "./editor-sidebar-selected-point-of-attack.component";
 import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { createAsset, createSystemComponent, createPointOfAttack } from "#test-utils/builders.ts";
+import { POINTS_OF_ATTACK } from "#api/types/points-of-attack.types.ts";
+import { POA_COLORS } from "#view/colors/pointsOfAttack.colors.ts";
 
 const setup = (propsOverride: Partial<EditorSidebarSelectedPointOfAttackProps> = {}) => {
     const props = {
@@ -35,6 +37,28 @@ describe("EditorSidebarSelectedPointOfAttack", () => {
             await user.click(screen.getByText("My Component"));
 
             expect(props.handleComponentBreadcrumbClick).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("type colour dot", () => {
+        it("fills the dot with the colour of the selected point of attack type", () => {
+            setup({
+                selectedPointOfAttack: createPointOfAttack({ type: POINTS_OF_ATTACK.USER_INTERFACE }),
+            });
+
+            expect(screen.getByTestId("poa-type-color-dot")).toHaveStyle({
+                backgroundColor: POA_COLORS[POINTS_OF_ATTACK.USER_INTERFACE].normal,
+            });
+        });
+
+        it("uses a different colour for a different point of attack type", () => {
+            setup({
+                selectedPointOfAttack: createPointOfAttack({ type: POINTS_OF_ATTACK.PROCESSING_INFRASTRUCTURE }),
+            });
+
+            expect(screen.getByTestId("poa-type-color-dot")).toHaveStyle({
+                backgroundColor: POA_COLORS[POINTS_OF_ATTACK.PROCESSING_INFRASTRUCTURE].normal,
+            });
         });
     });
 

--- a/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
+++ b/apps/frontend/src/view/components/editor-components/editor-sidebar-selected-point-of-attack.component.tsx
@@ -3,6 +3,7 @@ import { Box } from "@mui/system";
 import { useTranslation } from "react-i18next";
 import { AssetSecurityNeedsPopper } from "./asset-security-needs-popper.component";
 import { EditorSidebarAssetList } from "./editor-sidebar-asset-list.component";
+import { POA_COLORS } from "#view/colors/pointsOfAttack.colors.ts";
 import { SearchField } from "#view/components/search-field.component.tsx";
 import { useAssetHoverPopper } from "#application/hooks/useAssetHoverPopper.ts";
 import type { ChangeEvent } from "react";
@@ -41,12 +42,24 @@ export const EditorSidebarSelectedPointOfAttack = ({
                     backgroundColor: "transparent",
                     paddingLeft: 0,
                     paddingRight: 0,
-                    alignItems: "flex-start",
+                    alignItems: "center",
                     marginBottom: "-10px",
                     height: "26px",
                     border: "none",
                 }}
             >
+                <Box
+                    data-testid="poa-type-color-dot"
+                    sx={{
+                        backgroundColor: POA_COLORS[selectedPointOfAttack.type].normal,
+                        width: "16px",
+                        height: "16px",
+                        borderRadius: 50,
+                        marginRight: 1,
+                        marginTop: "1px",
+                        flexShrink: 0,
+                    }}
+                />
                 <Typography
                     sx={{
                         display: "inline",


### PR DESCRIPTION
## Summary
  Resolves #846

  - Single point-of-attack edit pane now shows a filled colour dot of the attack-point type
  
  ### Screenshots
  
<img width="488" height="416" alt="Screenshot 2026-08-03 at 17 35 47" src="https://github.com/user-attachments/assets/ad14226a-0de3-4fbd-a19f-10cc87d3f6f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a colored indicator beside the selected point-of-attack heading.
  - The indicator now reflects the selected point-of-attack type for easier identification.

- **Style**
  - Improved heading alignment so the label and color indicator are vertically centered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->