### PR TITLE
test(playwright): stabilize coverage for new workflows

### DIFF
--- a/apps/frontend/playwright/pages/editor.page.ts
+++ b/apps/frontend/playwright/pages/editor.page.ts
@@ -197,7 +197,9 @@ export class EditorPage extends BasePage {
     }
 
     communicationListItemByName(name: string): Locator {
-        return this.page.getByTestId("communication-list-item").filter({ hasText: name });
+        return this.page
+            .getByTestId("communication-list-item")
+            .filter({ has: this.page.getByText(name, { exact: true }) });
     }
 
     poaSwitchButton(poa: string): Locator {

--- a/apps/frontend/playwright/pages/editor.page.ts
+++ b/apps/frontend/playwright/pages/editor.page.ts
@@ -33,6 +33,8 @@ export class EditorPage extends BasePage {
     readonly assetCreationModalNameInput: Locator;
     readonly saveButton: Locator;
     readonly cancelButton: Locator;
+    readonly changeComponentIconButton: Locator;
+    readonly saveComponentIconButton: Locator;
 
     // Custom component context menu + dialog
     readonly addCustomComponentButton: Locator;
@@ -82,6 +84,8 @@ export class EditorPage extends BasePage {
         this.assetCreationModalNameInput = page.locator('[data-testid="asset-creation-modal_name-input"]');
         this.saveButton = page.locator('[data-testid="save-button"]');
         this.cancelButton = page.locator('[data-testid="cancel-button"]');
+        this.changeComponentIconButton = page.getByTestId("change-component-icon");
+        this.saveComponentIconButton = page.getByTestId("save-component-icon");
 
         // The "+" on the Custom row and the dialog have no data-testid, so rely on
         // the MUI add-icon test id and accessible roles/labels instead.
@@ -174,6 +178,10 @@ export class EditorPage extends BasePage {
         return this.componentDialog.getByRole("switch", { name: label });
     }
 
+    iconSelectionButton(iconName: string): Locator {
+        return this.componentDialog.getByRole("button", { name: iconName, exact: true });
+    }
+
     async uploadCustomIcon(): Promise<void> {
         // PLAYWRIGHT_FRONTEND_ROOT is set in playwright.config.ts (avoids import.meta.url cache dir issues).
         const iconPath = path.join(process.env["PLAYWRIGHT_FRONTEND_ROOT"]!, "playwright/fixtures/custom-icon.png");
@@ -186,6 +194,10 @@ export class EditorPage extends BasePage {
 
     customComponentMenuButton(name: string): Locator {
         return this.customComponentEntry(name).locator('[data-testid="MoreVertIcon"]');
+    }
+
+    communicationListItemByName(name: string): Locator {
+        return this.page.getByTestId("communication-list-item").filter({ hasText: name });
     }
 
     poaSwitchButton(poa: string): Locator {

--- a/apps/frontend/playwright/pages/projects.page.ts
+++ b/apps/frontend/playwright/pages/projects.page.ts
@@ -99,15 +99,38 @@ export class ProjectsPage extends BasePage {
         return this.page.locator('[data-testid="projects-page_project-card"] p').filter({ hasText: text });
     }
 
-    moveTargetByName(folderName: string): Locator {
-        return this.page
-            .locator('[data-testid="move-target-root"], [data-testid^="move-target-"]')
-            .filter({ has: this.page.getByText(folderName, { exact: true }) });
+    moveTargetByFolderId(folderId: number): Locator {
+        return this.page.locator(`[data-testid="move-target-${folderId}"]`);
     }
 
-    folderSectionByName(folderName: string): Locator {
-        return this.page
-            .locator('[data-testid^="folder-section-"]:not([data-testid$="_header"])')
-            .filter({ has: this.page.locator('[data-testid$="_header"]').getByText(folderName, { exact: true }) });
+    folderSectionById(folderId: number): Locator {
+        return this.page.locator(`[data-testid="folder-section-${folderId}"]`);
+    }
+
+    folderSectionHeaderById(folderId: number): Locator {
+        return this.page.locator(`[data-testid="folder-section-${folderId}_header"]`);
+    }
+
+    ungroupedFolderSection(): Locator {
+        return this.page.locator('[data-testid="folder-section-ungrouped"]');
+    }
+
+    projectNameInFolderSection(folderId: number, projectName: string): Locator {
+        return this.folderSectionById(folderId)
+            .locator('[data-testid="projects-page_project-card_project-name"]')
+            .filter({ has: this.page.getByText(projectName, { exact: true }) });
+    }
+
+    projectNameInUngroupedSection(projectName: string): Locator {
+        return this.ungroupedFolderSection()
+            .locator('[data-testid="projects-page_project-card_project-name"]')
+            .filter({ has: this.page.getByText(projectName, { exact: true }) });
+    }
+
+    async expandFolderSection(folderId: number): Promise<void> {
+        const folderSectionHeader = this.folderSectionHeaderById(folderId);
+        if ((await folderSectionHeader.getAttribute("aria-expanded")) !== "true") {
+            await folderSectionHeader.click();
+        }
     }
 }

--- a/apps/frontend/playwright/pages/projects.page.ts
+++ b/apps/frontend/playwright/pages/projects.page.ts
@@ -6,6 +6,7 @@ export class ProjectsPage extends BasePage {
 
     // Buttons
     readonly addProjectButton: Locator;
+    readonly addFolderButton: Locator;
     readonly sortByDateButton: Locator;
     readonly sortByNameButton: Locator;
     readonly ascendingSortButton: Locator;
@@ -16,6 +17,7 @@ export class ProjectsPage extends BasePage {
     readonly nameInput: Locator;
     readonly descriptionInput: Locator;
     readonly catalogSelection: Locator;
+    readonly folderNameInput: Locator;
     readonly saveButton: Locator;
     readonly cancelButton: Locator;
 
@@ -28,6 +30,7 @@ export class ProjectsPage extends BasePage {
     readonly editProjectButton: Locator;
     readonly deleteProjectButton: Locator;
     readonly exportProjectButton: Locator;
+    readonly moveProjectButton: Locator;
 
     // Navigation
     readonly projectsNavButton: Locator;
@@ -40,6 +43,7 @@ export class ProjectsPage extends BasePage {
     constructor(page: Page) {
         super(page);
         this.addProjectButton = page.locator('[data-testid="projects-page_add-project-button"]');
+        this.addFolderButton = page.locator('[data-testid="projects-page_add-folder-button"]');
         this.sortByDateButton = page.locator('[data-testid="projects-page_sort-projects-by-date-button"]');
         this.sortByNameButton = page.locator('[data-testid="projects-page_sort-projects-by-name-button"]');
         this.ascendingSortButton = page.locator('[data-testid="projects-page_ascending-projects-sort-button"]');
@@ -51,6 +55,7 @@ export class ProjectsPage extends BasePage {
             '[data-testid="project-creation-modal_description-input"] textarea[name="description"]'
         );
         this.catalogSelection = page.locator('[data-testid="project-creation-modal_catalog-selection"]');
+        this.folderNameInput = page.locator('[data-testid="folder-modal_name-input"] input');
         this.saveButton = page.locator('[data-testid="save-button"]');
         this.cancelButton = page.locator('[data-testid="cancel-button"]');
 
@@ -69,6 +74,9 @@ export class ProjectsPage extends BasePage {
         );
         this.exportProjectButton = page.locator(
             '[data-testid="projects-page_project-card_action-menu_export-project-button"]'
+        );
+        this.moveProjectButton = page.locator(
+            '[data-testid="projects-page_project-card_action-menu_move-project-button"]'
         );
 
         this.projectsNavButton = page.locator('[data-testid="navigation-header_projects-page-button"]');
@@ -89,5 +97,17 @@ export class ProjectsPage extends BasePage {
 
     projectCardNameFilter(text: string): Locator {
         return this.page.locator('[data-testid="projects-page_project-card"] p').filter({ hasText: text });
+    }
+
+    moveTargetByName(folderName: string): Locator {
+        return this.page
+            .locator('[data-testid="move-target-root"], [data-testid^="move-target-"]')
+            .filter({ has: this.page.getByText(folderName, { exact: true }) });
+    }
+
+    folderSectionByName(folderName: string): Locator {
+        return this.page
+            .locator('[data-testid^="folder-section-"]:not([data-testid$="_header"])')
+            .filter({ has: this.page.locator('[data-testid$="_header"]').getByText(folderName, { exact: true }) });
     }
 }

--- a/apps/frontend/playwright/tests/catalog.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/catalog.page.e2e.spec.ts
@@ -535,14 +535,17 @@ test.describe("Catalog Page Tests", () => {
         await expect(catalogPage.catalogEditorButton).toBeVisible();
         await expect(catalogPage.membersButton).toBeVisible();
         await expect(catalogPage.catalogEditorButton).toHaveAttribute("aria-pressed", "true");
+        await expect(catalogPage.membersButton).not.toHaveAttribute("aria-pressed", "true");
         await expect(page).toHaveTitle(catalogEditorTitle);
 
         await Promise.all([page.waitForURL(`/catalogs/${catalogId}/members`), catalogPage.membersButton.click()]);
         await expect(catalogPage.membersButton).toHaveAttribute("aria-pressed", "true");
+        await expect(catalogPage.catalogEditorButton).not.toHaveAttribute("aria-pressed", "true");
         await expect(page).toHaveTitle(membersTitle);
 
         await Promise.all([page.waitForURL(`/catalogs/${catalogId}`), catalogPage.catalogEditorButton.click()]);
         await expect(catalogPage.catalogEditorButton).toHaveAttribute("aria-pressed", "true");
+        await expect(catalogPage.membersButton).not.toHaveAttribute("aria-pressed", "true");
         await expect(page).toHaveTitle(catalogEditorTitle);
     });
 });

--- a/apps/frontend/playwright/tests/catalog.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/catalog.page.e2e.spec.ts
@@ -518,14 +518,31 @@ test.describe("Catalog Page Tests", () => {
         await expect(page).toHaveURL("/catalogs");
         await pg.goto(catalogId);
 
-        await pg.membersButton.click();
-        await expect(page).toHaveURL(`/catalogs/${catalogId}/members`);
+        await Promise.all([page.waitForURL(`/catalogs/${catalogId}/members`), pg.membersButton.click()]);
 
-        await pg.catalogEditorButton.click();
-        await expect(page).toHaveURL(`/catalogs/${catalogId}`);
+        await pg.goto(catalogId);
 
         await pg.accountButton.click();
         await expect(pg.accountMenuUsername).toBeVisible();
         await expect(pg.accountMenuLogout).toBeVisible();
+    });
+
+    test("Should keep catalog header tabs and title in sync", async ({ page }) => {
+        const catalogPage = new CatalogPage(page);
+        const catalogEditorTitle = /^ThreatSea(?: - .+)? - Catalog Editor$/;
+        const membersTitle = /^ThreatSea(?: - .+)? - Members$/;
+
+        await expect(catalogPage.catalogEditorButton).toBeVisible();
+        await expect(catalogPage.membersButton).toBeVisible();
+        await expect(catalogPage.catalogEditorButton).toHaveAttribute("aria-pressed", "true");
+        await expect(page).toHaveTitle(catalogEditorTitle);
+
+        await Promise.all([page.waitForURL(`/catalogs/${catalogId}/members`), catalogPage.membersButton.click()]);
+        await expect(catalogPage.membersButton).toHaveAttribute("aria-pressed", "true");
+        await expect(page).toHaveTitle(membersTitle);
+
+        await Promise.all([page.waitForURL(`/catalogs/${catalogId}`), catalogPage.catalogEditorButton.click()]);
+        await expect(catalogPage.catalogEditorButton).toHaveAttribute("aria-pressed", "true");
+        await expect(page).toHaveTitle(catalogEditorTitle);
     });
 });

--- a/apps/frontend/playwright/tests/editor.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/editor.page.e2e.spec.ts
@@ -149,6 +149,24 @@ test.describe("Editor Page Tests", () => {
     });
 
     test.describe("Communication Interface Sidebar Tests", () => {
+        test("Creates a communication interface without manually choosing an icon", async ({ page, browserName }, {
+            testId,
+        }) => {
+            const editorPage = new EditorPage(page);
+            const communicationName = `Default Interface ${buildTestId(browserName, testId)}`;
+
+            await editorPage.clickCanvas(880, 375);
+            await expect(editorPage.createCommunicationButton).toBeVisible();
+            await editorPage.createCommunicationButton.click();
+            await editorPage.communicationNameInput.fill(communicationName);
+
+            await expect(editorPage.saveCommunicationButton).toBeEnabled();
+            await editorPage.saveCommunicationButton.click();
+            await expect(editorPage.saveCommunicationButton).toBeHidden();
+            await editorPage.clickCanvas(880, 375);
+            await expect(editorPage.communicationListItemByName(communicationName)).toBeVisible();
+        });
+
         test("Performs case insensitive search", async ({ page }) => {
             const pg = new EditorPage(page);
             await pg.addCommunication();
@@ -370,6 +388,25 @@ test.describe("Editor Page Tests", () => {
             await pg.openContextMenu();
             await pg.expandCustomComponents();
             await expect(pg.customComponentEntry(name)).toHaveCount(0);
+        });
+    });
+
+    test.describe("Placed Component Icon Tests", () => {
+        test("Saves and reopens the selected icon for a placed component", async ({ page }) => {
+            const editorPage = new EditorPage(page);
+
+            await editorPage.clickCanvas(505, 345);
+            await expect(editorPage.changeComponentIconButton).toBeVisible();
+            await editorPage.changeComponentIconButton.click();
+
+            await editorPage.iconSelectionButton("Server").click();
+            await expect(editorPage.iconSelectionButton("Server")).toHaveAttribute("aria-pressed", "true");
+
+            await editorPage.saveComponentIconButton.click();
+            await expect(editorPage.componentDialog).toBeHidden();
+
+            await editorPage.changeComponentIconButton.click();
+            await expect(editorPage.iconSelectionButton("Server")).toHaveAttribute("aria-pressed", "true");
         });
     });
 });

--- a/apps/frontend/playwright/tests/projects.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/projects.page.e2e.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import type { CONFIDENTIALITY_LEVELS } from "#utils/confidentiality.ts";
 import { createCatalog, deleteCatalog, getCatalogs } from "../utils/catalog.api.ts";
+import { deleteFolders, getFolders } from "../utils/folder.api.ts";
 import { createProject, createProjects, deleteProjects, getProjects } from "../utils/project.api.ts";
 import { buildTestId, buildProject } from "../builder/test-data.builder.ts";
 import { ProjectsPage } from "../pages/projects.page.ts";
@@ -61,6 +62,10 @@ test.afterEach(async ({ page, request, browserName }, { testId }) => {
     const allProjects = await getProjects(request, token);
     const projectIds = allProjects.filter((p) => p.name.includes(tid)).map((p) => p.id);
     await deleteProjects(request, token, projectIds);
+
+    const allFolders = await getFolders(request, token);
+    const folderIds = allFolders.filter((folder) => folder.name.includes(tid)).map((folder) => folder.id);
+    await deleteFolders(request, token, folderIds);
 
     const catalogs = await getCatalogs(request, token);
     const catalog = catalogs.find((c) => c.name.includes(tid));
@@ -175,6 +180,45 @@ test.describe("Projects Page Tests", () => {
         await projectsPage.saveButton.click();
 
         await expect(projectsPage.projectCardNames.first()).toContainText(updatedName);
+    });
+
+    test("Should create a folder and move a project into it", async ({ page, request, browserName }, { testId }) => {
+        const projectsPage = new ProjectsPage(page);
+        const testIdentifier = buildTestId(browserName, testId);
+        const token = await projectsPage.getCsrfToken();
+
+        const projectToMove = { ...projects[0]!, name: `${projects[0]!.name}-${testIdentifier}` };
+        await createProject(
+            request,
+            token,
+            buildProject(projectToMove.name, projectToMove.catalogId, projectToMove.confidentialityLevel)
+        );
+        await page.reload();
+
+        const folderName = `Folder-${testIdentifier}`;
+        await projectsPage.addFolderButton.click();
+        await projectsPage.folderNameInput.fill(folderName);
+        await projectsPage.saveButton.click();
+        await expect(page).toHaveURL("/projects");
+        await expect(projectsPage.folderSectionByName(folderName)).toBeVisible();
+
+        await projectsPage.searchField.fill(testIdentifier);
+        await expect(projectsPage.projectCards).toHaveCount(1);
+        await projectsPage.actionMenuButton.first().click();
+        await projectsPage.moveProjectButton.click();
+
+        await expect(projectsPage.moveTargetByName(folderName)).toBeVisible();
+        await projectsPage.moveTargetByName(folderName).click();
+        await projectsPage.saveButton.click();
+        await expect(page).toHaveURL("/projects");
+
+        await projectsPage.searchField.fill("");
+        await expect(
+            projectsPage
+                .folderSectionByName(folderName)
+                .locator('[data-testid="projects-page_project-card_project-name"]')
+                .filter({ hasText: projectToMove.name })
+        ).toBeVisible();
     });
 
     test("Should delete an existing project", async ({ page, request, browserName }, { testId }) => {

--- a/apps/frontend/playwright/tests/projects.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/projects.page.e2e.spec.ts
@@ -200,25 +200,30 @@ test.describe("Projects Page Tests", () => {
         await projectsPage.folderNameInput.fill(folderName);
         await projectsPage.saveButton.click();
         await expect(page).toHaveURL("/projects");
-        await expect(projectsPage.folderSectionByName(folderName)).toBeVisible();
+
+        const folders = await getFolders(request, token);
+        const createdFolder = folders.find((folder) => folder.name === folderName);
+        if (!createdFolder) {
+            throw new Error(`Folder "${folderName}" was not created`);
+        }
+
+        await expect(projectsPage.folderSectionById(createdFolder.id)).toBeVisible();
 
         await projectsPage.searchField.fill(testIdentifier);
         await expect(projectsPage.projectCards).toHaveCount(1);
         await projectsPage.actionMenuButton.first().click();
         await projectsPage.moveProjectButton.click();
 
-        await expect(projectsPage.moveTargetByName(folderName)).toBeVisible();
-        await projectsPage.moveTargetByName(folderName).click();
+        await expect(projectsPage.moveTargetByFolderId(createdFolder.id)).toBeVisible();
+        await projectsPage.moveTargetByFolderId(createdFolder.id).click();
         await projectsPage.saveButton.click();
         await expect(page).toHaveURL("/projects");
+        await page.reload();
 
         await projectsPage.searchField.fill("");
-        await expect(
-            projectsPage
-                .folderSectionByName(folderName)
-                .locator('[data-testid="projects-page_project-card_project-name"]')
-                .filter({ hasText: projectToMove.name })
-        ).toBeVisible();
+        await projectsPage.expandFolderSection(createdFolder.id);
+        await expect(projectsPage.projectNameInFolderSection(createdFolder.id, projectToMove.name)).toBeVisible();
+        await expect(projectsPage.projectNameInUngroupedSection(projectToMove.name)).toHaveCount(0);
     });
 
     test("Should delete an existing project", async ({ page, request, browserName }, { testId }) => {

--- a/apps/frontend/playwright/utils/folder.api.ts
+++ b/apps/frontend/playwright/utils/folder.api.ts
@@ -3,7 +3,15 @@ import type { Folder } from "#api/types/folder.types.ts";
 import { fetchApi } from "./api.utils.ts";
 
 export async function getFolders(request: APIRequestContext, token: string): Promise<Folder[]> {
-    return fetchApi(request, token, "GET", "/folders");
+    const folders = await fetchApi<
+        (Omit<Folder, "createdAt" | "updatedAt"> & { createdAt: string; updatedAt: string })[]
+    >(request, token, "GET", "/folders");
+
+    return folders.map((folder) => ({
+        ...folder,
+        createdAt: new Date(folder.createdAt),
+        updatedAt: new Date(folder.updatedAt),
+    }));
 }
 
 export async function deleteFolder(request: APIRequestContext, token: string, folderId: number): Promise<void> {

--- a/apps/frontend/playwright/utils/folder.api.ts
+++ b/apps/frontend/playwright/utils/folder.api.ts
@@ -1,0 +1,17 @@
+import type { APIRequestContext } from "@playwright/test";
+import type { Folder } from "#api/types/folder.types.ts";
+import { fetchApi } from "./api.utils.ts";
+
+export async function getFolders(request: APIRequestContext, token: string): Promise<Folder[]> {
+    return fetchApi(request, token, "GET", "/folders");
+}
+
+export async function deleteFolder(request: APIRequestContext, token: string, folderId: number): Promise<void> {
+    await fetchApi(request, token, "DELETE", `/folders/${folderId}`);
+}
+
+export async function deleteFolders(request: APIRequestContext, token: string, folderIds: number[]): Promise<void> {
+    for (const folderId of folderIds) {
+        await deleteFolder(request, token, folderId);
+    }
+}


### PR DESCRIPTION
## Why
Our Playwright E2E coverage for recently added frontend workflows was incomplete and showed instability in a few navigation/locator scenarios.  
We need stable automated coverage before moving this into regular pipeline usage.

## What
- Added/extended Playwright coverage for:
  - project folder creation + moving a project into a folder
  - placed component icon change persistence (reopen check)
  - catalog header tab navigation (`Catalog Editor` ↔ `Members`) including URL/title sync
- Refined relevant Playwright page-object locators/assertions to reduce flakiness.
- Added a small folder API test utility used by cleanup/setup flows.

## Validation
- Frontend type-check passes.
- Full frontend Playwright suite passes locally (`104 passed`).
- Lint/type checks triggered by hooks passed during commit/push.

## Scope
- Test-focused changes only (Playwright tests/page objects/test utils).
- No product feature behavior changes intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating folders, moving projects into folders, and expanding folder sections.
  * Added component icon selection and saving workflows.
* **Bug Fixes**
  * Improved catalog navigation handling with reliable page transitions and verified tab states and titles.
* **Tests**
  * Added end-to-end coverage for folder management, component icon persistence, and communication interface creation without manually selecting an icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->