### PR TITLE
test(frontend): add footer regression e2e tests

### DIFF
--- a/apps/frontend/playwright/pages/footer-links.page.ts
+++ b/apps/frontend/playwright/pages/footer-links.page.ts
@@ -1,0 +1,30 @@
+import type { Locator, Page } from "@playwright/test";
+import { BasePage } from "./base.page.ts";
+
+export class FooterLinksPage extends BasePage {
+    readonly footerVersionLabel: Locator;
+    readonly imprintLink: Locator;
+    readonly privacyPolicyLink: Locator;
+    readonly aboutThreatSeaButton: Locator;
+    readonly aboutDialogVersionLabel: Locator;
+    readonly aboutDialogRepositoryLink: Locator;
+    readonly aboutDialogCloseButton: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        const footerContainer = page.getByTestId("page-footer_version").locator("xpath=ancestor::div[1]");
+
+        this.footerVersionLabel = page.getByTestId("page-footer_version");
+        this.imprintLink = footerContainer.locator('a[href="/imprint"]');
+        this.privacyPolicyLink = footerContainer.locator('a[href="/privacy-policy"]');
+        this.aboutThreatSeaButton = footerContainer.locator('button[type="button"]');
+
+        this.aboutDialogVersionLabel = page.getByTestId("about-dialog_version");
+        this.aboutDialogRepositoryLink = page.locator('a[href="https://github.com/MaibornWolff/ThreatSea"]');
+        this.aboutDialogCloseButton = page.getByTestId("close-button");
+    }
+
+    async gotoProjectsPage(): Promise<void> {
+        await this.page.goto("/projects");
+    }
+}

--- a/apps/frontend/playwright/tests/footer-links.page.e2e.spec.ts
+++ b/apps/frontend/playwright/tests/footer-links.page.e2e.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import { FooterLinksPage } from "../pages/footer-links.page.ts";
+
+test.describe("Footer links regression tests", () => {
+    test.beforeEach(async ({ page }) => {
+        const footerLinksPage = new FooterLinksPage(page);
+        await footerLinksPage.gotoProjectsPage();
+        await expect(footerLinksPage.footerVersionLabel).toBeVisible();
+    });
+
+    test("opens imprint page from footer", async ({ page }) => {
+        const footerLinksPage = new FooterLinksPage(page);
+
+        await expect(footerLinksPage.imprintLink).toBeVisible();
+        await footerLinksPage.imprintLink.click();
+
+        await expect(page).toHaveURL(/\/imprint$/);
+        await expect(footerLinksPage.footerVersionLabel).toBeVisible();
+    });
+
+    test("opens privacy policy page from footer", async ({ page }) => {
+        const footerLinksPage = new FooterLinksPage(page);
+
+        await expect(footerLinksPage.privacyPolicyLink).toBeVisible();
+        await footerLinksPage.privacyPolicyLink.click();
+
+        await expect(page).toHaveURL(/\/privacy-policy$/);
+        await expect(footerLinksPage.footerVersionLabel).toBeVisible();
+    });
+
+    test("opens and closes the about dialog from footer", async ({ page }) => {
+        const footerLinksPage = new FooterLinksPage(page);
+
+        await expect(footerLinksPage.aboutThreatSeaButton).toBeVisible();
+        await footerLinksPage.aboutThreatSeaButton.click();
+
+        await expect(footerLinksPage.aboutDialogVersionLabel).toBeVisible();
+        await expect(footerLinksPage.aboutDialogRepositoryLink).toBeVisible();
+
+        await footerLinksPage.aboutDialogCloseButton.click();
+        await expect(footerLinksPage.aboutDialogVersionLabel).toBeHidden();
+    });
+});


### PR DESCRIPTION
## Summary

Adds Playwright regression coverage for footer navigation and About dialog behavior to prevent future UI regressions.

## Changes

- added `apps/frontend/playwright/pages/footer-links.page.ts`
  - Page Object for footer links and About dialog interactions
- added `apps/frontend/playwright/tests/footer-links.page.e2e.spec.ts`
  - verifies footer link navigation to `/imprint`
  - verifies footer link navigation to `/privacy-policy`
  - verifies opening and closing the About dialog from the footer
  - verifies About dialog version/repository visibility

## Validation

- `pnpm exec playwright test apps/frontend/playwright/tests/footer-links.page.e2e.spec.ts --workers=1`
- full suite run completed successfully before push (`107 passed`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for footer navigation to the imprint and privacy policy pages.
  * Added regression checks for opening and closing the About dialog.
  * Added verification that the application version label is displayed correctly.
  * Added coverage for navigating from the footer to the projects page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->