### PR TITLE
ci(release): disable husky hooks so semantic-release can push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
 concurrency:
   group: release-${{ github.repository }}
 
+env:
+  # semantic-release pushes tags/commits; the local pre-push hook (lint/format/test) must not run in CI
+  HUSKY: "0"
+
 jobs:
   compute-version:
     name: Compute Version

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
                 lines: 64,
                 statements: 64,
             },
-            reportsDirectory: path.resolve(__dirname, "coverage"),
+            reportsDirectory: path.resolve(import.meta.dirname, "coverage"),
         },
         globalSetup: ["vitest.setup.global.ts", "vitest.teardown.global.ts"],
         setupFiles: ["vitest.setup.ts"],

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
             exclude: ["src/**/*.{test,spec}.{ts,tsx}", "src/test-utils/**", "src/index.tsx", "src/reportWebVitals.ts"],
             provider: "v8",
             reporter: ["text", "lcov", "html", "cobertura"],
-            reportsDirectory: path.resolve(__dirname, "coverage"),
+            reportsDirectory: path.resolve(import.meta.dirname, "coverage"),
         },
         globalSetup: ["vitest.global-setup.ts"],
         setupFiles: ["vitest.setup.ts"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release processing by preventing local development hooks from interrupting CI-based publishing.
* **Tests**
  * Updated test coverage reporting configuration for more reliable path resolution in both backend and frontend projects.
  * No user-facing features or changes to public functionality were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->