### PR TITLE
fix(frontend): add bottom padding to report page

### DIFF
--- a/apps/frontend/src/view/pages/report.page.tsx
+++ b/apps/frontend/src/view/pages/report.page.tsx
@@ -273,7 +273,7 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
     }, [setIsChanged, language]);
 
     return (
-        <Box>
+        <Box sx={{ overflow: "hidden", height: "100%", boxSizing: "border-box" }}>
             <Backdrop open={loading} sx={{ zIndex: 999 }}>
                 <Box
                     sx={{
@@ -292,9 +292,12 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
             {<LinearProgress sx={{ visibility: data ? "hidden" : "visible" }} />}
             <Page
                 sx={{
+                    boxSizing: "border-box",
+                    height: "100%",
                     padding: 0,
                     paddingLeft: 6,
                     paddingRight: 6,
+                    paddingBottom: 4,
                 }}
             >
                 {data && (
@@ -302,6 +305,8 @@ const ReportPageBody = ({ project }: ReportPageBodyProps) => {
                         sx={{
                             display: "flex",
                             flexDirection: "column",
+                            height: "100%",
+                            overflowY: "auto",
                         }}
                     >
                         <Box


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the report page layout to use the full available height.
  * Improved vertical scrolling and prevented horizontal overflow.
  * Added bottom spacing for better page usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->