### PR TITLE
feat(frontend): add about dialog and display app version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            APP_VERSION=${{ needs.compute-version.outputs.new_release_version }}
           platforms: linux/amd64,linux/arm64
           provenance: mode=max
           sbom: true
@@ -153,6 +155,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            APP_VERSION=${{ needs.compute-version.outputs.new_release_version }}
           platforms: linux/amd64,linux/arm64
           provenance: mode=max
           sbom: true

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,3 @@
 pnpm lint
+pnpm format:check
+pnpm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ ENV NODE_ENV=production
 ENV API_URI=""
 ENV VITE_API_URI=$API_URI
 
-ARG APP_VERSION=""
-ENV VITE_APP_VERSION=$APP_VERSION
-
 WORKDIR /builder
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
@@ -26,6 +23,9 @@ RUN pnpm fetch --filter "..../${FRONTEND_DIR}"
 COPY . .
 
 RUN pnpm -r --filter "..../${FRONTEND_DIR}" install --frozen-lockfile
+
+ARG APP_VERSION=""
+ENV VITE_APP_VERSION=$APP_VERSION
 RUN pnpm -r --filter "..../${FRONTEND_DIR}" run build
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ ENV NODE_ENV=production
 ENV API_URI=""
 ENV VITE_API_URI=$API_URI
 
+ARG APP_VERSION=""
+ENV VITE_APP_VERSION=$APP_VERSION
+
 WORKDIR /builder
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./

--- a/apps/frontend/src/api/utils.ts
+++ b/apps/frontend/src/api/utils.ts
@@ -4,7 +4,7 @@
  */
 import { CsrfApi } from "#api/csrf.api.ts";
 
