### PR TITLE
ci(frontend): add type check to frontend build stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Repository
         uses: ./.github/actions/repository-setup
       - name: Build Frontend
-        run: pnpm build --filter="..../apps/frontend"
+        run: pnpm build --filter="..../apps/frontend" && pnpm type-check --filter="..../apps/frontend"
       - name: Upload frontend build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Frontend builds now include an automated type-check to help catch type-related issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->