### PR TITLE
test: drop partial module mocks of the redux hooks

### DIFF
--- a/apps/frontend/src/view/components/folders-accordion.component.test.tsx
+++ b/apps/frontend/src/view/components/folders-accordion.component.test.tsx
@@ -1,20 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ExtendedProject } from "#api/types/project.types.ts";
 import { createFolder, createProject } from "#test-utils/builders.ts";
 import { mockUseConfirm, mockUseFolders } from "#test-utils/mock-hooks.ts";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { buildFolderTree } from "#utils/build-folder-tree.ts";
 
+// Partial mock: the real module is kept so renderWithProviders still gets
+// MemoryRouter, only useNavigate is swapped for a spy.
 const navigate = vi.fn();
-vi.mock("react-router", () => ({ useNavigate: () => navigate }));
-vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-
-const dispatch = vi.fn();
-vi.mock("#application/hooks/use-app-redux.hook.ts", () => ({
-    useAppSelector: (selector: (state: { folders: { collapsed: Record<string, boolean> } }) => unknown) =>
-        selector({ folders: { collapsed: {} } }),
-    useAppDispatch: () => dispatch,
-}));
+vi.mock("react-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react-router")>();
+    return { ...actual, useNavigate: () => navigate };
+});
 
 // The accordion owns grouping and sections, not card layout — stub the grid.
 vi.mock("./projects-grid.component", () => ({
@@ -44,7 +42,7 @@ describe("FoldersAccordion", () => {
         mockUseFolders();
         mockUseConfirm();
 
-        render(<FoldersAccordion tree={tree} {...handlers} />);
+        renderWithProviders(<FoldersAccordion tree={tree} {...handlers} />);
 
         expect(screen.getByTestId("folder-section-1")).toBeInTheDocument();
         expect(screen.getByTestId("folder-section-ungrouped")).toBeInTheDocument();
@@ -55,7 +53,7 @@ describe("FoldersAccordion", () => {
         mockUseFolders();
         mockUseConfirm();
 
-        render(<FoldersAccordion tree={tree} {...handlers} />);
+        renderWithProviders(<FoldersAccordion tree={tree} {...handlers} />);
 
         expect(screen.queryByTestId("folder-section-ungrouped")).not.toBeInTheDocument();
     });
@@ -66,7 +64,7 @@ describe("FoldersAccordion", () => {
         mockUseFolders();
         mockUseConfirm();
 
-        render(<FoldersAccordion tree={tree} {...handlers} />);
+        renderWithProviders(<FoldersAccordion tree={tree} {...handlers} />);
         await userEvent.click(screen.getByTestId("folder-section-1_menu-button"));
         await userEvent.click(screen.getByTestId("folder-section-1_rename-button"));
 
@@ -82,23 +80,26 @@ describe("FoldersAccordion", () => {
         mockUseFolders();
         mockUseConfirm({ openConfirm });
 
-        render(<FoldersAccordion tree={tree} {...handlers} />);
+        renderWithProviders(<FoldersAccordion tree={tree} {...handlers} />);
         await userEvent.click(screen.getByTestId("folder-section-1_menu-button"));
         await userEvent.click(screen.getByTestId("folder-section-1_delete-button"));
 
         expect(openConfirm).toHaveBeenCalledTimes(1);
     });
 
-    it("dispatches a collapse toggle when a section header is clicked", async () => {
+    it("collapses a section when its header is clicked", async () => {
         const tree = buildFolderTree([createFolder({ id: 1, name: "Payments" })], []);
         mockUseFolders();
         mockUseConfirm();
-        dispatch.mockClear();
 
-        render(<FoldersAccordion tree={tree} {...handlers} />);
+        // Asserts the store state the toggle produces, not merely that something
+        // was dispatched: absent means expanded, true means collapsed.
+        const { store } = renderWithProviders(<FoldersAccordion tree={tree} {...handlers} />);
+        expect(store.getState().folders.collapsed["1"]).toBeUndefined();
+
         await userEvent.click(screen.getByTestId("folder-section-1_header"));
 
-        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(store.getState().folders.collapsed["1"]).toBe(true);
     });
 
     it("disables new-subfolder once a folder is at the maximum depth", async () => {
@@ -110,7 +111,7 @@ describe("FoldersAccordion", () => {
         mockUseFolders();
         mockUseConfirm();
 
-        render(<FoldersAccordion tree={tree} {...handlers} />);
+        renderWithProviders(<FoldersAccordion tree={tree} {...handlers} />);
         await userEvent.click(screen.getByTestId("folder-section-7_menu-button"));
 
         expect(screen.getByTestId("folder-section-7_new-subfolder-button")).toHaveAttribute("aria-disabled", "true");

--- a/apps/frontend/src/view/dialogs/move-to-folder.dialog.test.tsx
+++ b/apps/frontend/src/view/dialogs/move-to-folder.dialog.test.tsx
@@ -1,45 +1,18 @@
-import type { ReactElement, ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FoldersActions } from "#application/actions/folders.actions.ts";
 import { createFolder, createProject } from "#test-utils/builders.ts";
 import { mockUseFolders } from "#test-utils/mock-hooks.ts";
+import { renderWithProviders } from "#test-utils/render-with-providers.tsx";
 import { MAX_FOLDER_DEPTH } from "#utils/build-folder-tree.ts";
-import { Theme } from "#view/wrappers/theme.wrapper.tsx";
-
-// Wrap in the real app theme so the icons resolving theme.vars.palette.* render correctly.
-const renderDialog = (ui: ReactElement) => render(ui, { wrapper: Theme });
-
-const navigate = vi.fn();
-vi.mock("react-router", () => ({ useNavigate: () => navigate }));
-vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-
-const dispatch = vi.fn();
-vi.mock("#application/hooks/use-app-redux.hook.ts", () => ({ useAppDispatch: () => dispatch }));
-
-// Stub the app Dialog/Button wrappers (they read the app theme) so the picker can render plainly.
-vi.mock("#view/components/dialog.component.tsx", () => ({
-    Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-}));
-vi.mock("#view/components/button.component.tsx", () => ({
-    Button: ({
-        children,
-        onClick,
-        disabled,
-        ["data-testid"]: testId,
-    }: {
-        children: ReactNode;
-        onClick?: () => void;
-        disabled?: boolean;
-        ["data-testid"]?: string;
-    }) => (
-        <button onClick={onClick} disabled={disabled} data-testid={testId}>
-            {children}
-        </button>
-    ),
-}));
-
 import MoveToFolderDialog from "./move-to-folder.dialog";
+
+// moveProject and updateFolder are async thunks. The real store from
+// renderWithProviders would execute them and call the API, so they are stubbed to
+// return an inert plain action. The assertions are unchanged: they check what the
+// dialog asked for, not what the backend did. restoreMocks puts them back.
+const stubAction = (name: "moveProject" | "updateFolder") =>
+    vi.spyOn(FoldersActions, name).mockReturnValue({ type: `test/${name}` } as never);
 
 describe("MoveToFolderDialog", () => {
     describe("moving a project", () => {
@@ -48,7 +21,7 @@ describe("MoveToFolderDialog", () => {
                 items: [createFolder({ id: 1, name: "Payments" }), createFolder({ id: 2, name: "Internal" })],
             });
 
-            renderDialog(
+            renderWithProviders(
                 <MoveToFolderDialog open project={createProject({ id: 5, folderId: null })} folder={undefined} />
             );
 
@@ -58,24 +31,23 @@ describe("MoveToFolderDialog", () => {
         });
 
         it("dispatches moveProject with the chosen folder", async () => {
-            const spy = vi.spyOn(FoldersActions, "moveProject");
+            const spy = stubAction("moveProject");
             mockUseFolders({ items: [createFolder({ id: 1, name: "Payments" })] });
 
-            renderDialog(
+            renderWithProviders(
                 <MoveToFolderDialog open project={createProject({ id: 5, folderId: null })} folder={undefined} />
             );
             await userEvent.click(screen.getByTestId("move-target-1"));
             await userEvent.click(screen.getByTestId("save-button"));
 
             expect(spy).toHaveBeenCalledWith({ projectId: 5, folderId: 1, currentFolderId: null });
-            spy.mockRestore();
         });
 
         it("disables the confirm button until a different target is chosen", async () => {
             mockUseFolders({ items: [createFolder({ id: 1, name: "Payments" })] });
 
             // Project already ungrouped, so the pre-selected target (root) is unchanged.
-            renderDialog(
+            renderWithProviders(
                 <MoveToFolderDialog open project={createProject({ id: 5, folderId: null })} folder={undefined} />
             );
             expect(screen.getByTestId("save-button")).toBeDisabled();
@@ -91,7 +63,7 @@ describe("MoveToFolderDialog", () => {
             const child = createFolder({ id: 2, name: "Child", parentId: 1 });
             mockUseFolders({ items: [parent, child] });
 
-            renderDialog(<MoveToFolderDialog open project={undefined} folder={parent} />);
+            renderWithProviders(<MoveToFolderDialog open project={undefined} folder={parent} />);
 
             expect(screen.getByTestId("move-target-1")).toHaveAttribute("aria-disabled", "true");
             expect(screen.getByTestId("move-target-2")).toHaveAttribute("aria-disabled", "true");
@@ -107,7 +79,7 @@ describe("MoveToFolderDialog", () => {
             const moving = createFolder({ id: 100, name: "Movable", parentId: null });
             mockUseFolders({ items: [...chain, moving] });
 
-            renderDialog(<MoveToFolderDialog open project={undefined} folder={moving} />);
+            renderWithProviders(<MoveToFolderDialog open project={undefined} folder={moving} />);
 
             expect(screen.getByTestId(`move-target-${MAX_FOLDER_DEPTH}`)).toHaveAttribute("aria-disabled", "true");
             expect(screen.getByTestId(`move-target-${MAX_FOLDER_DEPTH - 1}`)).not.toHaveAttribute(
@@ -117,16 +89,15 @@ describe("MoveToFolderDialog", () => {
         });
 
         it("dispatches updateFolder with the chosen parent", async () => {
-            const spy = vi.spyOn(FoldersActions, "updateFolder");
+            const spy = stubAction("updateFolder");
             const moving = createFolder({ id: 2, name: "Movable", parentId: null });
             mockUseFolders({ items: [createFolder({ id: 1, name: "Target" }), moving] });
 
-            renderDialog(<MoveToFolderDialog open project={undefined} folder={moving} />);
+            renderWithProviders(<MoveToFolderDialog open project={undefined} folder={moving} />);
             await userEvent.click(screen.getByTestId("move-target-1"));
             await userEvent.click(screen.getByTestId("save-button"));
 
             expect(spy).toHaveBeenCalledWith({ id: 2, parentId: 1 });
-            spy.mockRestore();
         });
     });
 });


### PR DESCRIPTION
References issue: –

> **Stacked on #1204**, which is itself stacked on #1199. Together the three finish audit finding B2. Reviewing them in order is worth it: #1204 closes the spy leak and measures what is left, this PR closes the remainder. GitHub retargets automatically as each parent merges.

## What does this PR do

Both Group-C test files replaced `#application/hooks/use-app-redux.hook.ts` wholesale with a factory declaring only the exports they happened to need — `move-to-folder` declared just `useAppDispatch`, neither declared `useAppStore`. Under `isolate: false` those partial factories reached files that never asked for them, and Vitest named the failure itself:

```
[vitest] No "useAppSelector" export is defined on the
         "#application/hooks/use-app-redux.hook.ts" mock.
[vitest] No "useAppStore" export is defined on the ... mock.
```

In the captured failing run the source ran at position 3 and its victims at 28, 40, 66 and 74 — which is why the failures looked random and why small reproductions stayed green.

Both files now render through `renderWithProviders` against the real store. **No `preloadedState` is needed**: the folders reducer already starts with `collapsed: {}`, exactly the state the fake supplied. The fake was never adding anything — only removing the rest of the store.

### Details worth a reviewer's eye

- **`react-router` is no longer replaced wholesale.** `folders-accordion` keeps a partial mock via `importOriginal`, so `MemoryRouter` survives and `useNavigate` stays assertable. `move-to-folder` never asserted navigation and drops the mock entirely.
- **The collapse test asserts an outcome, not a call.** It was `expect(dispatch).toHaveBeenCalledTimes(1)`; it now checks the store state the toggle produces — absent means expanded, `true` means collapsed. That survives a refactor of how the action gets dispatched, which the call-count assertion would not.
- **The async thunks had to be neutralised.** `moveProject` and `updateFolder` are `createAsyncThunk`. The old fake `dispatch` swallowed them; a real store would execute them and hit the API. They are stubbed to return an inert plain action, with the assertions unchanged — what the dialog asked for, not what the backend did.
- **The `Dialog` and `Button` stubs are gone.** Both wrappers spread `...props`, so the real components pass `data-testid` through; the stubs were never necessary.
- **The `react-i18next` mocks are gone**, in line with the convention added in #1202.

## Measured

| | shuffled runs | red |
| --- | --- | --- |
| before #1204 | 6 | 4 (~67%) |
| after #1204 | 32 | 3 (~9%) |
| **this PR** | **40** | **0** |

Forty runs rather than twenty on purpose. An earlier round in this series called a fix complete after six green runs and a wider sample disproved it, so the bar here is a sample that actually carries: at a 9% failure rate, 40 clean runs happen by chance about 2% of the time.

## Follow-ups, deliberately not in this PR

- **`--sequence.shuffle` in CI** is defensible for the first time — the audit's original suggestion, which it then withdrew as premature. Worth proposing separately so the measurement above stays the clean baseline.
- **Two more partial module mocks** turned up while searching and are untouched: `report.worker.test.ts` mocks `@react-pdf/renderer` with only `pdf`, while `view/report/**` uses `Document`, `Page` and `Text` from it; and `create-page.component.test.tsx` mocks `#main.tsx` and `use-project-tabs.hook.ts` without `importOriginal`. Neither surfaced in 40 runs. Whether that means harmless or merely not yet hit, I cannot say from the data.

## Definition of Done

- [x] Required unit tests are implemented — no tests added or removed; one assertion strengthened from a call count to the resulting store state. Ordered suite unchanged at **1076 passing, 16.4 s**
- [x] Functional tests and integration tests / e2e-tests have passed successfully — `pnpm test`, `tsc -b --noEmit`, oxlint and oxfmt all clean
- [x] Incompatible e2e-tests are adapted — none affected; **no production code is touched by this PR**
- [x] The Architectural Decision Record was taken into account — no ADR affected
- [x] If necessary: Required documentation has been written or updated — the convention these files now follow is documented in #1202
- [x] If necessary: new config parameters have been described — none
- [x] If necessary: User manual has been updated — no user-visible change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRB3dkT7RAYhhnXgXj2Qwq