-export const API_URI = `${import.meta.env["VITE_API_URI"] ?? ""}/api`;
+export const API_URI = `${import.meta.env.VITE_API_URI ?? ""}/api`;
 
 /**
  * Saves the csrf token as a string inside the local storage.

--- a/apps/frontend/src/translations/de/main-menu.de.json
+++ b/apps/frontend/src/translations/de/main-menu.de.json
@@ -3,5 +3,10 @@
   "settings": "Einstellungen",
   "member": "Mitglieder",
   "privacy": "Datenschutzerklärung",
-  "imprint": "Impressum"
+  "imprint": "Impressum",
+  "about": "Über ThreatSea",
+  "aboutDialog": {
+    "license": "Lizenz",
+    "repository": "Quellcode auf GitHub"
+  }
 }

--- a/apps/frontend/src/translations/de/main-menu.de.json
+++ b/apps/frontend/src/translations/de/main-menu.de.json
@@ -7,6 +7,7 @@
   "about": "Über ThreatSea",
   "aboutDialog": {
     "license": "Lizenz",
+    "version": "Version",
     "repository": "Quellcode auf GitHub",
     "close": "Schließen"
   }

--- a/apps/frontend/src/translations/de/main-menu.de.json
+++ b/apps/frontend/src/translations/de/main-menu.de.json
@@ -7,6 +7,7 @@
   "about": "Über ThreatSea",
   "aboutDialog": {
     "license": "Lizenz",
-    "repository": "Quellcode auf GitHub"
+    "repository": "Quellcode auf GitHub",
+    "close": "Schließen"
   }
 }

--- a/apps/frontend/src/translations/en/main-menu.en.json
+++ b/apps/frontend/src/translations/en/main-menu.en.json
@@ -8,6 +8,7 @@
   "about": "About ThreatSea",
   "aboutDialog": {
     "license": "License",
-    "repository": "Source code on GitHub"
+    "repository": "Source code on GitHub",
+    "close": "Close"
   }
 }

--- a/apps/frontend/src/translations/en/main-menu.en.json
+++ b/apps/frontend/src/translations/en/main-menu.en.json
@@ -4,5 +4,10 @@
   "member": "Members",
   "privacy": "Privacy Policy",
   "imprint": "Imprint",
-  "catalogs": "Catalogs"
+  "catalogs": "Catalogs",
+  "about": "About ThreatSea",
+  "aboutDialog": {
+    "license": "License",
+    "repository": "Source code on GitHub"
+  }
 }

--- a/apps/frontend/src/translations/en/main-menu.en.json
+++ b/apps/frontend/src/translations/en/main-menu.en.json
@@ -8,6 +8,7 @@
   "about": "About ThreatSea",
   "aboutDialog": {
     "license": "License",
+    "version": "Version",
     "repository": "Source code on GitHub",
     "close": "Close"
   }

--- a/apps/frontend/src/utils/version.test.ts
+++ b/apps/frontend/src/utils/version.test.ts
@@ -1,0 +1,35 @@
+describe("version module", () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+    });
+
+    const importFresh = async () => {
+        vi.resetModules();
+        return await import("./version.ts");
+    };
+
+    it("falls back to 'local dev' when VITE_APP_VERSION is unset", async () => {
+        vi.stubEnv("VITE_APP_VERSION", undefined);
+
+        const { APP_VERSION } = await importFresh();
+
+        expect(APP_VERSION).toBe("local dev");
+    });
+
+    it("falls back to 'local dev' when VITE_APP_VERSION is empty", async () => {
+        vi.stubEnv("VITE_APP_VERSION", "");
+
+        const { APP_VERSION } = await importFresh();
+
+        expect(APP_VERSION).toBe("local dev");
+    });
+
+    it("exposes the injected version as-is, without a leading v", async () => {
+        vi.stubEnv("VITE_APP_VERSION", "1.2.3-rc.4");
+
+        const { APP_VERSION } = await importFresh();
+
+        expect(APP_VERSION).toBe("1.2.3-rc.4");
+    });
+});

--- a/apps/frontend/src/utils/version.ts
+++ b/apps/frontend/src/utils/version.ts
@@ -1,0 +1,6 @@
+/**
+ * App version injected at Docker build time via the VITE_APP_VERSION env
+ * variable (see the build_frontend stage in the root Dockerfile). Builds
+ * without an injected version (local dev, PR/CI builds) show "local dev".
+ */
+export const APP_VERSION: string = import.meta.env.VITE_APP_VERSION || "local dev";

--- a/apps/frontend/src/view/components/about-dialog.component.test.tsx
+++ b/apps/frontend/src/view/components/about-dialog.component.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { translationUtil } from "#utils/translations.ts";
@@ -18,6 +18,8 @@ describe("AboutDialog", () => {
             name: translationUtil.t("aboutDialog.repository", { ns: "mainMenu" }),
         });
         expect(repoLink).toHaveAttribute("href", "https://github.com/MaibornWolff/ThreatSea");
