### PR TITLE
fix(backend): allow PNG, JPEG, WebP and SVG as valid MIME type

### DIFF
--- a/apps/backend/src/middlewares/input-validations/validator-messages.ts
+++ b/apps/backend/src/middlewares/input-validations/validator-messages.ts
@@ -103,6 +103,13 @@ export const INVALID_LINES_OF_TOLERANCE_RATIO_MESSAGE = () => {
     return "lineOfToleranceGreen must be less or equal than lineOfToleranceRed";
 };
 
-export function formatValidationErrors(errors: ValidationError[]): string[] {
-    return errors.flatMap((error) => (error.constraints ? Object.values(error.constraints) : []));
+export function formatValidationErrors(errors: ValidationError[], parentPath = ""): string[] {
+    return errors.flatMap((error) => {
+        const path = parentPath ? `${parentPath}.${error.property}` : error.property;
+        // Top-level messages already name their field; nested ones need the path to locate them.
+        const ownMessages = error.constraints
+            ? Object.values(error.constraints).map((message) => (parentPath ? `${path}: ${message}` : message))
+            : [];
+        return [...ownMessages, ...formatValidationErrors(error.children ?? [], path)];
+    });
 }

--- a/apps/backend/src/middlewares/input-validations/validator-messages.ts
+++ b/apps/backend/src/middlewares/input-validations/validator-messages.ts
@@ -18,14 +18,15 @@ export const MAX_NAME_LENGTH = 255;
 export const MAX_DESCRIPTION_LENGTH = 65535;
 // Allows ~100 kB binary after base64 inflation (~33%) plus the `data:image/...;base64,` prefix.
 export const MAX_SYMBOL_LENGTH = 150_000;
-// Uploaded icon (component type): a base64 PNG or JPEG data URL only.
-export const IMAGE_DATA_URL_PATTERN = /^data:image\/(png|jpeg);base64,[A-Za-z0-9+/=]+$/;
+// Uploaded icon (component type): a base64 PNG, JPEG, WebP or SVG data URL only.
+export const IMAGE_DATA_URL_PATTERN = /^data:image\/(png|jpeg|webp|svg\+xml);base64,[A-Za-z0-9+/=]+$/i;
 
-// Placed component: a rooted local asset path (bundled standard icons) or a PNG/JPEG data URL.
-// Anchored + case-insensitive so an embedded image can only ever be PNG/JPEG — blocks
-// data:image/svg+xml (incl. upper-cased/whitespace-padded schemes) and remote/`javascript:` URLs.
+// Placed component: a rooted local asset path (bundled standard icons) or one of the data URLs
+// above. Anchored + case-insensitive so an embedded image can only ever carry a registered image
+// MIME type — blocks non-image data URLs (incl. whitespace-padded schemes) and remote/
+// `javascript:` URLs. SVG may contain scripts, so symbols must only ever be rendered via <img>.
 export const SYSTEM_COMPONENT_SYMBOL_PATTERN =
-    /^(?:\/[\w.-][\w./-]*\.(?:png|jpe?g|webp|svg)|data:image\/(?:png|jpeg);base64,[A-Za-z0-9+/=]+)$/i;
+    /^(?:\/[\w.-][\w./-]*\.(?:png|jpe?g|webp|svg)|data:image\/(?:png|jpeg|webp|svg\+xml);base64,[A-Za-z0-9+/=]+)$/i;
 export const CIA_VALUE_MIN = 1;
 export const CIA_VALUE_MAX = 5;
 export const PROBABILITY_VALUE_MIN = 1;
@@ -76,7 +77,7 @@ export const FIELD_MUST_BE_ISO_8601_DATE = (field: string, condition?: string) =
 };
 
 export const FIELD_MUST_BE_VALID_IMAGE_DATA = (field: string, condition?: string) => {
-    return `Field ${field} must be a valid base64-encoded PNG or JPEG${condition ? ` ${condition}` : ""}`;
+    return `Field ${field} must be a valid base64-encoded PNG, JPEG, WebP or SVG${condition ? ` ${condition}` : ""}`;
 };
 
 export const FIELD_MUST_BE_ONE_OF_MESSAGE = (field: string, values: unknown[]) => {

--- a/apps/backend/tests/import.test.ts
+++ b/apps/backend/tests/import.test.ts
@@ -81,9 +81,21 @@ describe("import a project", () => {
         expect(res.statusCode).toEqual(204);
     });
 
-    it("should reject an import whose component type symbol is a data:image/svg+xml URL", async () => {
+    it("should import a project whose component type symbol is a data:image/svg+xml URL", async () => {
         const project = JSON.parse(JSON.stringify(VALID_TEST_PROJECT));
         project.componentTypes[0].symbol = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+
+        const res = await request(app)
+            .post("/api/import")
+            .send(project)
+            .set("X-CSRF-TOKEN", csrfToken)
+            .set("Cookie", cookies);
+        expect(res.statusCode).toEqual(204);
+    });
+
+    it("should reject an import whose component type symbol is an unsupported image data URL", async () => {
+        const project = JSON.parse(JSON.stringify(VALID_TEST_PROJECT));
+        project.componentTypes[0].symbol = "data:image/gif;base64,R0lGODlhAQABAAAAACw=";
 
         const res = await request(app)
             .post("/api/import")

--- a/apps/backend/tests/symbol-pattern-validation.test.ts
+++ b/apps/backend/tests/symbol-pattern-validation.test.ts
@@ -8,13 +8,20 @@ import {
  * cover only a couple of cases).
  */
 describe("IMAGE_DATA_URL_PATTERN (component types — strict)", () => {
-    it("accepts base64 PNG and JPEG data URLs", () => {
+    it("accepts base64 PNG, JPEG, WebP and SVG data URLs", () => {
         expect(IMAGE_DATA_URL_PATTERN.test("data:image/png;base64,iVBORw0KGgo=")).toBe(true);
         expect(IMAGE_DATA_URL_PATTERN.test("data:image/jpeg;base64,/9j/4AAQSkZJRg==")).toBe(true);
+        expect(IMAGE_DATA_URL_PATTERN.test("data:image/webp;base64,UklGRg==")).toBe(true);
+        expect(IMAGE_DATA_URL_PATTERN.test("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")).toBe(true);
     });
 
-    it("rejects non-image and embedded-script data URLs", () => {
-        expect(IMAGE_DATA_URL_PATTERN.test("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")).toBe(false);
+    it("rejects unregistered MIME type spellings", () => {
+        expect(IMAGE_DATA_URL_PATTERN.test("data:image/svg;base64,PHN2Zz4=")).toBe(false);
+        expect(IMAGE_DATA_URL_PATTERN.test("data:image/sv+xml;base64,PHN2Zz4=")).toBe(false);
+        expect(IMAGE_DATA_URL_PATTERN.test("data:image/jpg;base64,/9j/4AAQ==")).toBe(false);
+    });
+
+    it("rejects out-of-scope image, non-image and embedded-script data URLs", () => {
         expect(IMAGE_DATA_URL_PATTERN.test("data:image/gif;base64,R0lGOD==")).toBe(false);
         expect(IMAGE_DATA_URL_PATTERN.test("data:text/html;base64,PHNjcmlwdD4=")).toBe(false);
     });
@@ -29,18 +36,27 @@ describe("IMAGE_DATA_URL_PATTERN (component types — strict)", () => {
 });
 
 describe("SYSTEM_COMPONENT_SYMBOL_PATTERN (placed components — lax on references)", () => {
-    it("accepts base64 PNG and JPEG data URLs", () => {
+    it("accepts base64 PNG, JPEG, WebP and SVG data URLs", () => {
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/png;base64,iVBORw0KGgo=")).toBe(true);
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/jpeg;base64,/9j/4AAQ==")).toBe(true);
+        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/webp;base64,UklGRg==")).toBe(true);
+        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")).toBe(true);
     });
 
     it("accepts legacy non-data reference paths so existing diagrams keep saving", () => {
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("/static/media/user.4176f8c5.png")).toBe(true);
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("/static/media/database.b31ed5f1.png")).toBe(true);
+        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("/static/media/cloud.0a1b2c3d.svg")).toBe(true);
+        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("/static/media/router.4e5f6a7b.webp")).toBe(true);
+    });
+
+    it("rejects unregistered MIME type spellings and MIME-like path extensions", () => {
+        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/svg;base64,PHN2Zz4=")).toBe(false);
+        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/sv+xml;base64,PHN2Zz4=")).toBe(false);
+        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("/static/media/icon.svg+xml")).toBe(false);
     });
 
     it("still rejects embedded non-image and script data URLs", () => {
-        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")).toBe(false);
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/gif;base64,R0lGOD==")).toBe(false);
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:text/html;base64,PHNjcmlwdD4=")).toBe(false);
     });
@@ -49,9 +65,9 @@ describe("SYSTEM_COMPONENT_SYMBOL_PATTERN (placed components — lax on referenc
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("data:image/png;charset=utf-8;base64,AAAA")).toBe(false);
     });
 
-    it("still rejects an svg data URL when the scheme is upper-cased or whitespace-padded", () => {
-        // Consumers treat the scheme case-insensitively and trim whitespace; must not bypass png/jpeg.
-        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("DATA:image/svg+xml;base64,PHN2Zz4=")).toBe(false);
+    it("treats scheme case-insensitively but still rejects whitespace-padded data URLs", () => {
+        // Consumers treat the scheme case-insensitively; the pattern mirrors that on purpose.
+        expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("DATA:image/svg+xml;base64,PHN2Zz4=")).toBe(true);
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test(" data:image/svg+xml;base64,PHN2Zz4=")).toBe(false);
         expect(SYSTEM_COMPONENT_SYMBOL_PATTERN.test("\tdata:text/html;base64,PHNjcmlwdD4=")).toBe(false);
     });

--- a/apps/backend/tests/system.test.ts
+++ b/apps/backend/tests/system.test.ts
@@ -647,11 +647,20 @@ const systemWithComponentSymbol = (symbol: string) => ({
     image: null,
 });
 
-it("should reject a component whose symbol is a data:image/svg+xml URL", async () => {
-    // "<svg></svg>" — embedded payload that must not be stored.
+it("should accept a component whose symbol is a data:image/svg+xml URL", async () => {
+    // "<svg></svg>" — SVG is a supported symbol format; only ever rendered via <img>.
     const res = await request(app)
         .put(`/api/projects/${projectId}/system`)
         .send(systemWithComponentSymbol("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="))
+        .set("X-CSRF-TOKEN", csrfToken)
+        .set("Cookie", cookies);
+    expect(res.statusCode).toEqual(200);
+});
+
+it("should reject a component whose symbol is an unsupported image data URL", async () => {
+    const res = await request(app)
+        .put(`/api/projects/${projectId}/system`)
+        .send(systemWithComponentSymbol("data:image/gif;base64,R0lGODlhAQABAAAAACw="))
         .set("X-CSRF-TOKEN", csrfToken)
         .set("Cookie", cookies);
     expect(res.statusCode).toEqual(400);

--- a/apps/backend/tests/validator-messages.test.ts
+++ b/apps/backend/tests/validator-messages.test.ts
@@ -12,7 +12,7 @@ describe("formatValidationErrors", () => {
             data: {
                 components: [
                     { symbol: "/static/media/user.4176f8c5.png" },
-                    { symbol: "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" },
+                    { symbol: "data:image/gif;base64,R0lGODlhAQABAAAAACw=" },
                 ],
             },
         };

--- a/apps/backend/tests/validator-messages.test.ts
+++ b/apps/backend/tests/validator-messages.test.ts
@@ -1,0 +1,26 @@
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import {
+    FIELD_MUST_BE_VALID_IMAGE_DATA,
+    formatValidationErrors,
+} from "#middlewares/input-validations/validator-messages.js";
+import { UpdateSystemRequestDto } from "#types/system.types.js";
+
+describe("formatValidationErrors", () => {
+    it("includes messages from nested validation errors with their property path", async () => {
+        const body = {
+            data: {
+                components: [
+                    { symbol: "/static/media/user.4176f8c5.png" },
+                    { symbol: "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" },
+                ],
+            },
+        };
+        const instance = plainToInstance(UpdateSystemRequestDto, body, { enableImplicitConversion: true });
+
+        const errors = await validate(instance, { whitelist: false });
+        const messages = formatValidationErrors(errors);
+
+        expect(messages).toEqual([`data.components.1.symbol: ${FIELD_MUST_BE_VALID_IMAGE_DATA("symbol")}`]);
+    });
+});

--- a/apps/frontend/src/translations/de/editor-page.de.json
+++ b/apps/frontend/src/translations/de/editor-page.de.json
@@ -90,7 +90,7 @@
     "iconStandardLabel": "Standardsymbole",
     "iconOr": "oder",
     "iconUploadLabel": "Eigenes Symbol",
-    "iconUploadHint": "PNG / JPEG, bis 100 kB.",
+    "iconUploadHint": "PNG / JPEG / WebP / SVG, bis 100 kB.",
     "iconUploadTooltip": "Eigenes Symbol hochladen",
     "iconRequired": "Ein Symbol ist erforderlich"
   },

--- a/apps/frontend/src/translations/en/editor-page.en.json
+++ b/apps/frontend/src/translations/en/editor-page.en.json
@@ -90,7 +90,7 @@
     "iconStandardLabel": "Standard icons",
     "iconOr": "or",
     "iconUploadLabel": "Custom upload",
-    "iconUploadHint": "PNG / JPEG, up to 100 kB.",
+    "iconUploadHint": "PNG / JPEG / WebP / SVG, up to 100 kB.",
     "iconUploadTooltip": "Upload custom icon",
     "iconRequired": "An icon is required",
     "errorMessages": {

--- a/apps/frontend/src/utils/files.test.ts
+++ b/apps/frontend/src/utils/files.test.ts
@@ -2,6 +2,8 @@ import { MAX_ICON_BYTES, validateAndConvertIconFile } from "./files";
 
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47];
 const JPEG_SIGNATURE = [0xff, 0xd8, 0xff];
+// RIFF container (bytes 0-3) with WEBP form type (bytes 8-11).
+const WEBP_SIGNATURE = [0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50];
 
 /** Builds a File with `leadingBytes` first, zero-padded to `size`, of MIME `type`. */
 function buildFile({ leadingBytes = [], size, type }: { leadingBytes?: number[]; size?: number; type: string }): File {
@@ -32,6 +34,27 @@ describe("validateAndConvertIconFile", () => {
         }
     });
 
+    it("accepts a real WebP and returns a webp data URL", async () => {
+        const result = await validateAndConvertIconFile(
+            buildFile({ leadingBytes: WEBP_SIGNATURE, type: "image/webp" })
+        );
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.dataUrl.startsWith("data:image/webp;base64,")).toBe(true);
+        }
+    });
+
+    it("accepts an SVG and returns an svg data URL", async () => {
+        const svg = '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>';
+        const result = await validateAndConvertIconFile(new File([svg], "icon", { type: "image/svg+xml" }));
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.dataUrl.startsWith("data:image/svg+xml;base64,")).toBe(true);
+        }
+    });
+
     it("rejects an unsupported MIME type", async () => {
         const result = await validateAndConvertIconFile(buildFile({ leadingBytes: PNG_SIGNATURE, type: "image/gif" }));
 
@@ -56,6 +79,20 @@ describe("validateAndConvertIconFile", () => {
         );
 
         expect(result).toEqual({ ok: false, reason: "size" });
+    });
+
+    it("rejects PNG bytes labeled as WebP (type and content disagree)", async () => {
+        const result = await validateAndConvertIconFile(buildFile({ leadingBytes: PNG_SIGNATURE, type: "image/webp" }));
+
+        expect(result).toEqual({ ok: false, reason: "content" });
+    });
+
+    it("rejects non-SVG text labeled as SVG", async () => {
+        const result = await validateAndConvertIconFile(
+            new File(["<html><script>alert(1)</script></html>"], "icon", { type: "image/svg+xml" })
+        );
+
+        expect(result).toEqual({ ok: false, reason: "content" });
     });
 
     it("rejects a non-image whose extension/MIME was spoofed to look like a PNG", async () => {

--- a/apps/frontend/src/utils/files.test.ts
+++ b/apps/frontend/src/utils/files.test.ts
@@ -95,6 +95,22 @@ describe("validateAndConvertIconFile", () => {
         expect(result).toEqual({ ok: false, reason: "content" });
     });
 
+    it("rejects a non-SVG document that merely mentions <svg> in a comment", async () => {
+        const result = await validateAndConvertIconFile(
+            new File(["<!-- <svg> --><html></html>"], "icon", { type: "image/svg+xml" })
+        );
+
+        expect(result).toEqual({ ok: false, reason: "content" });
+    });
+
+    it("rejects malformed XML labeled as SVG", async () => {
+        const result = await validateAndConvertIconFile(
+            new File(['<svg xmlns="http://www.w3.org/2000/svg"><rect</svg>'], "icon", { type: "image/svg+xml" })
+        );
+
+        expect(result).toEqual({ ok: false, reason: "content" });
+    });
+
     it("rejects a non-image whose extension/MIME was spoofed to look like a PNG", async () => {
         // "GIF" header bytes but claims to be image/png.
         const result = await validateAndConvertIconFile(

--- a/apps/frontend/src/utils/files.ts
+++ b/apps/frontend/src/utils/files.ts
@@ -4,7 +4,7 @@
  */
 
 export const MAX_ICON_BYTES = 100_000;
-export const ACCEPTED_ICON_MIME_TYPES = "image/png,image/jpeg";
+export const ACCEPTED_ICON_MIME_TYPES = "image/png,image/jpeg,image/webp,image/svg+xml";
 
 // TODO(#577 follow-up): uploaded icons are stored inline as base64 data URLs in each
 // component's `symbol` (system.data JSONB), with no dedup. If storage size becomes a
@@ -35,25 +35,34 @@ export function convertFileToBase64(file: Blob): Promise<string> {
     });
 }
 
-/** Why an icon upload was refused: wrong MIME ("type"), too big ("size"), or bytes aren't a real PNG/JPEG ("content"). */
+/** Why an icon upload was refused: wrong MIME ("type"), too big ("size"), or bytes don't match the declared type ("content"). */
 export type IconRejectionReason = "type" | "size" | "content";
 
 export type IconValidationResult = { ok: true; dataUrl: string } | { ok: false; reason: IconRejectionReason };
 
-// Magic bytes per accepted MIME type.
-const IMAGE_SIGNATURES: Record<string, readonly number[]> = {
-    "image/png": [0x89, 0x50, 0x4e, 0x47],
-    "image/jpeg": [0xff, 0xd8, 0xff],
+function matchesBytes(header: Uint8Array, offset: number, bytes: readonly number[]): boolean {
+    return bytes.every((byte, index) => header[offset + index] === byte);
+}
+
+// Content checks per accepted MIME type: magic bytes for the binary formats, an <svg> element
+// for SVG (text-based, so it has no magic bytes).
+const IMAGE_CONTENT_CHECKS: Record<string, (header: Uint8Array) => boolean> = {
+    "image/png": (header) => matchesBytes(header, 0, [0x89, 0x50, 0x4e, 0x47]),
+    "image/jpeg": (header) => matchesBytes(header, 0, [0xff, 0xd8, 0xff]),
+    // RIFF container (bytes 0-3) with WEBP form type (bytes 8-11).
+    "image/webp": (header) =>
+        matchesBytes(header, 0, [0x52, 0x49, 0x46, 0x46]) && matchesBytes(header, 8, [0x57, 0x45, 0x42, 0x50]),
+    "image/svg+xml": (header) => /<svg[\s/>]/i.test(new TextDecoder().decode(header)),
 };
 
-// Check the bytes against the signature for the declared MIME type, so type and content must agree.
-function hasMatchingImageSignature(mimeType: string, header: Uint8Array): boolean {
-    const signature = IMAGE_SIGNATURES[mimeType];
-    return signature != null && signature.every((byte, index) => header[index] === byte);
+// Check the bytes against the check for the declared MIME type, so type and content must agree.
+function hasMatchingImageContent(mimeType: string, header: Uint8Array): boolean {
+    const check = IMAGE_CONTENT_CHECKS[mimeType];
+    return check != null && check(header);
 }
 
 /**
- * Validates an icon by MIME, size, and magic bytes (MIME alone is spoofable), then converts it to a
+ * Validates an icon by MIME, size, and content (MIME alone is spoofable), then converts it to a
  * base64 data URL. Returns the data URL, or the reason it was rejected.
  */
 export async function validateAndConvertIconFile(file: File): Promise<IconValidationResult> {
@@ -65,7 +74,7 @@ export async function validateAndConvertIconFile(file: File): Promise<IconValida
     }
 
     const header = new Uint8Array(await file.arrayBuffer());
-    if (!hasMatchingImageSignature(file.type, header)) {
+    if (!hasMatchingImageContent(file.type, header)) {
         return { ok: false, reason: "content" };
     }
 

--- a/apps/frontend/src/utils/files.ts
+++ b/apps/frontend/src/utils/files.ts
@@ -44,7 +44,14 @@ function matchesBytes(header: Uint8Array, offset: number, bytes: readonly number
     return bytes.every((byte, index) => header[offset + index] === byte);
 }
 
-// Content checks per accepted MIME type: magic bytes for the binary formats, an <svg> element
+function isSvgDocument(bytes: Uint8Array): boolean {
+    const doc = new DOMParser().parseFromString(new TextDecoder().decode(bytes), "image/svg+xml");
+    // On malformed XML, DOMParser yields a <parsererror> root instead of throwing.
+    const root = doc.documentElement;
+    return root.localName === "svg" && root.namespaceURI === "http://www.w3.org/2000/svg";
+}
+
+// Content checks per accepted MIME type: magic bytes for the binary formats, a full XML parse
 // for SVG (text-based, so it has no magic bytes).
 const IMAGE_CONTENT_CHECKS: Record<string, (header: Uint8Array) => boolean> = {
     "image/png": (header) => matchesBytes(header, 0, [0x89, 0x50, 0x4e, 0x47]),
@@ -52,7 +59,7 @@ const IMAGE_CONTENT_CHECKS: Record<string, (header: Uint8Array) => boolean> = {
     // RIFF container (bytes 0-3) with WEBP form type (bytes 8-11).
     "image/webp": (header) =>
         matchesBytes(header, 0, [0x52, 0x49, 0x46, 0x46]) && matchesBytes(header, 8, [0x57, 0x45, 0x42, 0x50]),
-    "image/svg+xml": (header) => /<svg[\s/>]/i.test(new TextDecoder().decode(header)),
+    "image/svg+xml": isSvgDocument,
 };
 
 // Check the bytes against the check for the declared MIME type, so type and content must agree.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for WebP and SVG icons and component symbols, including uploads up to 100 kB.
  * Preserved support for rooted local image paths.
  * Improved validation messages to show complete nested property paths, including array indices.

* **Bug Fixes**
  * Unsupported formats, invalid MIME types, malformed data URLs, and invalid image content are rejected.
  * Improved handling of uppercase data URL schemes while maintaining strict content validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->