+        // The glyph is decorative — it must not leak into the link's accessible name asserted above.
+        expect(within(repoLink).getByTestId("GitHubIcon")).toBeInTheDocument();
     });
 
     it("renders nothing when closed", () => {
@@ -31,7 +33,9 @@ describe("AboutDialog", () => {
         const onClose = vi.fn();
         renderWithProviders(<AboutDialog open onClose={onClose} />);
 
-        await user.click(screen.getByRole("button", { name: translationUtil.t("cancelBtn", { ns: "common" }) }));
+        await user.click(
+            screen.getByRole("button", { name: translationUtil.t("aboutDialog.close", { ns: "mainMenu" }) })
+        );
 
         expect(onClose).toHaveBeenCalledTimes(1);
     });

--- a/apps/frontend/src/view/components/about-dialog.component.test.tsx
+++ b/apps/frontend/src/view/components/about-dialog.component.test.tsx
@@ -9,7 +9,6 @@ describe("AboutDialog", () => {
         renderWithProviders(<AboutDialog open onClose={vi.fn()} />);
 
         const dialog = screen.getByRole("dialog");
-        expect(dialog).toHaveTextContent("ThreatSea");
         // Tests run without VITE_APP_VERSION, so the fallback label is shown.
         expect(screen.getByTestId("about-dialog_version")).toHaveTextContent("local dev");
         expect(dialog).toHaveTextContent("BSD-3-Clause");

--- a/apps/frontend/src/view/components/about-dialog.component.test.tsx
+++ b/apps/frontend/src/view/components/about-dialog.component.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
+import { translationUtil } from "#utils/translations.ts";
+import { AboutDialog } from "./about-dialog.component";
+
+describe("AboutDialog", () => {
+    it("shows the app name, version, license and repository link when open", () => {
+        renderWithProviders(<AboutDialog open onClose={vi.fn()} />);
+
+        const dialog = screen.getByRole("dialog");
+        expect(dialog).toHaveTextContent("ThreatSea");
+        // Tests run without VITE_APP_VERSION, so the fallback label is shown.
+        expect(screen.getByTestId("about-dialog_version")).toHaveTextContent("local dev");
+        expect(dialog).toHaveTextContent("BSD-3-Clause");
+
+        const repoLink = screen.getByRole("link", {
+            name: translationUtil.t("aboutDialog.repository", { ns: "mainMenu" }),
+        });
+        expect(repoLink).toHaveAttribute("href", "https://github.com/MaibornWolff/ThreatSea");
+    });
+
+    it("renders nothing when closed", () => {
+        renderWithProviders(<AboutDialog open={false} onClose={vi.fn()} />);
+
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+});

--- a/apps/frontend/src/view/components/about-dialog.component.test.tsx
+++ b/apps/frontend/src/view/components/about-dialog.component.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { translationUtil } from "#utils/translations.ts";
 import { AboutDialog } from "./about-dialog.component";
@@ -23,5 +24,15 @@ describe("AboutDialog", () => {
         renderWithProviders(<AboutDialog open={false} onClose={vi.fn()} />);
 
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("calls onClose when the close button is clicked", async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        renderWithProviders(<AboutDialog open onClose={onClose} />);
+
+        await user.click(screen.getByRole("button", { name: translationUtil.t("cancelBtn", { ns: "common" }) }));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/frontend/src/view/components/about-dialog.component.tsx
+++ b/apps/frontend/src/view/components/about-dialog.component.tsx
@@ -1,7 +1,8 @@
-import { Box, Link, Typography } from "@mui/material";
+import { Box, DialogActions, DialogTitle, Link, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import logo from "#images/threatsealogo-dez.png";
 import { APP_VERSION } from "#utils/version.ts";
+import { Button } from "#view/components/button.component.tsx";
 import { Dialog } from "./dialog.component";
 
 interface AboutDialogProps {
@@ -22,14 +23,19 @@ export const AboutDialog = ({ open, onClose }: AboutDialogProps) => {
                     gap: 1,
                 }}
             >
-                <img src={logo} height={64} alt="ThreatSea" />
-                <Typography variant="h5">ThreatSea</Typography>
+                <img src={logo} height={64} alt="" />
+                <DialogTitle sx={{ padding: 0 }}>ThreatSea</DialogTitle>
                 <Typography data-testid="about-dialog_version">{APP_VERSION}</Typography>
                 <Typography>{`${t("aboutDialog.license")}: BSD-3-Clause`}</Typography>
                 <Link href="https://github.com/MaibornWolff/ThreatSea" target="_blank" rel="noopener noreferrer">
                     {t("aboutDialog.repository")}
                 </Link>
             </Box>
+            <DialogActions sx={{ justifyContent: "center", paddingTop: 1.5, paddingBottom: 0 }}>
+                <Button data-testid="close-button" sx={{ marginRight: 0 }} onClick={onClose}>
+                    {t("cancelBtn")}
+                </Button>
+            </DialogActions>
         </Dialog>
     );
 };

--- a/apps/frontend/src/view/components/about-dialog.component.tsx
+++ b/apps/frontend/src/view/components/about-dialog.component.tsx
@@ -1,0 +1,35 @@
+import { Box, Link, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import logo from "#images/threatsealogo-dez.png";
+import { APP_VERSION } from "#utils/version.ts";
+import { Dialog } from "./dialog.component";
+
+interface AboutDialogProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+export const AboutDialog = ({ open, onClose }: AboutDialogProps) => {
+    const { t } = useTranslation("mainMenu");
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="xs">
+            <Box
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 1,
+                }}
+            >
+                <img src={logo} height={64} alt="ThreatSea" />
+                <Typography variant="h5">ThreatSea</Typography>
+                <Typography data-testid="about-dialog_version">{APP_VERSION}</Typography>
+                <Typography>{`${t("aboutDialog.license")}: BSD-3-Clause`}</Typography>
+                <Link href="https://github.com/MaibornWolff/ThreatSea" target="_blank" rel="noopener noreferrer">
+                    {t("aboutDialog.repository")}
+                </Link>
+            </Box>
+        </Dialog>
+    );
+};

--- a/apps/frontend/src/view/components/about-dialog.component.tsx
+++ b/apps/frontend/src/view/components/about-dialog.component.tsx
@@ -1,3 +1,4 @@
+import GitHub from "@mui/icons-material/GitHub";
 import { Box, DialogActions, DialogTitle, Link, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import logo from "#images/threatsealogo-dez.png";
@@ -27,13 +28,19 @@ export const AboutDialog = ({ open, onClose }: AboutDialogProps) => {
                 <DialogTitle sx={{ padding: 0 }}>ThreatSea</DialogTitle>
                 <Typography data-testid="about-dialog_version">{APP_VERSION}</Typography>
                 <Typography>{`${t("aboutDialog.license")}: BSD-3-Clause`}</Typography>
-                <Link href="https://github.com/MaibornWolff/ThreatSea" target="_blank" rel="noopener noreferrer">
+                <Link
+                    href="https://github.com/MaibornWolff/ThreatSea"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+                >
+                    <GitHub fontSize="small" />
                     {t("aboutDialog.repository")}
                 </Link>
             </Box>
             <DialogActions sx={{ justifyContent: "center", paddingTop: 1.5, paddingBottom: 0 }}>
                 <Button data-testid="close-button" sx={{ marginRight: 0 }} onClick={onClose}>
-                    {t("cancelBtn")}
+                    {t("aboutDialog.close")}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/apps/frontend/src/view/components/about-dialog.component.tsx
+++ b/apps/frontend/src/view/components/about-dialog.component.tsx
@@ -1,5 +1,5 @@
 import GitHub from "@mui/icons-material/GitHub";
-import { Box, DialogActions, DialogTitle, Link, Typography } from "@mui/material";
+import { Box, DialogActions, Link, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import logo from "#images/threatsealogo-dez.png";
 import { APP_VERSION } from "#utils/version.ts";
@@ -24,9 +24,8 @@ export const AboutDialog = ({ open, onClose }: AboutDialogProps) => {
                     gap: 1,
                 }}
             >
-                <img src={logo} height={64} alt="" />
-                <DialogTitle sx={{ padding: 0 }}>ThreatSea</DialogTitle>
-                <Typography data-testid="about-dialog_version">{APP_VERSION}</Typography>
+                <img src={logo} height={64} alt="ThreatSea" />
+                <Typography data-testid="about-dialog_version">{`${t("aboutDialog.version")}: ${APP_VERSION}`}</Typography>
                 <Typography>{`${t("aboutDialog.license")}: BSD-3-Clause`}</Typography>
                 <Link
                     href="https://github.com/MaibornWolff/ThreatSea"

--- a/apps/frontend/src/view/components/create-page.component.test.tsx
+++ b/apps/frontend/src/view/components/create-page.component.test.tsx
@@ -256,7 +256,7 @@ describe("CreatePage — footer", () => {
         setup(undefined, { showProjectInfo: false });
 
         // Tests run without VITE_APP_VERSION, so the fallback label is shown.
-        expect(screen.getByText("local dev")).toBeInTheDocument();
+        expect(screen.getByTestId("page-footer_version")).toHaveTextContent("local dev");
     });
 
     it("opens the About dialog from the footer link and shows the version", async () => {
@@ -265,7 +265,6 @@ describe("CreatePage — footer", () => {
         await user.click(screen.getByRole("button", { name: translationUtil.t("about", { ns: "mainMenu" }) }));
 
         const dialog = await screen.findByRole("dialog");
-        expect(dialog).toHaveTextContent("ThreatSea");
         expect(within(dialog).getByTestId("about-dialog_version")).toHaveTextContent("local dev");
     });
 });

--- a/apps/frontend/src/view/components/create-page.component.test.tsx
+++ b/apps/frontend/src/view/components/create-page.component.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { MouseEvent } from "react";
 import { Provider } from "react-redux";
@@ -111,7 +111,7 @@ describe("CreatePage — project header actions", () => {
 
         expect(screen.queryByTestId("project-actions-menu-stub")).not.toBeInTheDocument();
 
-        await user.click(screen.getByRole("button"));
+        await user.click(within(screen.getByRole("banner")).getByRole("button"));
 
         expect(navigate).toHaveBeenCalledWith("/projects/1/editProject", { state: { project } });
     });
@@ -120,7 +120,7 @@ describe("CreatePage — project header actions", () => {
         setup(createProject({ id: 1, role: USER_ROLES.OWNER }), { showProjectInfo: false });
 
         expect(screen.queryByTestId("project-actions-menu-stub")).not.toBeInTheDocument();
-        expect(screen.queryByRole("button")).not.toBeInTheDocument();
+        expect(within(screen.getByRole("banner")).queryByRole("button")).not.toBeInTheDocument();
     });
 
     it("navigates to the edit-project route with the project when edit is triggered", async () => {
@@ -240,5 +240,32 @@ describe("CreatePage — catalog header", () => {
         renderOnCatalog(undefined, true);
 
         expect(screen.queryByTestId("catalog-header_name")).not.toBeInTheDocument();
+    });
+});
+
+describe("CreatePage — footer", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("shows the app version in the footer", () => {
+        setup(undefined, { showProjectInfo: false });
+
+        // Tests run without VITE_APP_VERSION, so the fallback label is shown.
+        expect(screen.getByText("local dev")).toBeInTheDocument();
+    });
+
+    it("opens the About dialog from the footer link and shows the version", async () => {
+        const { user } = setup(undefined, { showProjectInfo: false });
+
+        await user.click(screen.getByRole("button", { name: translationUtil.t("about", { ns: "mainMenu" }) }));
+
+        const dialog = await screen.findByRole("dialog");
+        expect(dialog).toHaveTextContent("ThreatSea");
+        expect(within(dialog).getByTestId("about-dialog_version")).toHaveTextContent("local dev");
     });
 });

--- a/apps/frontend/src/view/components/create-page.component.tsx
+++ b/apps/frontend/src/view/components/create-page.component.tsx
@@ -501,8 +501,12 @@ export const CreatePage = <P extends object>(
                         >
                             {t("about")}
                         </MuiLink>
-                        <Typography component="span" sx={{ font: "inherit", color: theme.vars.palette.text.subtle }}>
-                            {APP_VERSION}
+                        <Typography
+                            component="span"
+                            data-testid="page-footer_version"
+                            sx={{ font: "inherit", color: theme.vars.palette.text.subtle }}
+                        >
+                            {t("aboutDialog.version")}: {APP_VERSION}
                         </Typography>
                     </div>
                 </Box>

--- a/apps/frontend/src/view/components/create-page.component.tsx
+++ b/apps/frontend/src/view/components/create-page.component.tsx
@@ -1,7 +1,7 @@
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutlined";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
 import SyncIcon from "@mui/icons-material/Sync";
-import { IconButton, Typography } from "@mui/material";
+import { IconButton, Link as MuiLink, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import { useLayoutEffect, useState, type ComponentType, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
@@ -487,20 +487,20 @@ export const CreatePage = <P extends object>(
                                 </a>
                             );
                         })}
-                        <button
+                        <MuiLink
+                            component="button"
                             type="button"
                             onClick={() => setAboutOpen(true)}
-                            style={{
-                                background: "none",
-                                border: "none",
+                            color="inherit"
+                            underline="always"
+                            sx={{
                                 padding: "0 10px 0 0",
                                 font: "inherit",
-                                cursor: "pointer",
                                 color: theme.vars.palette.text.subtle,
                             }}
                         >
                             {t("about")}
-                        </button>
+                        </MuiLink>
                         <Typography component="span" sx={{ font: "inherit", color: theme.vars.palette.text.subtle }}>
                             {APP_VERSION}
                         </Typography>

--- a/apps/frontend/src/view/components/create-page.component.tsx
+++ b/apps/frontend/src/view/components/create-page.component.tsx
@@ -23,6 +23,8 @@ import type { ExtendedProject } from "#api/types/project.types.ts";
 import { HeaderLevelOneNav } from "./header-level-one-nav.component";
 import { HeaderProjectTabs } from "./header-project-tabs.component";
 import { ProjectActionsMenu } from "./project-actions-menu.component";
+import { AboutDialog } from "./about-dialog.component";
+import { APP_VERSION } from "#utils/version.ts";
 import ProjectDialogPage from "#view/pages/project-dialog.page.tsx";
 import Edit from "@mui/icons-material/Edit";
 
@@ -55,6 +57,7 @@ export const CreatePage = <P extends object>(
         const autoSaveStatus = useAppSelector(editorSelectors.selectAutoSaveStatus);
         const autoSaveText = useAppSelector(editorSelectors.selectAutoSaveHelperText);
         const [autoSaveOnClick, setAutoSaveOnClick] = useState<(() => void) | undefined>(undefined);
+        const [aboutOpen, setAboutOpen] = useState(false);
 
         const updateAutoSaveOnClick = (onClick: () => void) => {
             setAutoSaveOnClick(() => onClick);
@@ -484,8 +487,26 @@ export const CreatePage = <P extends object>(
                                 </a>
                             );
                         })}
+                        <button
+                            type="button"
+                            onClick={() => setAboutOpen(true)}
+                            style={{
+                                background: "none",
+                                border: "none",
+                                padding: "0 10px 0 0",
+                                font: "inherit",
+                                cursor: "pointer",
+                                color: theme.vars.palette.text.subtle,
+                            }}
+                        >
+                            {t("about")}
+                        </button>
+                        <Typography component="span" sx={{ font: "inherit", color: theme.vars.palette.text.subtle }}>
+                            {APP_VERSION}
+                        </Typography>
                     </div>
                 </Box>
+                <AboutDialog open={aboutOpen} onClose={() => setAboutOpen(false)} />
                 <Routes>
                     <Route path="editProject" element={<ProjectDialogPage />} />
                 </Routes>

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_APP_VERSION?: string;
+}

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+    readonly VITE_API_URI?: string;
     readonly VITE_APP_VERSION?: string;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an About dialog accessible from the application footer.
  * Displays the application version, BSD-3-Clause license, source repository link, and ThreatSea branding.
  * Added localized About labels in English and German.
  * Application versions now appear in the footer and reflect the released build version when available.

* **Bug Fixes**
  * Improved footer and banner interactions to target the correct controls.

* **Tests**
  * Added coverage for About dialog behavior, version display, links, translations, and fallback version handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->